### PR TITLE
config.extra is supposed to be a dict

### DIFF
--- a/crossbar/common/process.py
+++ b/crossbar/common/process.py
@@ -127,10 +127,10 @@ class NativeProcessSession(ApplicationSession):
         """
         """
         if not hasattr(self, 'cbdir'):
-            self.cbdir = self.config.extra.cbdir
+            self.cbdir = self.config.extra['cbdir']
 
         if not hasattr(self, '_uri_prefix'):
-            self._uri_prefix = 'crossbar.node.{}'.format(self.config.extra.node)
+            self._uri_prefix = 'crossbar.node.{}'.format(self.config.extra['node'])
 
         self._started = datetime.utcnow()
 

--- a/crossbar/controller/process.py
+++ b/crossbar/controller/process.py
@@ -153,7 +153,7 @@ class NodeControllerSession(NativeProcessSession):
 
         self.log.debug("Connected to node management router")
 
-        # self._uri_prefix = u'crossbar.node.{}'.format(self.config.extra.node)
+        # self._uri_prefix = u'crossbar.node.{}'.format(self.config.extra['node'])
         self._uri_prefix = u'crossbar.node.{}'.format(self._node_id)
 
         NativeProcessSession.onConnect(self, False)

--- a/crossbar/worker/container.py
+++ b/crossbar/worker/container.py
@@ -279,7 +279,7 @@ class ContainerWorkerSession(NativeWorkerSession):
         # 3) create and connect client endpoint
         #
         endpoint = create_connecting_endpoint_from_config(transport_config['endpoint'],
-                                                          self.config.extra.cbdir,
+                                                          self.config.extra['cbdir'],
                                                           reactor)
 
         # now connect the client

--- a/crossbar/worker/process.py
+++ b/crossbar/worker/process.py
@@ -192,7 +192,7 @@ def run():
         from autobahn.twisted.wamp import ApplicationSessionFactory
         from autobahn.wamp.types import ComponentConfig
 
-        session_config = ComponentConfig(realm=options.realm, extra=options)
+        session_config = ComponentConfig(realm=options.realm, extra=vars(options))
         session_factory = ApplicationSessionFactory(session_config)
         session_factory.session = WORKER_TYPE_TO_CLASS[options.type]
 

--- a/crossbar/worker/router.py
+++ b/crossbar/worker/router.py
@@ -526,7 +526,7 @@ class RouterWorkerSession(NativeWorkerSession):
 
         if id in self._components:
             if self.debug:
-                log.msg("Worker {}: stopping component {}".format(self.config.extra.worker, id))
+                log.msg("Worker {}: stopping component {}".format(self.config.extra['worker'], id))
 
             try:
                 # self._components[id].disconnect()
@@ -595,7 +595,7 @@ class RouterWorkerSession(NativeWorkerSession):
         #
         elif config['type'] == 'websocket':
 
-            transport_factory = WampWebSocketServerFactory(self._router_session_factory, self.config.extra.cbdir, config, self._templates)
+            transport_factory = WampWebSocketServerFactory(self._router_session_factory, self.config.extra['cbdir'], config, self._templates)
             transport_factory.noisy = False
 
         # Flash-policy file server pseudo transport
@@ -635,7 +635,7 @@ class RouterWorkerSession(NativeWorkerSession):
 
                 if 'directory' in root_config:
 
-                    root_dir = os.path.abspath(os.path.join(self.config.extra.cbdir, root_config['directory']))
+                    root_dir = os.path.abspath(os.path.join(self.config.extra['cbdir'], root_config['directory']))
 
                 elif 'package' in root_config:
 
@@ -833,7 +833,7 @@ class RouterWorkerSession(NativeWorkerSession):
 
         # create transport endpoint / listening port from transport factory
         #
-        d = create_listening_port_from_config(config['endpoint'], transport_factory, self.config.extra.cbdir, reactor)
+        d = create_listening_port_from_config(config['endpoint'], transport_factory, self.config.extra['cbdir'], reactor)
 
         def ok(port):
             self.transports[id] = RouterTransport(id, config, transport_factory, port)
@@ -881,7 +881,7 @@ class RouterWorkerSession(NativeWorkerSession):
         #
         if path_config['type'] == 'websocket':
 
-            ws_factory = WampWebSocketServerFactory(self._router_session_factory, self.config.extra.cbdir, path_config, self._templates)
+            ws_factory = WampWebSocketServerFactory(self._router_session_factory, self.config.extra['cbdir'], path_config, self._templates)
 
             # FIXME: Site.start/stopFactory should start/stop factories wrapped as Resources
             ws_factory.startFactory()
@@ -896,7 +896,7 @@ class RouterWorkerSession(NativeWorkerSession):
 
             if 'directory' in path_config:
 
-                static_dir = os.path.abspath(os.path.join(self.config.extra.cbdir, path_config['directory']))
+                static_dir = os.path.abspath(os.path.join(self.config.extra['cbdir'], path_config['directory']))
 
             elif 'package' in path_config:
 
