### PR TITLE
Logging fun III

### DIFF
--- a/crossbar/_logging.py
+++ b/crossbar/_logging.py
@@ -31,9 +31,11 @@
 from __future__ import absolute_import, division, print_function
 
 import os
-import six
 import sys
 import json
+
+
+from functools import partial
 
 from zope.interface import provider
 
@@ -102,7 +104,7 @@ def make_stdout_observer(levels=(LogLevel.info, LogLevel.debug),
     @provider(ILogObserver)
     def StandardOutObserver(event):
 
-        if not trace and event.get("cb_trace") == True:
+        if not trace and event.get("cb_trace") is True:
             # Don't output 'trace' output
             return
 
@@ -188,7 +190,6 @@ def make_JSON_observer(outFile):
     Make an observer which writes JSON to C{outfile}.
     """
     def _make_json(event):
-        #print(event, file=outFile)
 
         return json.dumps({
             "text": escape_formatting(formatEvent(event)),
@@ -256,7 +257,6 @@ REAL_LEVELS = ["critical", "error", "warn", "info", "debug"]
 # Sanity check
 assert set(REAL_LEVELS).issubset(set(POSSIBLE_LEVELS))
 
-from functools import partial
 
 class CrossbarLogger(object):
     """
@@ -302,7 +302,7 @@ class CrossbarLogger(object):
 
     @log_level.setter
     def log_level(self, level):
-        if not level in POSSIBLE_LEVELS:
+        if level not in POSSIBLE_LEVELS:
             raise ValueError(
                 "{level} not in {levels}".format(level=level,
                                                  levels=POSSIBLE_LEVELS))

--- a/crossbar/controller/cli.py
+++ b/crossbar/controller/cli.py
@@ -416,7 +416,7 @@ def run_command_start(options):
     # start Twisted logging
     #
     from crossbar._logging import log_publisher, make_logger
-    from crossbar._logging import LogLevel, start_logging, set_global_log_level
+    from crossbar._logging import start_logging, set_global_log_level
 
     set_global_log_level(options.loglevel)
 

--- a/crossbar/controller/cli.py
+++ b/crossbar/controller/cli.py
@@ -47,7 +47,6 @@ from autobahn.util import utcnow
 from autobahn.twisted.choosereactor import install_reactor
 
 import crossbar
-from crossbar._logging import log, log_publisher
 
 try:
     import psutil
@@ -416,7 +415,12 @@ def run_command_start(options):
 
     # start Twisted logging
     #
-    from crossbar._logging import LogLevel, start_logging
+    from crossbar._logging import log_publisher, make_logger
+    from crossbar._logging import LogLevel, start_logging, set_global_log_level
+
+    set_global_log_level(options.loglevel)
+
+    log = make_logger()
 
     if options.logdir:
         # We want to log to a file
@@ -434,38 +438,25 @@ def run_command_start(options):
             pass
         elif options.loglevel == "error":
             # Error: Only print errors to stderr.
-            log_publisher.addObserver(make_stderr_observer(
-                (LogLevel.error, LogLevel.critical),
-                show_source=False, format=options.logformat))
+            log_publisher.addObserver(make_stdout_observer(show_source=False, format=options.logformat))
+            log_publisher.addObserver(make_stderr_observer(show_source=False, format=options.logformat))
         elif options.loglevel == "warn":
             # Print warnings+ to stderr.
-            log_publisher.addObserver(make_stderr_observer(
-                (LogLevel.warn, LogLevel.error,
-                 LogLevel.critical), show_source=False, format=options.logformat))
+            log_publisher.addObserver(make_stdout_observer(show_source=False, format=options.logformat))
+            log_publisher.addObserver(make_stderr_observer(show_source=False, format=options.logformat))
         elif options.loglevel == "info":
             # Print info to stdout, warn+ to stderr
-            log_publisher.addObserver(make_stdout_observer(
-                (LogLevel.info,), show_source=False, format=options.logformat))
-            log_publisher.addObserver(make_stderr_observer(
-                (LogLevel.warn, LogLevel.error,
-                 LogLevel.critical), show_source=False, format=options.logformat))
+            log_publisher.addObserver(make_stdout_observer(show_source=False, format=options.logformat))
+            log_publisher.addObserver(make_stderr_observer(show_source=False, format=options.logformat))
         elif options.loglevel == "debug":
             # Print debug+info to stdout, warn+ to stderr, with the class
             # source
-            log_publisher.addObserver(make_stdout_observer(
-                (LogLevel.info, LogLevel.debug), show_source=True,
-                format=options.logformat))
-            log_publisher.addObserver(make_stderr_observer(
-                (LogLevel.warn, LogLevel.error,
-                 LogLevel.critical), show_source=True, format=options.logformat))
+            log_publisher.addObserver(make_stdout_observer(show_source=True, format=options.logformat))
+            log_publisher.addObserver(make_stderr_observer(show_source=True, format=options.logformat))
         elif options.loglevel == "trace":
             # Print trace+, with the class source
-            log_publisher.addObserver(make_stdout_observer(
-                (LogLevel.info, LogLevel.debug), show_source=True,
-                format=options.logformat, trace=True))
-            log_publisher.addObserver(make_stderr_observer(
-                (LogLevel.warn, LogLevel.error,
-                 LogLevel.critical), show_source=True, format=options.logformat))
+            log_publisher.addObserver(make_stdout_observer(show_source=True, format=options.logformat, trace=True))
+            log_publisher.addObserver(make_stderr_observer(show_source=True, format=options.logformat))
         else:
             assert False, "Shouldn't ever get here."
 

--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -65,8 +65,6 @@ class Node(object):
     A single Crossbar.io node runs exactly one instance of this class, hence
     this class can be considered a system singleton.
     """
-    log = make_logger()
-
     def __init__(self, reactor, options):
         """
         Ctor.
@@ -76,6 +74,8 @@ class Node(object):
         :param options: Options from command line.
         :type options: obj
         """
+        self.log = make_logger()
+
         self.options = options
         # the reactor under which we run
         self._reactor = reactor

--- a/crossbar/controller/process.py
+++ b/crossbar/controller/process.py
@@ -67,7 +67,7 @@ from autobahn.twisted.websocket import WampWebSocketServerFactory
 
 from crossbar.platform import HAS_FSNOTIFY, DirWatcher
 
-from crossbar._logging import make_logger
+from crossbar._logging import make_logger, _loglevel
 
 
 __all__ = ('NodeControllerSession', 'create_process_env')
@@ -465,6 +465,7 @@ class NodeControllerSession(NativeProcessSession):
         args.extend(["--worker", str(id)])
         args.extend(["--realm", self._realm])
         args.extend(["--type", wtype])
+        args.extend(["--loglevel", _loglevel])
 
         # allow override worker process title from options
         #

--- a/crossbar/controller/processtypes.py
+++ b/crossbar/controller/processtypes.py
@@ -151,11 +151,13 @@ class WorkerProcess(object):
                     # We tried!
                     event = {"level": u"warn",
                              "text": u"INVALID JSON: {}".format(escape_formatting(log))}
-                event_text = event["text"]
-                level = LogLevel.levelWithName(event["level"])
+                event_text = event.pop("text")
+                event_namespace = event.pop("namespace", None)
+                level = LogLevel.levelWithName(event.pop("level"))
 
-                self._logger.emit(level, event_text, log_system=system)
-                self._log_entries.append(event_text)
+                self._logger.emit(level, event_text, log_system=system,
+                                  cb_namespace=event_namespace, **event)
+                self._log_entries.append(event)
 
                 if self._log_topic:
                     self._controller.publish(self._log_topic, event_text)

--- a/crossbar/router/protocol.py
+++ b/crossbar/router/protocol.py
@@ -40,7 +40,9 @@ from autobahn.websocket.compress import *  # noqa
 import crossbar
 
 from crossbar.router.cookiestore import CookieStore, PersistentCookieStore
-from crossbar._logging import make_logger, log
+from crossbar._logging import make_logger
+
+log = make_logger()
 
 __all__ = (
     'WampWebSocketServerFactory',

--- a/crossbar/router/router.py
+++ b/crossbar/router/router.py
@@ -139,7 +139,7 @@ class Router(object):
         """
         Implements :func:`autobahn.wamp.interfaces.IRouter.process`
         """
-        self.log.debug("Router.process: {msg}", msg=msg, cb_level="trace")
+        self.log.trace("Router.process: {msg}", msg=msg)
 
         # Broker
         #

--- a/crossbar/test/test_logger.py
+++ b/crossbar/test/test_logger.py
@@ -1,0 +1,33 @@
+from twisted.trial.unittest import TestCase
+
+from mock import Mock
+
+from crossbar._logging import make_logger, CrossbarLogger
+
+
+class CrossbarLoggerTests(TestCase):
+
+    def test_disallow_direct_instantiation(self):
+        """
+        The developer shouldn't call CrossbarLogger directly, but use
+        make_logger.
+        """
+        with self.assertRaises(AssertionError):
+            CrossbarLogger("warn")
+
+    def test_set_level(self):
+        """
+        The log level needs to be one of the accepted log levels.
+        """
+        with self.assertRaises(ValueError):
+            make_logger("not a suitable level")
+
+    def test_logger_emits(self):
+        """
+        A Logger emits messages through to its child logger.
+        """
+        logger = make_logger("info", logger=Mock)
+
+        logger.error("Foo happened!!!")
+
+        logger.logger.error.assert_called_with("Foo happened!!!")

--- a/crossbar/test/test_logger.py
+++ b/crossbar/test/test_logger.py
@@ -7,6 +7,7 @@ from crossbar._logging import make_logger, CrossbarLogger
 
 _log = make_logger("info", logger=Mock)
 
+
 def _makelog():
     log = make_logger("info", logger=Mock)
     return log

--- a/crossbar/test/test_logger.py
+++ b/crossbar/test/test_logger.py
@@ -5,6 +5,22 @@ from mock import Mock
 from crossbar._logging import make_logger, CrossbarLogger
 
 
+_log = make_logger("info", logger=Mock)
+
+def _makelog():
+    log = make_logger("info", logger=Mock)
+    return log
+
+
+class _InitLoggerMaker(object):
+    def __init__(self):
+        self.log = make_logger("info", logger=Mock)
+
+
+class _ClassDefLoggerMaker(object):
+    log = make_logger("info", logger=Mock)
+
+
 class CrossbarLoggerTests(TestCase):
 
     def test_disallow_direct_instantiation(self):
@@ -26,7 +42,7 @@ class CrossbarLoggerTests(TestCase):
         """
         A Logger emits messages through to its child logger.
         """
-        log = make_logger("info", logger=Mock)
+        log = make_logger("trace", logger=Mock)
 
         log.error("Foo happened!!!")
         log.logger.error.assert_called_with("Foo happened!!!")
@@ -34,6 +50,9 @@ class CrossbarLoggerTests(TestCase):
         log.warn("Stuff", foo="bar")
         log.logger.warn.assert_called_with("Stuff", foo="bar")
 
+        log.trace("Stuff that's trace", foo="bar")
+        log.logger.debug.assert_called_with("Stuff that's trace",
+                                            foo="bar", cb_trace=1)
 
     def test_logger_emits_if_higher(self):
         """
@@ -41,3 +60,51 @@ class CrossbarLoggerTests(TestCase):
         messages of a lower severity.
         """
         log = make_logger("info", logger=Mock)
+
+        log.error("Error!")
+        log.debug("Debug!")
+        log.info("Info!")
+        log.trace("Trace!")
+
+        self.assertEqual(log.logger.critical.call_count, 0)
+        self.assertEqual(log.logger.error.call_count, 1)
+        self.assertEqual(log.logger.warn.call_count, 0)
+        self.assertEqual(log.logger.info.call_count, 1)
+        self.assertEqual(log.logger.debug.call_count, 0)
+        self.assertEqual(log.logger.trace.call_count, 0)
+
+    def test_logger_namespace_init(self):
+        """
+        The namespace of the Logger is of the creator when using __init__.
+        """
+        lm = _InitLoggerMaker()
+
+        self.assertEqual(lm.log.logger.namespace,
+                         "crossbar.test.test_logger._InitLoggerMaker")
+
+    def test_logger_namespace_classdef(self):
+        """
+        The namespace of the Logger is of the creator when using it in a class
+        definition.
+        """
+        lm = _ClassDefLoggerMaker()
+
+        self.assertEqual(lm.log.logger.namespace,
+                         "crossbar.test.test_logger._ClassDefLoggerMaker")
+
+    def test_logger_namespace_moduledef(self):
+        """
+        The namespace of the Logger is the creator module when it is made in a
+        module.
+        """
+        self.assertEqual(_log.logger.namespace,
+                         "crossbar.test.test_logger")
+
+    def test_logger_namespace_function(self):
+        """
+        The namespace of the Logger is the creator function when it is made in
+        a function outside of a class.
+        """
+        log = _makelog()
+        self.assertEqual(log.logger.namespace,
+                         "crossbar.test.test_logger._makelog")

--- a/crossbar/test/test_logger.py
+++ b/crossbar/test/test_logger.py
@@ -26,8 +26,18 @@ class CrossbarLoggerTests(TestCase):
         """
         A Logger emits messages through to its child logger.
         """
-        logger = make_logger("info", logger=Mock)
+        log = make_logger("info", logger=Mock)
 
-        logger.error("Foo happened!!!")
+        log.error("Foo happened!!!")
+        log.logger.error.assert_called_with("Foo happened!!!")
 
-        logger.logger.error.assert_called_with("Foo happened!!!")
+        log.warn("Stuff", foo="bar")
+        log.logger.warn.assert_called_with("Stuff", foo="bar")
+
+
+    def test_logger_emits_if_higher(self):
+        """
+        A Logger that has a log level of a higher severity will not emit
+        messages of a lower severity.
+        """
+        log = make_logger("info", logger=Mock)

--- a/crossbar/worker/process.py
+++ b/crossbar/worker/process.py
@@ -71,6 +71,12 @@ def run():
                         choices=['select', 'poll', 'epoll', 'kqueue', 'iocp'],
                         help='Explicit Twisted reactor selection (optional).')
 
+    parser.add_argument('--loglevel',
+                        default="info",
+                        choices=['none', 'error', 'warn', 'info', 'debug', 'trace'],
+                        help='Initial log level.')
+
+
     parser.add_argument('-c',
                         '--cbdir',
                         type=str,
@@ -107,6 +113,10 @@ def run():
     #
     from crossbar._logging import make_JSON_observer, cb_logging_aware, _stderr
     from crossbar._logging import make_logger, log_publisher, start_logging
+    from crossbar._logging import set_global_log_level
+
+    # Set the global log level
+    set_global_log_level(options.loglevel)
 
     log = make_logger()
 

--- a/crossbar/worker/process.py
+++ b/crossbar/worker/process.py
@@ -76,7 +76,6 @@ def run():
                         choices=['none', 'error', 'warn', 'info', 'debug', 'trace'],
                         help='Initial log level.')
 
-
     parser.add_argument('-c',
                         '--cbdir',
                         type=str,

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,8 @@ extras_require_accelerate = [
 
 # Extra requirements which enhance the development experience
 extras_require_dev = [
-    "colorama>=0.3.3"       # BSD license
+    "colorama>=0.3.3",       # BSD license
+    "mock>=1.0.1",           # BSD license
 ]
 
 extras_require_all = extras_require_system + extras_require_db + \


### PR DESCRIPTION
This has further improvements to the logger, including:

- Logger-set, rather than observer set log verbosity levels
- Structured logging stuff going through the Controller<->Worker pipe
- The log-level of the worker being set by a CLI switch (need dynamic setting of that later)
- The `loglevel` option now matches the functions, except for `none`.