### PR TITLE
Fixed assertion on (service) wamp call

### DIFF
--- a/crossbar/crossbar/router/router.py
+++ b/crossbar/crossbar/router/router.py
@@ -77,6 +77,9 @@ class RouterApplicationSession:
       :type authrole: str
       """
 
+      assert(authid is None or isinstance(authid, six.text_type))
+      assert(authrole is None or isinstance(authrole, six.text_type))
+
       ## remember router we are wrapping the app session for
       ##
       self._routerFactory = routerFactory
@@ -611,7 +614,7 @@ class RouterFactory:
       """
 
       :param options: Default router options.
-      :type options: Instance of :class:`autobahn.wamp.types.RouterOptions`.      
+      :type options: Instance of :class:`autobahn.wamp.types.RouterOptions`.
       """
       self._routers = {}
       self.debug = debug

--- a/crossbar/crossbar/worker/router.py
+++ b/crossbar/crossbar/worker/router.py
@@ -329,7 +329,7 @@ class RouterWorkerSession(NativeWorkerSession):
 
       self.factory.start_realm(rlm)
 
-      self.session_factory.add(session, authrole = 'trusted')
+      self.session_factory.add(session, authrole = u'trusted')
 
 
 
@@ -480,7 +480,7 @@ class RouterWorkerSession(NativeWorkerSession):
 
             if self.debug:
                log.msg("Starting class '{}'".format(klassname))
-           
+
             c = klassname.split('.')
             module_name, klass_name = '.'.join(c[:-1]), c[-1]
             module = importlib.import_module(module_name)


### PR DESCRIPTION
A wamp call from the router failed with an assertion if the calle requested to disclose callers because the role of the internal service session was an ascii string.