### PR TITLE
Unicode dict keys

### DIFF
--- a/crossbar/controller/process.py
+++ b/crossbar/controller/process.py
@@ -558,10 +558,10 @@ class NodeControllerSession(NativeProcessSession):
         # now (immediately before actually forking) signal the starting of the worker
         #
         starting_info = {
-            'id': id,
-            'status': worker.status,
-            'created': utcstr(worker.created),
-            'who': worker.who
+            u'id': id,
+            u'status': worker.status,
+            u'created': utcstr(worker.created),
+            u'who': worker.who
         }
 
         # the caller gets a progressive result ..
@@ -831,10 +831,10 @@ class NodeControllerSession(NativeProcessSession):
             # assemble guest worker startup information
             #
             started_info = {
-                'id': worker.id,
-                'status': worker.status,
-                'started': utcstr(worker.started),
-                'who': worker.who
+                u'id': worker.id,
+                u'status': worker.status,
+                u'started': utcstr(worker.started),
+                u'who': worker.who
             }
 
             self.publish(started_topic, started_info, options=PublishOptions(exclude=[details.caller]))
@@ -869,10 +869,10 @@ class NodeControllerSession(NativeProcessSession):
         # now (immediately before actually forking) signal the starting of the worker
         #
         starting_info = {
-            'id': id,
-            'status': worker.status,
-            'created': utcstr(worker.created),
-            'who': worker.who
+            u'id': id,
+            u'status': worker.status,
+            u'created': utcstr(worker.created),
+            u'who': worker.who
         }
 
         # the caller gets a progressive result ..

--- a/crossbar/router/broker.py
+++ b/crossbar/router/broker.py
@@ -319,10 +319,10 @@ class Broker(object):
                     if service_session and not subscription.uri.startswith(u'wamp.'):
                         if is_first_subscriber:
                             subscription_details = {
-                                'id': subscription.id,
-                                'created': subscription.created,
-                                'uri': subscription.uri,
-                                'match': subscription.match,
+                                u'id': subscription.id,
+                                u'created': subscription.created,
+                                u'uri': subscription.uri,
+                                u'match': subscription.match,
                             }
                             service_session.publish(u'wamp.subscription.on_create', session._session_id, subscription_details)
                         if not was_already_subscribed:

--- a/crossbar/router/dealer.py
+++ b/crossbar/router/dealer.py
@@ -213,11 +213,11 @@ class Dealer(object):
                     if service_session and not registration.uri.startswith(u'wamp.'):
                         if is_first_callee:
                             registration_details = {
-                                'id': registration.id,
-                                'created': registration.created,
-                                'uri': registration.uri,
-                                'match': registration.match,
-                                'invoke': registration.extra.invoke,
+                                u'id': registration.id,
+                                u'created': registration.created,
+                                u'uri': registration.uri,
+                                u'match': registration.match,
+                                u'invoke': registration.extra.invoke,
                             }
                             service_session.publish(u'wamp.registration.on_create', session._session_id, registration_details)
                         if not was_already_registered:

--- a/crossbar/router/protocol.py
+++ b/crossbar/router/protocol.py
@@ -253,11 +253,11 @@ class CrossbarWampWebSocketServerProtocol(WampWebSocketServerProtocol):
             # WAMP meta event "wamp.session.on_join"
             #
             self._transport_info = {
-                'type': 'websocket',
-                'protocol': protocol,
-                'peer': self.peer,
-                'http_headers_received': request.headers,
-                'http_headers_sent': headers
+                u'type': 'websocket',
+                u'protocol': protocol,
+                u'peer': self.peer,
+                u'http_headers_received': request.headers,
+                u'http_headers_sent': headers
             }
 
             # accept the WebSocket connection, speaking subprotocol `protocol`
@@ -410,9 +410,9 @@ class CrossbarWampRawSocketServerProtocol(WampRawSocketServerProtocol):
         # WAMP meta event "wamp.session.on_join"
         #
         self._transport_info = {
-            'type': 'rawsocket',
-            'protocol': None,  # FIXME
-            'peer': self.peer
+            u'type': 'rawsocket',
+            u'protocol': None,  # FIXME
+            u'peer': self.peer
         }
 
     def lengthLimitExceeded(self, length):

--- a/crossbar/router/service.py
+++ b/crossbar/router/service.py
@@ -209,11 +209,11 @@ class CrossbarRouterServiceSession(ApplicationSession):
         registration = self._router._dealer._registration_map.get_observation_by_id(registration_id)
         if registration and not is_protected_uri(registration.uri):
             registration_details = {
-                'id': registration.id,
-                'created': registration.created,
-                'uri': registration.uri,
-                'match': registration.match,
-                'invoke': registration.extra.invoke,
+                u'id': registration.id,
+                u'created': registration.created,
+                u'uri': registration.uri,
+                u'match': registration.match,
+                u'invoke': registration.extra.invoke,
             }
             return registration_details
         else:
