### PR TITLE
shutdown + log improvements

### DIFF
--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -415,7 +415,8 @@ class Node(object):
                     # we've established a connection to the component
                     def component_exited(info):
                         dead_comp = info['id']
-                        self.log.info("Component '{}' failed to start; shutting down node.".format(dead_comp))
+                        self.log.info("Component '{dead_comp}' failed to start; shutting down node.", dead_comp=dead_comp)
+                        self.log.debug("'{dead_comp}' has config: {config}", dead_comp=dead_comp, config=info['config'])
                         if self._reactor.running:
                             self._reactor.stop()
                     topic = 'crossbar.node.{}.worker.{}.container.on_component_stop'.format(self._node_id, worker_id)

--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -414,9 +414,8 @@ class Node(object):
                     # start_container_component returns as soon as
                     # we've established a connection to the component
                     def component_exited(info):
-                        dead_comp = info['id']
-                        self.log.info("Component '{dead_comp}' failed to start; shutting down node.", dead_comp=dead_comp)
-                        self.log.debug("'{dead_comp}' has config: {config}", dead_comp=dead_comp, config=info['config'])
+                        self.log.info("Component '{info.id}' failed to start; shutting down node.", info=info)
+                        self.log.debug("'{info.id}' has config: {info.config}", info=info)
                         try:
                             self._reactor.stop()
                         except twisted.internet.error.ReactorNotRunning:

--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -417,8 +417,10 @@ class Node(object):
                         dead_comp = info['id']
                         self.log.info("Component '{dead_comp}' failed to start; shutting down node.", dead_comp=dead_comp)
                         self.log.debug("'{dead_comp}' has config: {config}", dead_comp=dead_comp, config=info['config'])
-                        if self._reactor.running:
+                        try:
                             self._reactor.stop()
+                        except twisted.internet.error.ReactorNotRunning:
+                            pass
                     topic = 'crossbar.node.{}.worker.{}.container.on_component_stop'.format(self._node_id, worker_id)
                     component_stop_sub = yield self._controller.subscribe(component_exited, topic)
 

--- a/crossbar/worker/container.py
+++ b/crossbar/worker/container.py
@@ -294,7 +294,7 @@ class ContainerWorkerSession(NativeWorkerSession):
             # https://twistedmatrix.com/documents/current/api/twisted.internet.error.ConnectError.html
             if isinstance(err.value, internet.error.ConnectError):
                 emsg = "ERROR: could not connect container component to router - transport establishment failed ({})".format(err.value)
-                self.log.failure(emsg)
+                self.log.error(emsg)
                 raise ApplicationError('crossbar.error.cannot_connect', emsg)
             else:
                 # should not arrive here (since all errors arriving here should be subclasses of ConnectError)

--- a/crossbar/worker/container.py
+++ b/crossbar/worker/container.py
@@ -311,7 +311,10 @@ class ContainerWorkerSession(NativeWorkerSession):
         event = component.marshal()
         topic = self._uri_prefix + '.container.on_component_stop'
         # XXX just ignoring a Deferred here...
-        self.publish(topic, event)
+        try:
+            self.publish(topic, event)
+        except TransportLost:
+            self.log.error("Transport already gone trying to publish on_component_stop")
         return event
 
     @inlineCallbacks

--- a/crossbar/worker/container.py
+++ b/crossbar/worker/container.py
@@ -39,7 +39,7 @@ from twisted.internet.defer import Deferred, DeferredList, inlineCallbacks
 from twisted.internet.defer import returnValue
 
 from autobahn.util import utcstr
-from autobahn.wamp.exception import ApplicationError
+from autobahn.wamp.exception import ApplicationError, TransportLost
 from autobahn.wamp.types import ComponentConfig, PublishOptions
 from autobahn.wamp.types import RegisterOptions
 
@@ -192,7 +192,7 @@ class ContainerWorkerSession(NativeWorkerSession):
             try:
                 return create_component(component_config)
             except Exception:
-                self.log.failure("Instantiating component failed")
+                self.log.error("Instantiating component failed")
                 raise
 
         # 2) create WAMP transport factory

--- a/crossbar/worker/process.py
+++ b/crossbar/worker/process.py
@@ -30,6 +30,8 @@
 
 from __future__ import absolute_import, print_function
 
+from twisted.internet.error import ReactorNotRunning
+
 __all__ = ('run',)
 
 
@@ -181,9 +183,12 @@ def run():
             finally:
                 # loosing the connection to the node controller is fatal:
                 # stop the reactor and exit with error
-                if reactor.running:
-                    reactor.addSystemEventTrigger('after', 'shutdown', os._exit, 1)
+                log.info("No more controller connection; shutting down.")
+                reactor.addSystemEventTrigger('after', 'shutdown', os._exit, 1)
+                try:
                     reactor.stop()
+                except ReactorNotRunning:
+                    pass
                 # if the reactor *isn't* running, we're already shutting down
 
     try:

--- a/crossbar/worker/test/test_router.py
+++ b/crossbar/worker/test/test_router.py
@@ -113,7 +113,8 @@ class RouterWorkerSessionTests(TestCase):
 
         # Should have 35 registers, all for the management interface
         self.assertEqual(len(transport._get(Register)), 35)
-        self.assertIn("ready", log_list[-1]["log_format"])
+        # XXX depends on log-text; perhaps a little flaky...
+        self.assertIn("running as", log_list[-1]["log_format"])
 
     def test_start_router_component(self):
         """

--- a/crossbar/worker/worker.py
+++ b/crossbar/worker/worker.py
@@ -120,7 +120,8 @@ class NativeWorkerSession(NativeProcessSession):
                            {'type': self.WORKER_TYPE, 'id': self.config.extra.worker, 'pid': os.getpid()},
                            options=PublishOptions(acknowledge=True))
 
-        self.log.info("Worker ready to roll!")
+        self.log.info("Worker '{worker}' running as PID {pid}",
+                      worker=self.config.extra.node, pid=os.getpid())
 
     def get_profilers(self, details=None):
         """


### PR DESCRIPTION
Relating to #328, a few minor logging improvements and a couple changes to make shutdown more robust: ignore TransportLost while trying to publish on_component_stop and stop checking if the reactor is running.