### PR TITLE
More logging improvements

### DIFF
--- a/crossbar/_logging.py
+++ b/crossbar/_logging.py
@@ -78,6 +78,9 @@ def makeStandardOutObserver(levels=(LogLevel.info, LogLevel.debug),
     @provider(ILogObserver)
     def StandardOutObserver(event):
 
+        if event.get("cb_level") == "trace":
+            return
+
         if event["log_level"] not in levels:
             return
 

--- a/crossbar/_logging.py
+++ b/crossbar/_logging.py
@@ -217,6 +217,10 @@ def make_legacy_daily_logfile_observer(path, logoutputlevel):
     return _log
 
 
+def make_logger():
+    return Logger(observer=log_publisher)
+
+
 def start_logging():
     """
     Start logging to the publishers.

--- a/crossbar/_logging.py
+++ b/crossbar/_logging.py
@@ -154,14 +154,13 @@ def makeStandardErrObserver(levels=(LogLevel.warn, LogLevel.error,
 
 
 def makeJSONObserver(outFile):
-
+    """
+    Make an observer which writes JSON to C{outfile}.
+    """
     def _make_json(event):
 
-        r = json.dumps({"text": formatEvent(event).replace(u"{", u"{{").replace(u"}", u"}}"),
-                        "level":event.get("log_level", LogLevel.info).name})
-        if not _PY3:
-            r = r.decode("utf8")
-        return r
+        return json.dumps({"text": formatEvent(event).replace(u"{", u"{{").replace(u"}", u"}}"),
+                           "level":event.get("log_level", LogLevel.info).name})
 
     recordSeparator=u"\x1e"
     return FileLogObserver(

--- a/crossbar/_logging.py
+++ b/crossbar/_logging.py
@@ -42,8 +42,8 @@ from twisted.logger import FileLogObserver
 
 from twisted.python.reflect import qual
 
-logPublisher = LogPublisher()
-log = Logger(observer=logPublisher)
+log_publisher = LogPublisher()
+log = Logger(observer=log_publisher)
 
 try:
     from colorama import Fore
@@ -69,8 +69,8 @@ SYSLOGD_FORMAT = "[{}] {}"
 _stderr, _stdout = sys.stderr, sys.stdout
 
 
-def makeStandardOutObserver(levels=(LogLevel.info, LogLevel.debug),
-                            showSource=False, format="colour", trace=False):
+def make_stdout_observer(levels=(LogLevel.info, LogLevel.debug),
+                         show_source=False, format="colour", trace=False):
     """
     Create an observer which prints logs to L{sys.stdout}.
     """
@@ -89,7 +89,7 @@ def makeStandardOutObserver(levels=(LogLevel.info, LogLevel.debug),
         else:
             logSystem = event["log_system"]
 
-        if showSource and event.get("log_source") is not None:
+        if show_source and event.get("log_source") is not None:
             logSystem += " " + qual(event["log_source"].__class__)
 
         if format == "colour":
@@ -117,9 +117,9 @@ def makeStandardOutObserver(levels=(LogLevel.info, LogLevel.debug),
     return StandardOutObserver
 
 
-def makeStandardErrObserver(levels=(LogLevel.warn, LogLevel.error,
-                                    LogLevel.critical),
-                            showSource=False, format="colour"):
+def make_stderr_observer(levels=(LogLevel.warn, LogLevel.error,
+                                 LogLevel.critical),
+                         show_source=False, format="colour"):
     """
     Create an observer which prints logs to L{sys.stderr}.
     """
@@ -134,7 +134,7 @@ def makeStandardErrObserver(levels=(LogLevel.warn, LogLevel.error,
         else:
             logSystem = event["log_system"]
 
-        if showSource and event.get("log_source") is not None:
+        if show_source and event.get("log_source") is not None:
             logSystem += " " + qual(event["log_source"].__class__)
 
         if format == "colour":
@@ -153,7 +153,7 @@ def makeStandardErrObserver(levels=(LogLevel.warn, LogLevel.error,
     return StandardErrorObserver
 
 
-def makeJSONObserver(outFile):
+def make_JSON_observer(outFile):
     """
     Make an observer which writes JSON to C{outfile}.
     """
@@ -169,9 +169,9 @@ def makeJSONObserver(outFile):
     )
 
 
-def makeLegacyDailyLogFileObserver(path, logoutputlevel):
+def make_legacy_daily_logfile_observer(path, logoutputlevel):
     """
-    Make a L{DefaultSystemFileLogObserver}
+    Make a L{DefaultSystemFileLogObserver}.
     """
     from crossbar.twisted.processutil import DefaultSystemFileLogObserver
     from twisted.logger import LegacyLogObserverWrapper
@@ -217,8 +217,8 @@ def makeLegacyDailyLogFileObserver(path, logoutputlevel):
     return _log
 
 
-def startLogging():
+def start_logging():
     """
     Start logging to the publishers.
     """
-    globalLogBeginner.beginLoggingTo([logPublisher])
+    globalLogBeginner.beginLoggingTo([log_publisher])

--- a/crossbar/_logging.py
+++ b/crossbar/_logging.py
@@ -38,7 +38,7 @@ from zope.interface import provider
 
 from twisted.logger import ILogObserver, formatEvent, Logger, LogPublisher
 from twisted.logger import LogLevel, globalLogBeginner, formatTime
-from twisted.logger import FileLogObserver, eventAsJSON
+from twisted.logger import FileLogObserver
 
 from twisted.python.reflect import qual
 
@@ -160,13 +160,14 @@ def makeJSONObserver(outFile):
     def _make_json(event):
 
         return json.dumps({"text": formatEvent(event).replace(u"{", u"{{").replace(u"}", u"}}"),
-                           "level":event.get("log_level", LogLevel.info).name})
+                           "level": event.get("log_level", LogLevel.info).name})
 
-    recordSeparator=u"\x1e"
+    recordSeparator = u"\x1e"
     return FileLogObserver(
         outFile,
         lambda event: u"{0}{1}".format(_make_json(event), recordSeparator)
     )
+
 
 def makeLegacyDailyLogFileObserver(path, logoutputlevel):
     """
@@ -182,6 +183,7 @@ def makeLegacyDailyLogFileObserver(path, logoutputlevel):
         DefaultSystemFileLogObserver(logfd,
                                      system="{:<10} {:>6}".format(
                                          "Controller", os.getpid())).emit)
