### PR TITLE
fixed wrong URIs

### DIFF
--- a/crossbar/crossbar/router/session.py
+++ b/crossbar/crossbar/router/session.py
@@ -522,14 +522,14 @@ class CrossbarRouterSession(RouterSession):
 
       ## dispatch session metaevent from WAMP AP
       ##
-      self._service_session.publish(u'wamp.metaevent.session.on_join', self._session_details)
+      self._service_session.publish(u'wamp.session.on_join', self._session_details)
 
 
    def onLeave(self, details):
 
       ## dispatch session metaevent from WAMP AP
       ##
-      self._service_session.publish(u'wamp.metaevent.session.on_leave', self._session_details)
+      self._service_session.publish(u'wamp.session.on_leave', self._session_details)
 
       self._session_details = None
 


### PR DESCRIPTION
The used URIs were wrong according to the WAMP documentation. Maybe having a dedicated file inside autobahn for all predfined URIs from the WAMP specification might be a good idea to prevent such mistakes. Its would also be quite convenient for autobahn users.