### PR TITLE
fix for fileupload

### DIFF
--- a/crossbar/twisted/resource.py
+++ b/crossbar/twisted/resource.py
@@ -123,7 +123,7 @@ class FileUploadResource(Resource):
         headers = request.getAllHeaders()
 
         # FIXME: this is a hack
-        origin = headers['host'].replace(".", "_").replace(":", "-").replace("/", "_")
+        origin = headers['host'] #.replace(".", "_").replace(":", "-").replace("/", "_")
 
         content = cgi.FieldStorage(
             fp=request.content,
@@ -139,6 +139,16 @@ class FileUploadResource(Resource):
         chunkSize = int(content[f['chunk_size']].value)
         chunkNumber = int(content[f['chunk_number']].value)
         fileContent = content[f['content']].value
+
+        fileId = filename
+
+        # Register upload right at the start to avoid overlapping upload conflicts
+        if fileId not in self._uploads:
+            self._uploads[fileId] = {'chunk_list':[], 'origin': origin}
+            chunk_is_first = True
+        else:
+            chunk_is_first = False            
+
 
         if self._debug:
             log.msg('file upload resource - started upload of file: file_id={}, file_name={}, total_size={}, total_chunks={}, chunk_size={}, chunk_number={}'.format(fileId, filename, totalSize, totalChunks, chunkSize, chunkNumber))
@@ -182,24 +192,28 @@ class FileUploadResource(Resource):
         # FIXME: this is a hack
         # check if another session is uploading this file already
         #
-        for e in os.listdir(self._tempDir):
-            common_id = e[0:e.find("#")]
-            existing_origin = e[e.find("#") + 1:]
-            if common_id == fileId + '_orig' and existing_origin != origin:
+        try:
+            upl = self._uploads[fileId]
+            if upl['origin'] != origin:
                 msg = "file upload resource - file being uploaded is already uploaded in a different session"
                 if self._debug:
                     log.msg(msg)
                 # 409 Conflict
                 request.setResponseCode(409, msg)
                 return msg
+        except Exception:
+            pass
 
         # TODO: check mime type
 
-        fileTempDir = os.path.join(self._tempDir, fileId + '_orig#' + origin)
+        fileTempDir = os.path.join(self._tempDir, fileId)
         chunkName = os.path.join(fileTempDir, 'chunk_' + str(chunkNumber))
 
-        if not (os.path.exists(os.path.join(self._dir, fileId)) or os.path.exists(fileTempDir)):
+        if chunk_is_first:
             # first chunk of file
+
+            # clean the temp dir once per file upload
+            self._remove_stale_uploads()
 
             # publish file upload start
             #
@@ -217,7 +231,9 @@ class FileUploadResource(Resource):
                 # only one chunk overall -> write file directly
                 finalFileName = os.path.join(self._dir, fileId)
                 with open(finalFileName, 'wb') as finalFile:
-                    finalFile.write(fileContent)
+                    finalFile.write(fileContent)                
+
+                self._uploads[fileId]['chunk_list'].append(chunkNumber)
 
                 if self._file_permissions:
                     perm = int(self._file_permissions, 8)
@@ -231,6 +247,8 @@ class FileUploadResource(Resource):
                             log.msg(e)
                         request.setResponseCode(500, msg)
                         return msg
+
+                self._uploads.pop(fileId, None)
 
                 # publish file upload progress to file_progress_URI
                 fileupload_publish({
@@ -247,6 +265,8 @@ class FileUploadResource(Resource):
                 os.makedirs(fileTempDir)
                 with open(chunkName, 'wb') as chunk:
                     chunk.write(fileContent)
+
+                self._uploads[fileId]['chunk_list'].append(chunkNumber)                
 
                 # publish file upload progress
                 #
@@ -265,6 +285,8 @@ class FileUploadResource(Resource):
             with open(chunkName, 'wb') as chunk:
                 chunk.write(fileContent)
 
+            self._uploads[fileId]['chunk_list'].append(chunkNumber)
+
             received = sum(os.path.getsize(os.path.join(fileTempDir, f)) for f in os.listdir(fileTempDir))
 
             fileupload_publish({
@@ -277,54 +299,68 @@ class FileUploadResource(Resource):
                                "progress": round(float(received) / float(totalSize), 3)
                                })
 
-            if chunkNumber == totalChunks:
-                # last chunk
-                with open(chunkName, 'wb') as chunk:
-                    chunk.write(fileContent)
 
-                # Now merge all files into one file and remove the temp files
-                with open(os.path.join(self._dir, fileId), 'wb') as finalFile:
-                    for tfileName in os.listdir(fileTempDir):
-                        with open(os.path.join(fileTempDir, tfileName), 'r') as tfile:
-                            finalFile.write(tfile.read())
+        # every chunk has to check if it is the last chunk written, except in a single chunk scenario
 
-                if self._file_permissions:
-                    perm = int(self._file_permissions, 8)
-                    try:
-                        os.chmod(finalFileName, perm)
-                    except Exception as e:
-                        self._remove_temp_dir(fileTempDir)
-                        msg = "file upload resource - could not change file permissions of uploaded file"
-                        if self._debug:
-                            log.msg(msg)
-                            log.msg(e)
-                        request.setResponseCode(500, msg)
-                        return msg
+        if totalChunks > 1 and len(self._uploads[fileId]['chunk_list']) == totalChunks:
+            # last chunk
+            log.msg('---- finish after chunk ----- ' + str(chunkNumber))
+            # Merge all files into one file and remove the temp files
+            # TODO: How to avoid the extra file IO ?
+            with open(os.path.join(self._dir, fileId), 'wb') as finalFile:
+                for tfileName in os.listdir(fileTempDir):
+                    with open(os.path.join(fileTempDir, tfileName), 'r') as tfile:
+                        finalFile.write(tfile.read())
 
-                # publish file upload progress to file_progress_URI
+            if self._file_permissions:
+                perm = int(self._file_permissions, 8)
+                try:
+                    os.chmod(finalFileName, perm)
+                except Exception as e:
+                    self._remove_temp_dir(fileTempDir)
+                    msg = "file upload resource - could not change file permissions of uploaded file"
+                    if self._debug:
+                        log.msg(msg)
+                        log.msg(e)
+                    request.setResponseCode(500, msg)
+                    return msg
 
-                fileupload_publish({
-                                   "id": fileId,
-                                   "chunk": chunkNumber,
-                                   "name": filename,
-                                   "total": totalSize,
-                                   "remaining": 0,
-                                   "status": "finished",
-                                   "progress": 1.
-                                   })
+            # publish file upload progress to file_progress_URI
 
-                # remove the file temp folder
-                self._remove_temp_dir(fileTempDir)
+            fileupload_publish({
+                               "id": fileId,
+                               "chunk": chunkNumber,
+                               "name": filename,
+                               "total": totalSize,
+                               "remaining": 0,
+                               "status": "finished",
+                               "progress": 1.
+                               })
+
+            # remove the file temp folder
+            self._remove_temp_dir(fileTempDir)
+
+            self._uploads.pop(fileId, None)
 
         request.setResponseCode(200)
         return ''
 
-    def _remove_temp_dir(self, fileTempDir):
-        return
+    def _remove_temp_dir(self, fileTempDir):        
         for tfileName in os.listdir(fileTempDir):
             os.remove(os.path.join(fileTempDir, tfileName))
 
         os.rmdir(fileTempDir)
+
+    # this only works if there is a temp folder exclusive for crossbar file uploads
+    # if the system temp folder is used then crossbar creates a "crossbar-uploads" there and
+    # uses that as the temp folder for uploads
+    # If you don't clean up regularly an attacker could fill up the OS file system 
+    def _remove_stale_uploads(self):
+        for _dir in os.listdir(self._tempDir):
+            fileTempDir = os.path.join(self._tempDir,_dir)
+            if os.path.isdir(fileTempDir) and _dir not in self._uploads:
+                self._remove_temp_dir(fileTempDir)
+
 
     def render_GET(self, request):
         """
@@ -344,12 +380,14 @@ class FileUploadResource(Resource):
         file_id = request.args[self._form_fields['file_id']][0]
         chunk_number = request.args[self._form_fields['chunk_number']][0]
         origin = request.getHeader('host')[0]
+
         origin = origin.replace(".", "_").replace(":", "-").replace("/", "_")
 
-        fileTempDir = os.path.join(self._tempDir, file_id + '_orig#' + origin)
+        fileTempDir = os.path.join(self._tempDir, file_id)
         chunkName = os.path.join(fileTempDir, 'chunk_' + str(chunk_number))
 
-        if (os.path.exists(chunkName) or os.path.exists(os.path.join(self._dir, file_id))):
+        if chunkNumber in self._uploads[fileId]['chunk_list'] or os.path.exists(os.path.join(self._dir, file_id)):
+        # if (os.path.exists(chunkName) or os.path.exists(os.path.join(self._dir, file_id))):
             msg = "chunk of file already uploaded"
             request.setResponseCode(200, msg)
             return msg
@@ -357,7 +395,6 @@ class FileUploadResource(Resource):
             msg = "chunk of file not yet uploaded"
             request.setResponseCode(404, msg)
             return msg
-
 
 class Resource404(Resource):
 

--- a/crossbar/worker/router.py
+++ b/crossbar/worker/router.py
@@ -1073,6 +1073,10 @@ class RouterWorkerSession(NativeWorkerSession):
                 temp_directory = temp_directory.encode('ascii', 'ignore')  # http://stackoverflow.com/a/20433918/884770
             else:
                 temp_directory = os.path.abspath(tempfile.gettempdir())
+                temp_directory = os.path.join(temp_directory,'crossbar-uploads')
+                if not os.path.exists(temp_directory):
+                    os.makedirs(temp_directory)
+
             if not os.path.isdir(temp_directory):
                 emsg = "configured temp directory '{}' in file upload resource isn't a directory".format(temp_directory)
                 log.msg(emsg)

--- a/crossbar/worker/router.py
+++ b/crossbar/worker/router.py
@@ -1073,7 +1073,7 @@ class RouterWorkerSession(NativeWorkerSession):
                 temp_directory = temp_directory.encode('ascii', 'ignore')  # http://stackoverflow.com/a/20433918/884770
             else:
                 temp_directory = os.path.abspath(tempfile.gettempdir())
-                temp_directory = os.path.join(temp_directory,'crossbar-uploads')
+                temp_directory = os.path.join(temp_directory, 'crossbar-uploads')
                 if not os.path.exists(temp_directory):
                     os.makedirs(temp_directory)
 


### PR DESCRIPTION
fix for write after last chunk
optional temp folder with auto clean

Regarding the file_id as hash I would still propose to not autocompute a sha256 hash or something. The normal id in a folder is the filename. In fact I would remove the file_id altogether and only have the file_name set by the client. If the client whiches a hash it is up to him.
I see no security issue with this.
If you agree I would remove the file_id option.