+
     def _log(event):
 
         level = event["log_level"]

--- a/crossbar/_logging.py
+++ b/crossbar/_logging.py
@@ -69,9 +69,6 @@ SYSLOGD_FORMAT = "[{}] {}"
 _stderr, _stdout = sys.stderr, sys.stdout
 
 
-__all__ = ["log", "logPublisher", "Logger"]
-
-
 def makeStandardOutObserver(levels=(LogLevel.info, LogLevel.debug),
                             showSource=False, format="colour", trace=False):
     """
@@ -160,8 +157,10 @@ def makeJSONObserver(outFile):
 
     def _make_json(event):
 
-        r = json.dumps({"text": formatEvent(event).replace("{", "{{").replace("}", "}}"),
+        r = json.dumps({"text": formatEvent(event).replace(u"{", u"{{").replace(u"}", u"}}"),
                         "level":event.get("log_level", LogLevel.info).name})
+        if not _PY3:
+            r = r.decode("utf8")
         return r
 
     recordSeparator=u"\x1e"

--- a/crossbar/common/process.py
+++ b/crossbar/common/process.py
@@ -36,10 +36,7 @@ from datetime import datetime
 
 from twisted.python import log
 from twisted.internet import reactor
-from twisted.internet.defer import DeferredList, \
-    inlineCallbacks, \
-    returnValue
-
+from twisted.internet.defer import DeferredList, inlineCallbacks, returnValue
 from twisted.internet.task import LoopingCall
 
 
@@ -66,8 +63,7 @@ else:
 from autobahn.util import utcnow, utcstr, rtime
 from autobahn.twisted.wamp import ApplicationSession
 from autobahn.wamp.exception import ApplicationError
-from autobahn.wamp.types import PublishOptions, \
-    RegisterOptions
+from autobahn.wamp.types import PublishOptions, RegisterOptions
 
 from crossbar.common import checkconfig
 from crossbar.twisted.endpoint import create_listening_port_from_config
@@ -76,6 +72,8 @@ from crossbar.common.processinfo import _HAS_PSUTIL
 if _HAS_PSUTIL:
     from crossbar.common.processinfo import ProcessInfo
     # from crossbar.common.processinfo import SystemInfo
+
+from crossbar._logging import make_logger
 
 __all__ = ('NativeProcessSession',)
 
@@ -122,25 +120,21 @@ if _HAS_MANHOLE:
 
 
 class NativeProcessSession(ApplicationSession):
-
     """
     A native Crossbar.io process (currently: controller, router or container).
     """
+    log = make_logger()
 
     def onConnect(self, do_join=True):
         """
         """
-        if not hasattr(self, 'debug'):
-            self.debug = self.config.extra.debug
-
         if not hasattr(self, 'cbdir'):
             self.cbdir = self.config.extra.cbdir
 
         if not hasattr(self, '_uri_prefix'):
             self._uri_prefix = 'crossbar.node.{}'.format(self.config.extra.node)
 
-        if self.debug:
-            log.msg("Session connected to management router")
+        self.log.debug("Session connected to management router")
 
         self._started = datetime.utcnow()
 
@@ -184,14 +178,13 @@ class NativeProcessSession(ApplicationSession):
         dl = []
         for proc in procs:
             uri = '{}.{}'.format(self._uri_prefix, proc)
-            if self.debug:
-                log.msg("Registering procedure '{}'".format(uri))
+            self.log.debug("Registering procedure '{uri}'", uri=uri)
             dl.append(self.register(getattr(self, proc), uri, options=RegisterOptions(details_arg='details')))
 
         regs = yield DeferredList(dl)
 
-        if self.debug:
-            log.msg("{} registered {} procedures".format(self.__class__.__name__, len(regs)))
+        self.log.debug("{cls} registered {len_reg} procedures",
+                       cls=self.__class__.__name__, len_reg=len(regs))
 
     def get_process_info(self, details=None):
         """
