### PR TITLE
Process shutdown

### DIFF
--- a/crossbar/controller/native.py
+++ b/crossbar/controller/native.py
@@ -112,6 +112,11 @@ def create_native_worker_client_factory(router_session_factory, on_ready, on_exi
     # we need to increase the opening handshake timeout in particular, since starting up a worker
     # on PyPy will take a little (due to JITting)
     factory.setProtocolOptions(failByDrop=False, openHandshakeTimeout=30, closeHandshakeTimeout=5)
+
+    # on_ready is resolved in crossbar/controller/process.py:on_worker_ready around 175
+    # after crossbar.node.<ID>.on_worker_ready is published to (in the controller session)
+    # that happens in crossbar/worker/native.py:publish_ready which itself happens when
+    # the native worker joins the realm (part of onJoin)
     factory._on_ready = on_ready
     factory._on_exit = on_exit
 

--- a/crossbar/controller/process.py
+++ b/crossbar/controller/process.py
@@ -618,7 +618,7 @@ class NodeControllerSession(NativeProcessSession):
         :type kill: bool
         """
         if self.debug:
-            log.msg("NodeControllerSession.start_router", id, kill)
+            log.msg("NodeControllerSession.stop_router", id, kill)
 
         return self._stop_native_worker('router', id, kill, details=details)
 

--- a/crossbar/controller/process.py
+++ b/crossbar/controller/process.py
@@ -512,6 +512,11 @@ class NodeControllerSession(NativeProcessSession):
         def on_ready_success(id):
             log.msg("{} with ID '{}' and PID {} started".format(worker_logname, worker.id, worker.pid))
 
+            self._node._reactor.addSystemEventTrigger(
+                'before', 'shutdown',
+                worker.proto.transport.signalProcess, 'TERM',
+            )
+
             worker.status = 'started'
             worker.started = datetime.utcnow()
 


### PR DESCRIPTION
The native workers in crossbar weren't getting shutdown nicely enough to run atexit handlers etc.
This ensures we send a SIGTERM to native workers as crossbar shuts down.