### PR TITLE
RouterSession exception handling refactoring

### DIFF
--- a/crossbar/crossbar/router/router.py
+++ b/crossbar/crossbar/router/router.py
@@ -429,13 +429,12 @@ class RouterSession(FutureMixin, BaseSession):
          if self.debug:
             print("exception raised in onError callback: {0}".format(e)) 
 
-      self.leave(None, u"Internal server error")
+      self.leave(message = u"Internal server error")
 
     
    def onError(self, err):
       """
       Overwride for custom error handling.
-      Shall return a tuple (reason, message)
       """
       if self.debug:
          print("Catched exception during message processing: {0}".format(err.getTraceback())) # replace with proper logging

--- a/crossbar/crossbar/router/router.py
+++ b/crossbar/crossbar/router/router.py
@@ -429,7 +429,13 @@ class RouterSession(FutureMixin, BaseSession):
          if self.debug:
             print("exception raised in onError callback: {0}".format(e)) 
 
-      self.leave(message = u"Internal server error")
+      reply = message.Abort(u"wamp.error.authorization_failed", u"Internal server error")
+      self._transport.send(reply)
+
+      self._router.detach(self)
+
+      self._session_id = None
+      self._pending_session_id = None
 
     
    def onError(self, err):


### PR DESCRIPTION
This pull request shall be seen as a hotfix and provides a minimalistic solution, this problem might require a better solution.

When a exception was thrown inside RouterSession.onHello and RouterSession.onAuthenticate, nothing but a print happend. Not only was the log output very simplistic and lacked crucial informations (e.g file name and line number) but it also caused the session to stay alive without any reply to the client.