@@ -199,8 +192,8 @@ class NativeProcessSession(ApplicationSession):
 
         :returns: dict -- Dictionary with process information.
         """
-        if self.debug:
-            log.msg("{}.get_process_info".format(self.__class__.__name__))
+        self.log.debug("{cls}.get_process_info",
+                       cls=self.__class__.__name__)
 
         if self._pinfo:
             return self._pinfo.get_info()
@@ -214,8 +207,7 @@ class NativeProcessSession(ApplicationSession):
 
         :returns: dict -- Dictionary with process statistics.
         """
-        if self.debug:
-            log.msg("{}.get_process_stats".format(self.__class__.__name__))
+        self.log.debug("{cls}.get_process_stats", cls=self.__class__.__name__)
 
         if self._pinfo:
             return self._pinfo.get_stats()
@@ -230,8 +222,8 @@ class NativeProcessSession(ApplicationSession):
         :param interval: The monitoring interval in seconds. Set to 0 to disable monitoring.
         :type interval: float
         """
-        if self.debug:
-            log.msg("{}.set_process_stats_monitoring".format(self.__class__.__name__), interval)
+        self.log.debug("{cls}.set_process_stats_monitoring(interval = {interval})",
+                       cls=self.__class__.__name__, interval=interval)
 
         if self._pinfo:
 
@@ -268,8 +260,7 @@ class NativeProcessSession(ApplicationSession):
 
         :returns: float -- Time consumed for GC in ms.
         """
-        if self.debug:
-            log.msg("{}.trigger_gc".format(self.__class__.__name__))
+        self.msg.debug("{cls}.trigger_gc", cls=self.__class__.__name__)
 
         started = rtime()
         gc.collect()
@@ -283,24 +274,24 @@ class NativeProcessSession(ApplicationSession):
         :param config: Manhole configuration.
         :type config: obj
         """
-        if self.debug:
-            log.msg("{}.start_manhole".format(self.__class__.__name__), config)
+        self.log.debug("{cls}.start_manhole(config = {config})",
+                       cls=self.__class__.__name__, config=config)
 
         if not _HAS_MANHOLE:
             emsg = "ERROR: could not start manhole - required packages are missing ({})".format(_MANHOLE_MISSING_REASON)
-            log.msg(emsg)
+            self.log.error(emsg)
             raise ApplicationError("crossbar.error.feature_unavailable", emsg)
 
         if self._manhole_service:
             emsg = "ERROR: could not start manhole - already running (or starting)"
-            log.msg(emsg)
+            self.log.warn(emsg)
             raise ApplicationError("crossbar.error.already_started", emsg)
 
         try:
             checkconfig.check_manhole(config)
         except Exception as e:
             emsg = "ERROR: could not start manhole - invalid configuration ({})".format(e)
-            log.msg(emsg)
+            self.log.error(emsg)
             raise ApplicationError('crossbar.error.invalid_configuration', emsg)
 
         # setup user authentication
@@ -346,7 +337,7 @@ class NativeProcessSession(ApplicationSession):
         except Exception as e:
             self._manhole_service = None
             emsg = "ERROR: manhole service endpoint cannot listen - {}".format(e)
-            log.msg(emsg)
+            self.log.error(emsg)
             raise ApplicationError("crossbar.error.cannot_listen", emsg)
 
         # alright, manhole has started
@@ -364,12 +355,11 @@ class NativeProcessSession(ApplicationSession):
         """
         Stop Manhole.
         """
-        if self.debug:
-            log.msg("{}.stop_manhole".format(self.__class__.__name__))
+        self.log.debug("{cls}.stop_manhole", cls=self.__class__.__name__)
 
         if not _HAS_MANHOLE:
             emsg = "ERROR: could not start manhole - required packages are missing ({})".format(_MANHOLE_MISSING_REASON)
-            log.msg(emsg)
+            self.log.error(emsg)
             raise ApplicationError("crossbar.error.feature_unavailable", emsg)
 
         if not self._manhole_service or self._manhole_service.status != 'started':
@@ -407,12 +397,11 @@ class NativeProcessSession(ApplicationSession):
 
         :returns: dict -- A dict with service information or `None` if the service is not running.
         """
-        if self.debug:
-            log.msg("{}.get_manhole".format(self.__class__.__name__))
+        self.log.debug("{cls}.get_manhole", cls=self.__class__.__name__)
 
         if not _HAS_MANHOLE:
             emsg = "ERROR: could not start manhole - required packages are missing ({})".format(_MANHOLE_MISSING_REASON)
-            log.msg(emsg)
+            self.log.error(emsg)
             raise ApplicationError("crossbar.error.feature_unavailable", emsg)
 
         if not self._manhole_service:
@@ -426,8 +415,7 @@ class NativeProcessSession(ApplicationSession):
 
         :returns str -- Current time (UTC) in UTC ISO 8601 format.
         """
-        if self.debug:
-            log.msg("{}.utcnow".format(self.__class__.__name__))
+        self.log.debug("{cls}.utcnow", cls=self.__class__.__name__)
 
         return utcnow()
 
@@ -437,8 +425,7 @@ class NativeProcessSession(ApplicationSession):
 
         :returns str -- Start time (UTC) in UTC ISO 8601 format.
         """
