### PR TITLE
Process exit cleanup

### DIFF
--- a/crossbar/worker/process.py
+++ b/crossbar/worker/process.py
@@ -150,8 +150,7 @@ def run():
                 if reactor.running:
                     reactor.addSystemEventTrigger('after', 'shutdown', os._exit, 1)
                     reactor.stop()
-                else:
-                    sys.exit(1)
+                # if the reactor *isn't* running, we're already shutting down
 
     try:
         # create a WAMP application session factory


### PR DESCRIPTION
The previous patch for #278 isn't sufficient in cases where the router process has already died when the controller shuts down. It would also throw an extra exception if the reactor was already stopping in loseConnection().