### PR TITLE
Session shutdown behavior

### DIFF
--- a/crossbar/router/observation.py
+++ b/crossbar/router/observation.py
@@ -66,7 +66,6 @@ class OrderedSet(set):
 
 
 class UriObservation(object):
-
     """
     Represents an URI observation maintained by a broker/dealer.
     """
@@ -99,6 +98,11 @@ class UriObservation(object):
             self.observers = OrderedSet()
         else:
             self.observers = set()
+
+    def __repr__(self):
+        return "<{} id={} uri={} ordered={} extra={} created={} observers={}>".format(
+            self.__class__.__name__, self.id, self.uri, self.ordered, self.extra, self.created,
+            self.observers)
 
 
 class ExactUriObservation(UriObservation):

--- a/crossbar/router/router.py
+++ b/crossbar/router/router.py
@@ -44,6 +44,9 @@ from crossbar.router.role import CrossbarRouterRole, \
     CrossbarRouterRoleDynamicAuth
 
 
+def _is_client_session(session):
+    return hasattr(session, '_session_details')
+
 class Router(object):
     """
     Basic WAMP router.
@@ -87,7 +90,7 @@ class Router(object):
         Implements :func:`autobahn.wamp.interfaces.IRouter.attach`
         """
         if session._session_id not in self._session_id_to_session:
-            if hasattr(session, '_session_details'):
+            if _is_client_session(session):
                 self._session_id_to_session[session._session_id] = session
             else:
                 if self.debug:
@@ -112,7 +115,8 @@ class Router(object):
         if session._session_id in self._session_id_to_session:
             del self._session_id_to_session[session._session_id]
         else:
-            raise Exception("session with ID {} not attached".format(session._session_id))
+            if _is_client_session(session):
+                raise Exception("session with ID {} not attached".format(session._session_id))
 
         self._attached -= 1
         if not self._attached:

--- a/crossbar/router/router.py
+++ b/crossbar/router/router.py
@@ -47,6 +47,7 @@ from crossbar.router.role import CrossbarRouterRole, \
 def _is_client_session(session):
     return hasattr(session, '_session_details')
 
+
 class Router(object):
     """
     Basic WAMP router.


### PR DESCRIPTION
Do the same checks during session detach that we do during attach, or all "not-client sessions" will fail to shutdown cleanly. Plus a couple cleanups I left it.