-        if self.debug:
-            log.msg("{}.started".format(self.__class__.__name__))
+        self.log.debug("{cls}.started", cls=self.__class__.__name__)
 
         return utcstr(self._started)
 
@@ -448,8 +435,7 @@ class NativeProcessSession(ApplicationSession):
 
         :returns float -- Uptime in seconds.
         """
-        if self.debug:
-            log.msg("{}.uptime".format(self.__class__.__name__))
+        self.log.debug("{cls}.uptime", cls=self.__class__.__name__)
 
         now = datetime.utcnow()
         return (now - self._started).total_seconds()

--- a/crossbar/common/process.py
+++ b/crossbar/common/process.py
@@ -34,7 +34,6 @@ import gc
 
 from datetime import datetime
 
-from twisted.python import log
 from twisted.internet import reactor
 from twisted.internet.defer import DeferredList, inlineCallbacks, returnValue
 from twisted.internet.task import LoopingCall
@@ -152,7 +151,7 @@ class NativeProcessSession(ApplicationSession):
             self._pinfo = None
             self._pinfo_monitor = None
             self._pinfo_monitor_seq = None
-            log.msg("Warning: process utilities not available")
+            self.log.info("Warning: process utilities not available")
 
         if do_join:
             self.join(self.config.realm)

--- a/crossbar/controller/cli.py
+++ b/crossbar/controller/cli.py
@@ -398,6 +398,7 @@ def run_command_start(options):
         # We want to log to stdout/stderr.
         from crossbar._logging import makeStandardOutObserver
         from crossbar._logging import makeStandardErrObserver
+
         if options.loglevel == "none":
             # Do no logging!
             pass

--- a/crossbar/controller/cli.py
+++ b/crossbar/controller/cli.py
@@ -410,6 +410,11 @@ def run_command_start(options):
     if options.loglevel == "none":
         # Do no logging!
         pass
+    elif options.loglevel == "quiet":
+        # Quiet: Only print warnings and errors to stderr.
+        logPublisher.addObserver(makeStandardErrObserver(
+            (LogLevel.warn, LogLevel.error,
+             LogLevel.critical), showSource=False, format=options.logformat))
     elif options.loglevel == "standard":
         # Standard: For users of Crossbar
         logPublisher.addObserver(makeStandardOutObserver(
@@ -426,11 +431,15 @@ def run_command_start(options):
         logPublisher.addObserver(makeStandardErrObserver(
             (LogLevel.warn, LogLevel.error,
              LogLevel.critical), showSource=True, format=options.logformat))
-    elif options.loglevel == "quiet":
-        # Quiet: Only print warnings and errors to stderr.
+    elif options.loglevel == "trace":
+        # Verbose: for developers
+        # Adds the class source + "trace" output
+        logPublisher.addObserver(makeStandardOutObserver(
+            (LogLevel.info, LogLevel.debug), showSource=True,
+            format=options.logformat, trace=True))
         logPublisher.addObserver(makeStandardErrObserver(
             (LogLevel.warn, LogLevel.error,
-             LogLevel.critical), showSource=False, format=options.logformat))
+             LogLevel.critical), showSource=True, format=options.logformat))
     else:
         assert False, "Shouldn't ever get here."
 
@@ -595,7 +604,7 @@ def run(prog=None, args=None):
     parser_start.add_argument('--loglevel',
                               type=str,
                               default='standard',
-                              choices=['none', 'quiet', 'standard', 'verbose'],
+                              choices=['none', 'quiet', 'standard', 'verbose', 'trace'],
                               help="How much Crossbar.io should log to the terminal, in order of verbosity.")
 
     parser_start.add_argument('--logformat',

--- a/crossbar/controller/cli.py
+++ b/crossbar/controller/cli.py
@@ -47,7 +47,7 @@ from autobahn.util import utcnow
 from autobahn.twisted.choosereactor import install_reactor
 
 import crossbar
-from crossbar._logging import log, logPublisher
+from crossbar._logging import log, log_publisher
 
 try:
     import psutil
@@ -386,57 +386,57 @@ def run_command_start(options):
 
     # start Twisted logging
     #
-    from crossbar._logging import LogLevel, startLogging
+    from crossbar._logging import LogLevel, start_logging
 
     if options.logdir:
         # We want to log to a file
-        from crossbar._logging import makeLegacyDailyLogFileObserver
+        from crossbar._logging import make_legacy_daily_logfile_observer
 
-        logPublisher.addObserver(
-            makeLegacyDailyLogFileObserver(options.logdir, options.loglevel))
+        log_publisher.addObserver(
+            make_legacy_daily_logfile_observer(options.logdir, options.loglevel))
     else:
         # We want to log to stdout/stderr.
-        from crossbar._logging import makeStandardOutObserver
-        from crossbar._logging import makeStandardErrObserver
+        from crossbar._logging import make_stdout_observer
+        from crossbar._logging import make_stderr_observer
 
         if options.loglevel == "none":
             # Do no logging!
             pass
         elif options.loglevel == "quiet":
             # Quiet: Only print warnings and errors to stderr.
-            logPublisher.addObserver(makeStandardErrObserver(
+            log_publisher.addObserver(make_stderr_observer(
                 (LogLevel.warn, LogLevel.error,
-                 LogLevel.critical), showSource=False, format=options.logformat))
+                 LogLevel.critical), show_source=False, format=options.logformat))
         elif options.loglevel == "standard":
             # Standard: For users of Crossbar
-            logPublisher.addObserver(makeStandardOutObserver(
-                (LogLevel.info,), showSource=False, format=options.logformat))
-            logPublisher.addObserver(makeStandardErrObserver(
+            log_publisher.addObserver(make_stdout_observer(
+                (LogLevel.info,), show_source=False, format=options.logformat))
+            log_publisher.addObserver(make_stderr_observer(
                 (LogLevel.warn, LogLevel.error,
-                 LogLevel.critical), showSource=False, format=options.logformat))
+                 LogLevel.critical), show_source=False, format=options.logformat))
         elif options.loglevel == "verbose":
             # Verbose: for developers
             # Adds the class source.
-            logPublisher.addObserver(makeStandardOutObserver(
-                (LogLevel.info, LogLevel.debug), showSource=True,
+            log_publisher.addObserver(make_stdout_observer(
+                (LogLevel.info, LogLevel.debug), show_source=True,
                 format=options.logformat))
-            logPublisher.addObserver(makeStandardErrObserver(
+            log_publisher.addObserver(make_stderr_observer(
                 (LogLevel.warn, LogLevel.error,
-                 LogLevel.critical), showSource=True, format=options.logformat))
+                 LogLevel.critical), show_source=True, format=options.logformat))
         elif options.loglevel == "trace":
             # Verbose: for developers
             # Adds the class source + "trace" output
-            logPublisher.addObserver(makeStandardOutObserver(
-                (LogLevel.info, LogLevel.debug), showSource=True,
+            log_publisher.addObserver(make_stdout_observer(
+                (LogLevel.info, LogLevel.debug), show_source=True,
                 format=options.logformat, trace=True))
-            logPublisher.addObserver(makeStandardErrObserver(
+            log_publisher.addObserver(make_stderr_observer(
                 (LogLevel.warn, LogLevel.error,
-                 LogLevel.critical), showSource=True, format=options.logformat))
+                 LogLevel.critical), show_source=True, format=options.logformat))
         else:
             assert False, "Shouldn't ever get here."
 
     # Actually start the logger.
-    startLogging()
+    start_logging()
 
     for line in BANNER.splitlines():
         log.info(click.style(("{:>40}").format(line), fg='yellow', bold=True))

--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -52,7 +52,7 @@ from crossbar.controller.process import NodeControllerSession
 from crossbar.controller.management import NodeManagementBridgeSession
 from crossbar.controller.management import NodeManagementSession
 
-from crossbar._logging import logPublisher, Logger
+from crossbar._logging import log_publisher, Logger
 
 __all__ = ('Node',)
 
@@ -65,7 +65,7 @@ class Node(object):
     A single Crossbar.io node runs exactly one instance of this class, hence
     this class can be considered a system singleton.
     """
