### PR TITLE
make crossbar compatible with autobahn version 0.8.15

### DIFF
--- a/crossbar/crossbar/router/session.py
+++ b/crossbar/crossbar/router/session.py
@@ -397,7 +397,7 @@ class CrossbarRouterServiceSession(ApplicationSession):
          log.msg("CrossbarRouterServiceSession: registered {} procedures".format(len(regs)))
 
 
-   @wamp.register('wamp.reflect.describe')
+   @wamp.register(u'wamp.reflect.describe')
    def describe(self, uri = None):
       """
       Describe a given URI or all URIs.
@@ -413,7 +413,7 @@ class CrossbarRouterServiceSession(ApplicationSession):
          return self._schemas
 
 
-   @wamp.register('wamp.reflect.define')
+   @wamp.register(u'wamp.reflect.define')
    def define(self, uri, schema):
       """
       Declare metadata for a given URI.

--- a/crossbar/crossbar/templates/votes/python/votes.py
+++ b/crossbar/crossbar/templates/votes/python/votes.py
@@ -46,19 +46,19 @@ class VotesBackend(ApplicationSession):
             'Lemon': 0
         }
 
-    @wamp.register('io.crossbar.demo.vote.get')
+    @wamp.register(u'io.crossbar.demo.vote.get')
     def getVotes(self):
         return [{'subject': key, 'votes': value} for key, value in self._votes.items()]
 
 
-    @wamp.register('io.crossbar.demo.vote.vote')
+    @wamp.register(u'io.crossbar.demo.vote.vote')
     def submitVote(self, subject):
         self._votes[subject] += 1
         result = {'subject': subject, 'votes': self._votes[subject]}
         self.publish('io.crossbar.demo.vote.onvote', result)
         return result
 
-    @wamp.register('io.crossbar.demo.vote.reset')
+    @wamp.register(u'io.crossbar.demo.vote.reset')
     def resetVotes(self):
         self.init()
         self.publish('io.crossbar.demo.vote.onreset')


### PR DESCRIPTION
There was an unicode problem when crossbar run with autobahn version 0.8.15,
error details are show bellow:

```
2014-08-24 11:10:08+0800 [Controller  13044] Crossbar.io 0.9.7-5 starting
2014-08-24 11:10:10+0800 [Controller  13044] Running on PyPy using EPollReactor reactor
2014-08-24 11:10:10+0800 [Controller  13044] Starting from node directory /home/ubuntu/cb/hello/.crossbar
2014-08-24 11:10:10+0800 [Controller  13044] Starting from local configuration '/home/ubuntu/cb/hello/.crossbar/config.json'
2014-08-24 11:10:10+0800 [Controller  13044] No WAMPlets detected in enviroment.
2014-08-24 11:10:10+0800 [Controller  13044] Starting Router with ID 'worker1' ..
2014-08-24 11:10:10+0800 [Router      13108] Log opened.
2014-08-24 11:10:12+0800 [Router      13108] Running under PyPy using EPollReactor reactor
2014-08-24 11:10:12+0800 [Router      13108] Traceback (most recent call last):
2014-08-24 11:10:12+0800 [Router      13108] File "app_main.py", line 75, in run_toplevel
2014-08-24 11:10:12+0800 [Router      13108] File "/home/ubuntu/.pyenv/versions/cb/site-packages/crossbar/worker/process.py", line 188, in <module>
2014-08-24 11:10:12+0800 [Router      13108] run()
2014-08-24 11:10:12+0800 [Router      13108] File "/home/ubuntu/.pyenv/versions/cb/site-packages/crossbar/worker/process.py", line 118, in run
2014-08-24 11:10:12+0800 [Router      13108] from crossbar.worker.router import RouterWorkerSession
2014-08-24 11:10:12+0800 [Router      13108] File "/home/ubuntu/.pyenv/versions/cb/site-packages/crossbar/worker/router.py", line 42, in <module>
2014-08-24 11:10:12+0800 [Router      13108] from crossbar.router.session import CrossbarRouterSessionFactory, \
2014-08-24 11:10:12+0800 [Router      13108] File "/home/ubuntu/.pyenv/versions/cb/site-packages/crossbar/router/session.py", line 368, in <module>
2014-08-24 11:10:12+0800 [Router      13108] class CrossbarRouterServiceSession(ApplicationSession):
2014-08-24 11:10:12+0800 [Router      13108] File "/home/ubuntu/.pyenv/versions/cb/site-packages/crossbar/router/session.py", line 416, in CrossbarRouterServiceSession
2014-08-24 11:10:12+0800 [Router      13108] @wamp.register('wamp.reflect.define')
2014-08-24 11:10:12+0800 [Router      13108] File "/home/ubuntu/.pyenv/versions/cb/site-packages/autobahn/wamp/__init__.py", line 34, in decorate
2014-08-24 11:10:12+0800 [Router      13108] f._wampuris.append(Pattern(uri, Pattern.URI_TARGET_ENDPOINT))
2014-08-24 11:10:12+0800 [Router      13108] File "/home/ubuntu/.pyenv/versions/cb/site-packages/autobahn/wamp/uri.py", line 60, in __init__
2014-08-24 11:10:12+0800 [Router      13108] assert(type(uri) == six.text_type)
2014-08-24 11:10:12+0800 [Router      13108] AssertionError
2014-08-24 11:10:12+0800 [Controller  13044] Worker 13108: Process connection gone (A process has ended with a probable error condition: process ended with exit code 1.)
2014-08-24 11:10:12+0800 [Controller  13044] ERROR: failed to start native worker - A process has ended with a probable error condition: process ended with exit code 1.
2014-08-24 11:10:12+0800 [Controller  13044] Traceback (most recent call last):
2014-08-24 11:10:13+0800 [Controller  13044]   File "/home/ubuntu/.pyenv/versions/cb/site-packages/crossbar/controller/node.py", line 187, in run_node_config
2014-08-24 11:10:13+0800 [Controller  13044]     yield self._run_node_config(config)
2014-08-24 11:10:13+0800 [Controller  13044]   File "/home/ubuntu/.pyenv/versions/cb/site-packages/twisted/internet/defer.py", line 1097, in _inlineCallbacks
2014-08-24 11:10:13+0800 [Controller  13044]     result = result.throwExceptionIntoGenerator(g)
2014-08-24 11:10:13+0800 [Controller  13044]   File "/home/ubuntu/.pyenv/versions/cb/site-packages/twisted/python/failure.py", line 389, in throwExceptionIntoGenerator
2014-08-24 11:10:13+0800 [Controller  13044]     return g.throw(self.type, self.value, self.tb)
2014-08-24 11:10:13+0800 [Controller  13044]   File "/home/ubuntu/.pyenv/versions/cb/site-packages/crossbar/controller/node.py", line 257, in _run_node_config
2014-08-24 11:10:13+0800 [Controller  13044]     yield self._controller.start_router(worker_id, worker_options, details = call_details)
2014-08-24 11:10:13+0800 [Controller  13044]   File "/home/ubuntu/.pyenv/versions/cb/site-packages/twisted/internet/defer.py", line 577, in _runCallbacks
2014-08-24 11:10:13+0800 [Controller  13044]     current.result = callback(current.result, *args, **kw)
2014-08-24 11:10:13+0800 [Controller  13044]   File "/home/ubuntu/.pyenv/versions/cb/site-packages/crossbar/controller/process.py", line 545, in on_ready_error
2014-08-24 11:10:13+0800 [Controller  13044]     raise ApplicationError("crossbar.error.cannot_start", emsg, worker.getlog())
2014-08-24 11:10:13+0800 [Controller  13044] ApplicationError: ApplicationError('crossbar.error.cannot_start', args = ('ERROR: failed to start native worker - A process has ended with a probable error condition: process ended with exit code 1.', []), kwargs = {})
2014-08-24 11:10:13+0800 [Controller  13044] Main loop terminated.
```
