### PR TITLE
Component stopping and on_component_stop

### DIFF
--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -215,7 +215,6 @@ class Node:
         call_options = CallOptions(disclose_me=True)
 
         for worker in config.get('workers', []):
-
             # worker ID, type and logname
             #
             if 'id' in worker:
@@ -365,6 +364,21 @@ class Node:
 
                     component_no = 1
 
+                    # if components exit "very soon after" we try to
+                    # start them, we consider that a failure and shut
+                    # our node down. We remove this subscription 2
+                    # seconds after we're done starting everything
+                    # (see below). This is necessary as
+                    # start_container_component returns as soon as
+                    # we've established a connection to the component
+                    def component_exited(info):
+                        dead_comp = info['id']
+                        log.msg("Component '{}' failed to start; shutting down node.".format(dead_comp))
+                        if self._reactor.running:
+                            self._reactor.stop()
+                    topic = 'crossbar.node.{}.worker.{}.container.on_component_stop'.format(self._node_id, worker_id)
+                    component_stop_sub = yield self._controller.subscribe(component_exited, topic)
+
                     for component in worker.get('components', []):
 
                         if 'id' in component:
@@ -375,6 +389,9 @@ class Node:
 
                         yield self._controller.call('crossbar.node.{}.worker.{}.start_container_component'.format(self._node_id, worker_id), component_id, component, options=call_options)
                         log.msg("{}: component '{}' started".format(worker_logname, component_id))
+
+                    # after 2 seconds, consider all the application components running
+                    self._reactor.callLater(2, component_stop_sub.unsubscribe)
 
                 else:
                     raise Exception("logic error")

--- a/crossbar/controller/process.py
+++ b/crossbar/controller/process.py
@@ -572,7 +572,7 @@ class NodeControllerSession(NativeProcessSession):
             details.progress(starting_info)
 
         # .. while all others get an event
-        options=None
+        options = None
         if details.caller is not None:
             options = PublishOptions(exclude=[details.caller])
         self.publish(starting_topic, starting_info, options=options)

--- a/crossbar/controller/process.py
+++ b/crossbar/controller/process.py
@@ -528,7 +528,10 @@ class NodeControllerSession(NativeProcessSession):
                 'who': worker.who
             }
 
-            self.publish(started_topic, started_info, options=PublishOptions(exclude=[details.caller]))
+            options = None
+            if details.caller is not None:
+                options = PublishOptions(exclude=[details.caller])
+            self.publish(started_topic, started_info, options=options)
 
             return started_info
 
@@ -569,7 +572,10 @@ class NodeControllerSession(NativeProcessSession):
             details.progress(starting_info)
 
         # .. while all others get an event
-        self.publish(starting_topic, starting_info, options=PublishOptions(exclude=[details.caller]))
+        options=None
+        if details.caller is not None:
+            options = PublishOptions(exclude=[details.caller])
+        self.publish(starting_topic, starting_info, options=options)
 
         # now actually fork the worker ..
         #

--- a/crossbar/controller/process.py
+++ b/crossbar/controller/process.py
@@ -703,7 +703,7 @@ class NodeControllerSession(NativeProcessSession):
         else:
             log.msg("Stopping {} worker with ID '{}'".format(wtype, id))
             self._workers[id].factory.stopFactory()
-            # self._workers[id].proto._session.leave()
+            self._workers[id].proto.transport.signalProcess('TERM')
 
     def start_guest(self, id, config, details=None):
         """

--- a/crossbar/worker/container.py
+++ b/crossbar/worker/container.py
@@ -34,15 +34,16 @@ import sys
 import importlib
 import pkg_resources
 import traceback
-
+from functools import partial
 from datetime import datetime
 
 from twisted.internet import reactor
 from twisted import internet
 from twisted.python import log
-from twisted.internet.defer import DeferredList, inlineCallbacks, returnValue
+from twisted.internet.defer import Deferred, DeferredList, inlineCallbacks, returnValue
 
 from autobahn.util import utcstr
+from autobahn.twisted.util import sleep
 from autobahn.wamp.exception import ApplicationError
 from autobahn.wamp.types import ComponentConfig, \
     PublishOptions, \
@@ -86,6 +87,9 @@ class ContainerComponent:
         self.proto = proto
         self.session = session
 
+        # internal use; see e.g. restart_container_component
+        self._stopped = Deferred()
+
     def marshal(self):
         """
         Marshal object information for use with WAMP calls/events.
@@ -100,7 +104,6 @@ class ContainerComponent:
 
 
 class ContainerWorkerSession(NativeWorkerSession):