-    log = Logger(observer=logPublisher)
+    log = Logger(observer=log_publisher)
 
     def __init__(self, reactor, options):
         """

--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -52,7 +52,7 @@ from crossbar.controller.process import NodeControllerSession
 from crossbar.controller.management import NodeManagementBridgeSession
 from crossbar.controller.management import NodeManagementSession
 
-from crossbar._logging import log_publisher, Logger
+from crossbar._logging import make_logger
 
 __all__ = ('Node',)
 
@@ -65,7 +65,7 @@ class Node(object):
     A single Crossbar.io node runs exactly one instance of this class, hence
     this class can be considered a system singleton.
     """
-    log = Logger(observer=log_publisher)
+    log = make_logger()
 
     def __init__(self, reactor, options):
         """

--- a/crossbar/controller/process.py
+++ b/crossbar/controller/process.py
@@ -67,7 +67,7 @@ from autobahn.twisted.websocket import WampWebSocketServerFactory
 
 from crossbar.platform import HAS_FSNOTIFY, DirWatcher
 
-from crossbar._logging import Logger, logPublisher
+from crossbar._logging import Logger, log_publisher
 
 
 __all__ = ('NodeControllerSession', 'create_process_env')
@@ -124,7 +124,7 @@ class NodeControllerSession(NativeProcessSession):
 
     This class exposes the node's management API.
     """
-    log = Logger(observer=logPublisher)
+    log = Logger(observer=log_publisher)
 
     def __init__(self, node):
         """
@@ -619,7 +619,7 @@ class NodeControllerSession(NativeProcessSession):
         This is called during reactor shutdown and ensures we wait for our
         subprocesses to shut down nicely.
         """
-        log = Logger(observer=logPublisher)
+        log = Logger(observer=log_publisher)
         try:
             log.info("sending TERM to subprocess {pid}", pid=worker.pid)
             worker.proto.transport.signalProcess('TERM')