@@ -1001,7 +1001,7 @@ class RouterWorkerSession(NativeWorkerSession):
         elif path_config['type'] == 'cgi':
 
             cgi_processor = path_config['processor']
-            cgi_directory = os.path.abspath(os.path.join(self.config.extra.cbdir, path_config['directory']))
+            cgi_directory = os.path.abspath(os.path.join(self.config.extra['cbdir'], path_config['directory']))
             cgi_directory = cgi_directory.encode('ascii', 'ignore')  # http://stackoverflow.com/a/20433918/884770
 
             return CgiDirectory(cgi_directory, cgi_processor, Resource404(self._templates, cgi_directory))
@@ -1062,7 +1062,7 @@ class RouterWorkerSession(NativeWorkerSession):
         #
         elif path_config['type'] == 'upload':
 
-            upload_directory = os.path.abspath(os.path.join(self.config.extra.cbdir, path_config['directory']))
+            upload_directory = os.path.abspath(os.path.join(self.config.extra['cbdir'], path_config['directory']))
             upload_directory = upload_directory.encode('ascii', 'ignore')  # http://stackoverflow.com/a/20433918/884770
             if not os.path.isdir(upload_directory):
                 emsg = "configured upload directory '{}' in file upload resource isn't a directory".format(upload_directory)
@@ -1070,7 +1070,7 @@ class RouterWorkerSession(NativeWorkerSession):
                 raise ApplicationError("crossbar.error.invalid_configuration", emsg)
 
             if 'temp_directory' in path_config:
-                temp_directory = os.path.abspath(os.path.join(self.config.extra.cbdir, path_config['temp_directory']))
+                temp_directory = os.path.abspath(os.path.join(self.config.extra['cbdir'], path_config['temp_directory']))
                 temp_directory = temp_directory.encode('ascii', 'ignore')  # http://stackoverflow.com/a/20433918/884770
             else:
                 temp_directory = os.path.abspath(tempfile.gettempdir())

--- a/crossbar/worker/worker.py
+++ b/crossbar/worker/worker.py
@@ -65,7 +65,7 @@ class NativeWorkerSession(NativeProcessSession):
         """
         Called when the worker has connected to the node's management router.
         """
-        self._uri_prefix = 'crossbar.node.{}.worker.{}'.format(self.config.extra.node, self.config.extra.worker)
+        self._uri_prefix = 'crossbar.node.{}.worker.{}'.format(self.config.extra['node'], self.config.extra['worker'])
 
         NativeProcessSession.onConnect(self, False)
 
@@ -108,8 +108,8 @@ class NativeWorkerSession(NativeProcessSession):
         # will either be sequenced from the local node configuration file or remotely
         # from a management service
         #
-        pub = yield self.publish('crossbar.node.{}.on_worker_ready'.format(self.config.extra.node),
-                                 {'type': self.WORKER_TYPE, 'id': self.config.extra.worker, 'pid': os.getpid()},
+        pub = yield self.publish('crossbar.node.{}.on_worker_ready'.format(self.config.extra['node']),
+                                 {'type': self.WORKER_TYPE, 'id': self.config.extra['worker'], 'pid': os.getpid()},
                                  options=PublishOptions(acknowledge=True))
 
         if self.debug:
@@ -167,7 +167,7 @@ class NativeWorkerSession(NativeProcessSession):
 
             # publish info to all but the caller ..
             #
-            cpu_affinity_set_topic = 'crossbar.node.{}.worker.{}.on_cpu_affinity_set'.format(self.config.extra.node, self.config.extra.worker)
+            cpu_affinity_set_topic = 'crossbar.node.{}.worker.{}.on_cpu_affinity_set'.format(self.config.extra['node'], self.config.extra['worker'])
             cpu_affinity_set_info = {
                 'affinity': new_affinity,
                 'who': details.caller
@@ -207,7 +207,7 @@ class NativeWorkerSession(NativeProcessSession):
         for p in paths:
             # transform all paths (relative to cbdir) into absolute paths
             #
-            path_to_add = os.path.abspath(os.path.join(self.config.extra.cbdir, p))
+            path_to_add = os.path.abspath(os.path.join(self.config.extra['cbdir'], p))
             if os.path.isdir(path_to_add):
                 paths_added.append({'requested': p, 'resolved': path_to_add})
             else:
@@ -235,7 +235,7 @@ class NativeWorkerSession(NativeProcessSession):
 
         # publish event "on_pythonpath_add" to all but the caller
         #
-        topic = 'crossbar.node.{}.worker.{}.on_pythonpath_add'.format(self.config.extra.node, self.config.extra.worker)
+        topic = 'crossbar.node.{}.worker.{}.on_pythonpath_add'.format(self.config.extra['node'], self.config.extra['worker'])
         res = {
             'paths': sys.path,
             'paths_added': paths_added,


### PR DESCRIPTION
Sometimes it is an `argparse.Namespace()` in crossbar usage, but Autobahn
docs say it should be a dict()