### PR TITLE
Close zip files on python 2.6

### DIFF
--- a/crossbar/ez_setup.py
+++ b/crossbar/ez_setup.py
@@ -72,7 +72,7 @@ def get_zip_class():
         def __enter__(self):
             return self
         def __exit__(self, type, value, traceback):
-            self.close
+            self.close()
     return zipfile.ZipFile if hasattr(zipfile.ZipFile, '__exit__') else \
         ContextualZipFile
 


### PR DESCRIPTION
Sorry it's really really small. Wish I could add more to this pull request, but I think in Python 2.6 the zip file isn't getting `"closed"` when using `with`. I don't think it's a big deal but just good practice.