--- a/crossbar/controller/process.py
+++ b/crossbar/controller/process.py
@@ -392,7 +392,8 @@ class NodeControllerSession(NativeProcessSession):
         :param options: The container worker options.
         :type options: dict
         """
-        self.log.debug("NodeControllerSession.start_container", id=id, options=options)
+        self.log.debug("NodeControllerSession.start_container(id = {id}, options = {options})",
+                       id=id, options=options)
 
         return self._start_native_worker('container', id, options, details=details)
 

--- a/crossbar/controller/process.py
+++ b/crossbar/controller/process.py
@@ -67,7 +67,7 @@ from autobahn.twisted.websocket import WampWebSocketServerFactory
 
 from crossbar.platform import HAS_FSNOTIFY, DirWatcher
 
-from crossbar._logging import Logger, log_publisher
+from crossbar._logging import make_logger
 
 
 __all__ = ('NodeControllerSession', 'create_process_env')
@@ -124,7 +124,7 @@ class NodeControllerSession(NativeProcessSession):
 
     This class exposes the node's management API.
     """
-    log = Logger(observer=log_publisher)
+    log = make_logger()
 
     def __init__(self, node):
         """
@@ -619,7 +619,7 @@ class NodeControllerSession(NativeProcessSession):
         This is called during reactor shutdown and ensures we wait for our
         subprocesses to shut down nicely.
         """
-        log = Logger(observer=log_publisher)
+        log = make_logger()
         try:
             log.info("sending TERM to subprocess {pid}", pid=worker.pid)
             worker.proto.transport.signalProcess('TERM')

--- a/crossbar/controller/processtypes.py
+++ b/crossbar/controller/processtypes.py
@@ -35,12 +35,10 @@ import json
 from datetime import datetime
 from collections import deque
 
-from twisted.python.compat import _PY3, unicode
+from twisted.python.compat import unicode
 from twisted.internet.defer import Deferred
 
 from crossbar._logging import Logger, logPublisher, LogLevel
