### PR TITLE
Add cache control headers for static resources

### DIFF
--- a/crossbar/crossbar/common/checkconfig.py
+++ b/crossbar/crossbar/common/checkconfig.py
@@ -594,6 +594,7 @@ def check_web_path_service_static(config):
         check_dict_args({
             'enable_directory_listing': (False, [bool]),
             'mime_types': (False, [dict]),
+            'cache_timeout': (False, list(six.integer_types) + [type(None)])
         }, config['options'], "'options' in Web transport 'static' path service")
 
 

--- a/crossbar/crossbar/twisted/resource.py
+++ b/crossbar/crossbar/twisted/resource.py
@@ -139,6 +139,11 @@ if _HAS_STATIC:
             return File.render_GET(self, request)
 
         def createSimilarFile(self, *args, **kwargs):
+            ##
+            # File.getChild uses File.createSimilarFile to make a new resource of the same class to serve actual files under
+            # a directory. We need to override that to also set the cache timeout on the child.
+            ##
+
             similar_file = File.createSimilarFile(self, *args, **kwargs)
 
             # need to manually set this - above explicitly enumerates constructor args


### PR DESCRIPTION
For crossbario/crossbar#251

As discussed:

* `cache_timeout` is specified in seconds
* Default is 12 hours
* There's no special-casing for 0 timeout (i.e. I don't explicitly set `no-cache`) but you should get essentially no caching when `cache_timeout` is set to 0
* `null`/`None` preserves the current behavior, which sets no cache control headers, and lets the browser cache for as long as it wants