-
     """
     A container is a native worker process that hosts application components
     written in Python. A container connects to an application router (creating
@@ -235,7 +238,8 @@ class ContainerWorkerSession(NativeWorkerSession):
             self._module_tracker.reload()
 
         # WAMP application session factory
-        #
+        # ultimately, this gets called once the connection is
+        # establised, from onOpen in autobahn/wamp/websocket.py:59
         def create_session():
             return create_component(componentcfg)
 
@@ -280,14 +284,41 @@ class ContainerWorkerSession(NativeWorkerSession):
         d = endpoint.connect(transport_factory)
 
         def success(proto):
-            self.components[id] = ContainerComponent(id, config, proto, None)
+            component = ContainerComponent(id, config, proto, None)
+            self.components[id] = component
+
+            def close_wrapper(orig, was_clean, code, reason):
+                """
+                Wrap our protocol's onClose so we can tell when the component
+                exits.
+                """
+                r = orig(was_clean, code, reason)
+                if component.id not in self.components:
+                    log.msg("Component '{}' closed, but not in set.".format(component.id))
+                    return r
+
+                if was_clean:
+                    log.msg("Closed connection to '{}' with code '{}'".format(component.id, code))
+                else:
+                    msg = "Lost connection to container '{}' with code '{}'."
+                    log.msg(msg.format(component.id, code))
+
+                if reason:
+                    log.msg(str(reason))
+                del self.components[component.id]
+                self._publish_component_stop(component)
+                component._stopped.callback(component.marshal())
+                return r
+            proto.onClose = partial(close_wrapper, proto.onClose)
 
             # publish event "on_component_start" to all but the caller
             #
-            topic = 'crossbar.node.{}.worker.{}.container.on_component_start'.format(self.config.extra.node, self.config.extra.worker)
+            topic = self._uri_prefix + '.container.on_component_start'
             event = {'id': id}
-            self.publish(topic, event, options=PublishOptions(exclude=[details.caller]))
-
+            options = None
+            if details.caller:
+                options = PublishOptions(exclude=[details.caller])
+            self.publish(topic, event, options=options)
             return event
 
         def error(err):
@@ -303,6 +334,15 @@ class ContainerWorkerSession(NativeWorkerSession):
         d.addCallbacks(success, error)
 
         return d
+
+    def _publish_component_stop(self, component):
+        """
+        Internal helper to publish details to on_component_stop
+        """
+        event = component.marshal()
+        topic = self._uri_prefix + '.container.on_component_stop'
+        self.publish(topic, event)
+        return event
 
     @inlineCallbacks
     def restart_container_component(self, id, reload_modules=False, details=None):
@@ -323,11 +363,15 @@ class ContainerWorkerSession(NativeWorkerSession):
         if id not in self.components:
             raise ApplicationError('crossbar.error.no_such_object', 'no component with ID {} running in this container'.format(id))
 
-        config = self.components[id].config
-        stopped = yield self.stop_component(id, details=details)
-        started = yield self.start_component(config, reload_modules=reload_modules, details=details)
+        component = self.components[id]
+
+        stopped = yield self.stop_container_component(id, details=details)
+        started = yield self.start_container_component(
+            id, component.config, reload_modules=reload_modules, details=details)
+
         returnValue({'stopped': stopped, 'started': started})
 
+    @inlineCallbacks
     def stop_container_component(self, id, details=None):
         """
         Stop a component currently running within this container.
@@ -342,28 +386,16 @@ class ContainerWorkerSession(NativeWorkerSession):
         if id not in self.components:
             raise ApplicationError('crossbar.error.no_such_object', 'no component with ID {} running in this container'.format(id))
 
-        now = datetime.utcnow()
+        component = self.components[id]
+        try:
+            component.proto.close()
+        except:
+            log.err(_why="Failed to close component '{}':".format(id))
+            raise
 
-        # FIXME: should we session.leave() first and only close the transport then?
-        # This gives the app component a better hook to do any cleanup.
-        self.components[id].proto.close()
-
-        c = self.components[id]
-        event = {
-            'id': id,
-            'started': utcstr(c.started),
-            'stopped': utcstr(now),
-            'uptime': (now - c.started).total_seconds()
-        }
-
-        # publish event "on_component_stop" to all but the caller
-        #
-        topic = 'crossbar.node.{}.worker.{}.container.on_component_stop'.format(self.config.extra.node, self.config.extra.worker)
-        self.publish(topic, event, options=PublishOptions(exclude=[details.caller]))
-
-        del self.components[id]
-
-        return event
+        # essentially just waiting for "on_component_stop"
+        yield component._stopped
+        returnValue(component.marshal())
 
     def get_container_components(self, details=None):
         """

--- a/crossbar/worker/container.py
+++ b/crossbar/worker/container.py
@@ -241,7 +241,12 @@ class ContainerWorkerSession(NativeWorkerSession):
         # ultimately, this gets called once the connection is
         # establised, from onOpen in autobahn/wamp/websocket.py:59
         def create_session():
-            return create_component(componentcfg)
+            try:
+                return create_component(componentcfg)
+            except Exception as e:
+                # AutobahnPython swallows exceptions from onOpen
+                log.err(_why="Instantiating component failed")
+                raise
 
         # 2) create WAMP transport factory
         #

--- a/crossbar/worker/container.py
+++ b/crossbar/worker/container.py
@@ -305,7 +305,7 @@ class ContainerWorkerSession(NativeWorkerSession):
                 if was_clean:
                     log.msg("Closed connection to '{}' with code '{}'".format(component.id, code))
                 else:
-                    msg = "Lost connection to container '{}' with code '{}'."
+                    msg = "Lost connection to component '{}' with code '{}'."
                     log.msg(msg.format(component.id, code))
 
                 if reason:

--- a/crossbar/worker/container.py
+++ b/crossbar/worker/container.py
@@ -43,7 +43,6 @@ from twisted.python import log
 from twisted.internet.defer import Deferred, DeferredList, inlineCallbacks, returnValue
 
 from autobahn.util import utcstr
-from autobahn.twisted.util import sleep
 from autobahn.wamp.exception import ApplicationError
 from autobahn.wamp.types import ComponentConfig, \
     PublishOptions, \
@@ -243,7 +242,7 @@ class ContainerWorkerSession(NativeWorkerSession):
         def create_session():
             try:
                 return create_component(componentcfg)
-            except Exception as e:
+            except Exception:
                 # AutobahnPython swallows exceptions from onOpen
                 log.err(_why="Instantiating component failed")
                 raise


### PR DESCRIPTION
This fixes up a few things relating to stopping components:

 - on_component_stop published whenever a connection to a component dies
 - log errors when instantiating a component fails
 - proper shutdown in stop_container
 - while doing "static config initialization", if any component dies within 2 seconds, we shutdown crossbar
 - if details.caller was None, this wasn't dealt with properly (could rebase this out; not strictly related...)