-
-from autobahn.util import utcnow
 
 __all__ = ('RouterWorkerProcess',
            'ContainerWorkerProcess',
@@ -116,8 +114,6 @@ class WorkerProcess(object):
 
         while u"\x1e" in self._log_data:
 
-            from twisted.logger import eventFromJSON, formatEvent
-
             log, self._log_data = self._log_data.split(u"\x1e", 1)
 
             event = json.loads(log)
@@ -128,7 +124,6 @@ class WorkerProcess(object):
 
             if self._log_topic:
                 self._controller.publish(self._log_topic, event["text"])
-
 
     def getlog(self, limit=None):
         """

--- a/crossbar/controller/processtypes.py
+++ b/crossbar/controller/processtypes.py
@@ -38,7 +38,7 @@ from collections import deque
 
 from twisted.internet.defer import Deferred
 
-from crossbar._logging import Logger, log_publisher, LogLevel
+from crossbar._logging import make_logger, LogLevel
 
 __all__ = ('RouterWorkerProcess',
            'ContainerWorkerProcess',
@@ -49,7 +49,7 @@ class WorkerProcess(object):
     """
     Internal run-time representation of a worker process.
     """
-    _logger = Logger(observer=log_publisher)
+    _logger = make_logger()
 
     TYPE = 'worker'
     LOGNAME = 'Worker'

--- a/crossbar/controller/processtypes.py
+++ b/crossbar/controller/processtypes.py
@@ -30,12 +30,15 @@
 
 from __future__ import absolute_import
 
+import json
+
 from datetime import datetime
 from collections import deque
 
-from twisted.python import log
-from twisted.python.compat import _PY3
+from twisted.python.compat import _PY3, unicode
 from twisted.internet.defer import Deferred
+
+from crossbar._logging import Logger, logPublisher, LogLevel
 
 from autobahn.util import utcnow
 
@@ -44,11 +47,11 @@ __all__ = ('RouterWorkerProcess',
            'GuestWorkerProcess')
 
 
-class WorkerProcess:
-
+class WorkerProcess(object):
     """
     Internal run-time representation of a worker process.
     """
+    _logger = Logger(observer=logPublisher)
 
     TYPE = 'worker'
     LOGNAME = 'Worker'
@@ -92,6 +95,8 @@ class WorkerProcess:
         self._log_lineno = 0
         self._log_topic = 'crossbar.node.{}.worker.{}.on_log'.format(self._controller._node_id, self.id)
 
+        self._log_data = ""
+
         # A deferred that resolves when the worker is ready.
         self.ready = Deferred()
 
@@ -104,34 +109,26 @@ class WorkerProcess:
         """
         assert(childFD in self._log_fds)
 
-        if _PY3 and type(data) != str:
+        if type(data) != unicode:
             data = data.decode('utf8')
 
-        for msg in data.split('\n'):
-            msg = msg.strip()
-            if msg != "":
+        self._log_data += data
 
-                # log entry used for buffered worker log and/or worker log events
-                #
-                if self._log is not None or self._log_topic:
-                    log_entry = (self._log_lineno, utcnow(), msg)
+        while u"\x1e" in self._log_data:
 
-                # maintain buffered worker log
-                #
-                if self._log is not None:
-                    self._log_lineno += 1
-                    self._log.append(log_entry)
-                    if self._keeplog > 0 and len(self._log) > self._keeplog:
-                        self._log.popleft()
+            from twisted.logger import eventFromJSON, formatEvent
 
-                # publish worker log event
-                #
-                if self._log_topic:
-                    self._controller.publish(self._log_topic, log_entry)
+            log, self._log_data = self._log_data.split(u"\x1e", 1)
 
-                # log to controller
-                #
-                log.msg(msg, system="{:<10} {:>6}".format(self.LOGNAME, self.pid), override_system=True)
+            event = json.loads(log)
+            level = LogLevel.levelWithName(event["level"])
+            system = "{:<10} {:>6}".format(self.LOGNAME, self.pid)
+
+            self._logger.emit(level, event["text"], log_system=system)
+
+            if self._log_topic:
+                self._controller.publish(self._log_topic, event["text"])
+
 
     def getlog(self, limit=None):
         """

--- a/crossbar/controller/processtypes.py
+++ b/crossbar/controller/processtypes.py
@@ -38,7 +38,7 @@ from collections import deque
 from twisted.python.compat import unicode
 from twisted.internet.defer import Deferred
 
-from crossbar._logging import Logger, logPublisher, LogLevel
+from crossbar._logging import Logger, log_publisher, LogLevel
 
 __all__ = ('RouterWorkerProcess',
            'ContainerWorkerProcess',
@@ -49,7 +49,7 @@ class WorkerProcess(object):
     """
     Internal run-time representation of a worker process.
     """
-    _logger = Logger(observer=logPublisher)
+    _logger = Logger(observer=log_publisher)
 
     TYPE = 'worker'
     LOGNAME = 'Worker'

--- a/crossbar/controller/processtypes.py
+++ b/crossbar/controller/processtypes.py
@@ -30,12 +30,12 @@
 
 from __future__ import absolute_import
 
+import six
 import json
 
 from datetime import datetime
 from collections import deque
 
-from twisted.python.compat import unicode
 from twisted.internet.defer import Deferred
 
 from crossbar._logging import Logger, log_publisher, LogLevel
@@ -107,7 +107,7 @@ class WorkerProcess(object):
         """
         assert(childFD in self._log_fds)
 
-        if type(data) != unicode:
+        if type(data) != six.text_type:
             data = data.decode('utf8')
 
         self._log_data += data

--- a/crossbar/router/router.py
+++ b/crossbar/router/router.py
@@ -40,7 +40,7 @@ from crossbar.router.role import RouterRole, \
     RouterTrustedRole, RouterRoleStaticAuth, \
     RouterRoleDynamicAuth
 
-from crossbar._logging import Logger, logPublisher
+from crossbar._logging import Logger, log_publisher
 
 __all__ = (
     'RouterFactory',
@@ -51,7 +51,7 @@ class Router(object):
     """
     Crossbar.io core router class.
     """
-    log = Logger(observer=logPublisher)
+    log = Logger(observer=log_publisher)
 
     RESERVED_ROLES = ["trusted"]
     """
@@ -249,11 +249,11 @@ class Router(object):
                        kwargs=kwargs, cb_level="trace")
 
 
-class RouterFactory:
+class RouterFactory(object):
     """
     Crossbar.io core router factory.
     """
-    log = Logger(observer=logPublisher)
+    log = Logger(observer=log_publisher)
     router = Router
     """
     The router class this factory will create router instances from.

--- a/crossbar/router/router.py
+++ b/crossbar/router/router.py
@@ -30,7 +30,6 @@
 
 from __future__ import absolute_import
 
-from twisted.python import log
 from autobahn.wamp import message
 from autobahn.wamp.exception import ProtocolError
 
@@ -293,7 +292,7 @@ class RouterFactory:
         assert(router.realm in self._routers)
         del self._routers[router.realm]
         self.log.debug("Router destroyed for realm '{realm}'",
-                       realm=realm)
+                       realm=router.realm)
 
     def start_realm(self, realm):
         """

--- a/crossbar/router/router.py
+++ b/crossbar/router/router.py
@@ -40,7 +40,7 @@ from crossbar.router.role import RouterRole, \
     RouterTrustedRole, RouterRoleStaticAuth, \
     RouterRoleDynamicAuth
 
-from crossbar._logging import Logger, log_publisher
+from crossbar._logging import make_logger
 
 __all__ = (
     'RouterFactory',
@@ -51,7 +51,7 @@ class Router(object):
     """
     Crossbar.io core router class.
     """
-    log = Logger(observer=log_publisher)
+    log = make_logger()
 
     RESERVED_ROLES = ["trusted"]
     """
@@ -253,7 +253,7 @@ class RouterFactory(object):
     """
     Crossbar.io core router factory.
     """
-    log = Logger(observer=log_publisher)
+    log = make_logger()
     router = Router
     """
     The router class this factory will create router instances from.

--- a/crossbar/worker/process.py
+++ b/crossbar/worker/process.py
@@ -28,7 +28,7 @@
 #
 #####################################################################################
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 __all__ = ('run',)
 
@@ -105,13 +105,12 @@ def run():
 
     # make sure logging to something else than stdio is setup _first_
     #
-    from crossbar.twisted.processutil import BareFormatFileLogObserver
-    from crossbar._logging import Logger, globalLogBeginner, makeJSONObserver
+    from twisted.logger import globalLogBeginner
+    from crossbar._logging import Logger, makeJSONObserver
 
     log = Logger()
     _stderr = sys.stderr
     flo = makeJSONObserver(_stderr)
-
     globalLogBeginner.beginLoggingTo([flo])
 
     try:
@@ -137,7 +136,7 @@ def run():
 
     from twisted.python.reflect import qual
     log.info("Running under {python} using {reactor} reactor",
-             python=str(platform.python_implementation()),
+             python=platform.python_implementation(),
              reactor=qual(reactor.__class__).split('.')[-1])
 
     options.cbdir = os.path.abspath(options.cbdir)
@@ -197,7 +196,7 @@ def run():
 
         # now start reactor loop
         #
-        log.info("Entering event loop ..")
+        log.info("Entering event loop...")
         reactor.run()
 
     except Exception as e:

--- a/crossbar/worker/process.py
+++ b/crossbar/worker/process.py
@@ -106,11 +106,11 @@ def run():
     # make sure logging to something else than stdio is setup _first_
     #
     from twisted.logger import globalLogBeginner
-    from crossbar._logging import Logger, makeJSONObserver
+    from crossbar._logging import Logger, make_JSON_observer
 
     log = Logger()
     _stderr = sys.stderr
-    flo = makeJSONObserver(_stderr)
+    flo = make_JSON_observer(_stderr)
     globalLogBeginner.beginLoggingTo([flo])
 
     try:

--- a/crossbar/worker/process.py
+++ b/crossbar/worker/process.py
@@ -53,7 +53,7 @@ def run():
     # present.
 
     def ignore(sig, frame):
-        log.msg("Ignoring SIGINT in worker.")
+        log.debug("Ignoring SIGINT in worker.")
     signal.signal(signal.SIGINT, ignore)
 
     # create the top-level parser
@@ -105,15 +105,19 @@ def run():
 
     # make sure logging to something else than stdio is setup _first_
     #
-    from twisted.python import log
     from crossbar.twisted.processutil import BareFormatFileLogObserver
-    flo = BareFormatFileLogObserver(sys.stderr)
-    log.startLoggingWithObserver(flo.emit)
+    from crossbar._logging import Logger, globalLogBeginner, makeJSONObserver
+
+    log = Logger()
+    _stderr = sys.stderr
+    flo = makeJSONObserver(_stderr)
+
+    globalLogBeginner.beginLoggingTo([flo])
 
     try:
         import setproctitle
     except ImportError:
-        log.msg("Warning: could not set worker process title (setproctitle not installed)")
+        log.info("Warning: could not set worker process title (setproctitle not installed)")
     else:
         # set process title if requested to
         #
@@ -132,7 +136,9 @@ def run():
     reactor = install_reactor(options.reactor)
 
     from twisted.python.reflect import qual
-    log.msg("Running under {} using {} reactor".format(platform.python_implementation(), qual(reactor.__class__).split('.')[-1]))
+    log.info("Running under {python} using {reactor} reactor",
+             python=str(platform.python_implementation()),
+             reactor=qual(reactor.__class__).split('.')[-1])
 
     options.cbdir = os.path.abspath(options.cbdir)
     os.chdir(options.cbdir)
@@ -154,7 +160,7 @@ def run():
             try:
                 # this log message is unlikely to reach the controller (unless
                 # only stdin/stdout pipes were lost, but not stderr)
-                log.msg("Connection to node controller lost.")
+                log.warn("Connection to node controller lost.")
                 WampWebSocketServerProtocol.connectionLost(self, reason)
             except:
                 pass
@@ -191,11 +197,11 @@ def run():
 
         # now start reactor loop
         #
-        log.msg("Entering event loop ..")
+        log.info("Entering event loop ..")
         reactor.run()
 
     except Exception as e:
-        log.msg("Unhandled exception: {}".format(e))
+        log.info("Unhandled exception: {}".format(e))
         if reactor.running:
             reactor.addSystemEventTrigger('after', 'shutdown', os._exit, 1)
             reactor.stop()

--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,7 @@ setup(
     url='http://crossbar.io/',
     platforms=('Any'),
     install_requires=[
+        'click>=4.0',                 # BSD license
         'setuptools>=2.2',            # Python Software Foundation license
         'zope.interface>=3.6.0',      # Zope Public license
         'twisted>=15.2.1',            # MIT license


### PR DESCRIPTION
This implements:
- Loglevels being applied to log file output (Py2 only, can't write to log output on Py3)
- Worker containers communicating logs by JSON through stdout, to give richer and multi-line logs
- "trace" debug entries, usable by ``--loglevel=trace``, which outputs things like WAMP calls routed, for super debugging.

cc: @oberstet 