### PR TITLE
Improve the file logging

### DIFF
--- a/crossbar/_logging.py
+++ b/crossbar/_logging.py
@@ -261,7 +261,7 @@ def make_JSON_observer(outFile):
     return _make_json
 
 
-def make_legacy_daily_logfile_observer(path, logoutputlevel):
+def make_legacy_daily_logfile_observer(path):
     """
     Make a L{DefaultSystemFileLogObserver}.
     """
@@ -276,37 +276,7 @@ def make_legacy_daily_logfile_observer(path, logoutputlevel):
                                      system="{:<10} {:>6}".format(
                                          "Controller", os.getpid())).emit)
 
-    def _log(event):
-
-        level = event["log_level"]
-
-        if logoutputlevel == "none":
-            return
-        elif logoutputlevel == "quiet":
-            # Quiet: Only print warnings and errors to stderr.
-            if level not in (LogLevel.warn, LogLevel.error, LogLevel.critical):
-                return
-        elif logoutputlevel == "standard":
-            # Standard: For users of Crossbar
-            if level not in (LogLevel.info, LogLevel.warn, LogLevel.error,
-                             LogLevel.critical):
-                return
-        elif logoutputlevel == "verbose":
-            # Verbose: for developers
-            # Adds the class source.
-            if event.get("cb_level") == "trace":
-                return
-        elif logoutputlevel == "trace":
-            # Verbose: for developers
-            # Adds "trace" output
-            pass
-        else:
-            assert False, "Shouldn't ever get here."
-
-        # Forward the event
-        flo(event)
-
-    return _log
+    return flo
 
 
 class CrossbarLogger(object):

--- a/crossbar/controller/cli.py
+++ b/crossbar/controller/cli.py
@@ -425,12 +425,17 @@ def run_command_start(options):
 
     log = make_logger()
 
-    if options.logdir:
+    if options.logtofile:
         # We want to log to a file
         from crossbar._logging import make_legacy_daily_logfile_observer
 
+        if not options.logdir:
+            logdir = options.cbdir
+        else:
+            logdir = options.logdir
+
         log_publisher.addObserver(
-            make_legacy_daily_logfile_observer(options.logdir, options.loglevel))
+            make_legacy_daily_logfile_observer(logdir))
     else:
         # We want to log to stdout/stderr.
         from crossbar._logging import make_stdout_observer
@@ -439,15 +444,7 @@ def run_command_start(options):
         if options.loglevel == "none":
             # Do no logging!
             pass
-        elif options.loglevel == "error":
-            # Error: Only print errors to stderr.
-            log_publisher.addObserver(make_stdout_observer(show_source=False, format=options.logformat))
-            log_publisher.addObserver(make_stderr_observer(show_source=False, format=options.logformat))
-        elif options.loglevel == "warn":
-            # Print warnings+ to stderr.
-            log_publisher.addObserver(make_stdout_observer(show_source=False, format=options.logformat))
-            log_publisher.addObserver(make_stderr_observer(show_source=False, format=options.logformat))
-        elif options.loglevel == "info":
+        elif options.loglevel in ["error", "warn", "info"]:
             # Print info to stdout, warn+ to stderr
             log_publisher.addObserver(make_stdout_observer(show_source=False, format=options.logformat))
             log_publisher.addObserver(make_stderr_observer(show_source=False, format=options.logformat))
@@ -639,7 +636,11 @@ def run(prog=None, args=None):
     parser_start.add_argument('--logdir',
                               type=str,
                               default=None,
-                              help="Crossbar.io log directory (default: <Crossbar Node Directory>/log)")
+                              help="Crossbar.io log directory (default: <Crossbar Node Directory>/)")
+
+    parser_start.add_argument('--logtofile',
+                              action='store_true',
+                              help="Whether or not to log to file")
 
     parser_start.add_argument('--loglevel',
                               type=str,


### PR DESCRIPTION
After the refactoring of the logger where loggers have log levels, but not the observers, this will make file logging work nicer/at all. (I should write some tests for this so it doesn't break again)

It also adds a `--logtofile` switch which enables file logging in the default location unless `--logdir` is provided.