@@ -233,10 +233,10 @@ class CrossbarRouterServiceSession(ApplicationSession):
         subscription = self._router._broker._subscription_map.get_observation_by_id(subscription_id)
         if subscription and not is_protected_uri(subscription.uri):
             subscription_details = {
-                'id': subscription.id,
-                'created': subscription.created,
-                'uri': subscription.uri,
-                'match': subscription.match,
+                u'id': subscription.id,
+                u'created': subscription.created,
+                u'uri': subscription.uri,
+                u'match': subscription.match,
             }
             return subscription_details
         else:

--- a/crossbar/router/session.py
+++ b/crossbar/router/session.py
@@ -602,11 +602,11 @@ class CrossbarRouterSession(RouterSession):
                                     session_details = {
                                         # forward transport level details of the WAMP session that
                                         # wishes to authenticate
-                                        'transport': self._transport._transport_info,
+                                        u'transport': self._transport._transport_info,
 
                                         # the following WAMP session ID will be assigned to the session
                                         # if (and only if) the subsequent authentication succeeds.
-                                        'session': self._pending_session_id
+                                        u'session': self._pending_session_id
                                     }
                                     d = service_session.call(cfg['authenticator'], realm, details.authid, session_details)
 
@@ -989,13 +989,13 @@ class CrossbarRouterSession(RouterSession):
         # self._router._realm.session:   crossbar.router.session.CrossbarRouterServiceSession
 
         self._session_details = {
-            'authid': details.authid,
-            'authrole': details.authrole,
-            'authmethod': details.authmethod,
-            'authprovider': details.authprovider,
-            'realm': details.realm,
-            'session': details.session,
-            'transport': self._transport._transport_info
+            u'authid': details.authid,
+            u'authrole': details.authrole,
+            u'authmethod': details.authmethod,
+            u'authprovider': details.authprovider,
+            u'realm': details.realm,
+            u'session': details.session,
+            u'transport': self._transport._transport_info
         }
 
         # dispatch session metaevent from WAMP AP

--- a/crossbar/router/session.py
+++ b/crossbar/router/session.py
@@ -60,7 +60,7 @@ from crossbar.router.auth import PendingAuthPersona, \
 
 __all__ = (
     'CrossbarRouterSessionFactory',
-    'CrossbarRouterFactory',
+    'CrossbarRouterSession',
 )
 
 

--- a/crossbar/router/test/test_router.py
+++ b/crossbar/router/test/test_router.py
@@ -64,7 +64,6 @@ class TestCrossbarSessions(unittest.TestCase):
         session.onJoin(details)
 
         calls = session._router._realm.session.method_calls
-        print(calls, calls[0][1])
         self.assertEqual(1, len(calls))
         for (k, v) in six.iteritems(calls[0][1][1]):
             self.assertTrue(type(k) == six.text_type)

--- a/crossbar/router/test/test_router.py
+++ b/crossbar/router/test/test_router.py
@@ -32,13 +32,42 @@ from __future__ import absolute_import
 
 from twisted.trial import unittest
 
+from mock import Mock
+
 import txaio
+
+import six
 
 from autobahn.wamp import types
 from autobahn.twisted.wamp import ApplicationSession
 
-from crossbar.router.router import RouterFactory
+from crossbar.router.router import RouterFactory, CrossbarRouterFactory
 from crossbar.router.session import RouterSessionFactory
+from crossbar.router.session import CrossbarRouterSession
+
+
+class TestCrossbarSessions(unittest.TestCase):
+    def test_onjoin_metaevent(self):
+        # we're just short-circuiting straight to calling onJoin()
+        # ourselves rather than drive the protocol to that point.
+        factory = CrossbarRouterFactory()
+        session = CrossbarRouterSession(factory)
+        # ...but we therefore have to set up enough internals so the
+        # onJoin() can emit the session-details it wants.
+        session._router = Mock()
+        session._router._realm = Mock()
+        session._router._realm.session = Mock()
+        session._transport = Mock()
+        session._transport._transport_info = 'nothing to see here'
+        details = types.SessionDetails(u'test_realm', 1234)
+
+        session.onJoin(details)
+
+        calls = session._router._realm.session.method_calls
+        print(calls, calls[0][1])
+        self.assertEqual(1, len(calls))
+        for (k, v) in six.iteritems(calls[0][1][1]):
+            self.assertTrue(type(k) == six.text_type)
 
 
 class TestEmbeddedSessions(unittest.TestCase):


### PR DESCRIPTION
A unit-test of sorts for #316 and switch the dict keys for anything we publish to be unicode strings.

I'm not 100% sure this is the *right* fix, now that I look at the diff.

WAMP says dicts should have string keys, so perhaps this really was an Autobahn|Python bug after all? That is, a trip through the serializers should have made all they keys the appropriate string type for a Python3 client instead of bytes()...