### PR TITLE
pypy can't install pycrypto extra + only report on crossbar/*

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,8 @@ deps =
    twcurrent: Twisted
    twtrunk: https://github.com/twisted/twisted/archive/trunk.zip
 commands =
-   pip -q install .[all]
+   {py27,py33,py34}: pip install -q .[all]
+   {pypy}: pip install -q .[msgpack,tls,system]
    sh -c "which python"
    sh -c "which coverage"
    python -V
@@ -33,7 +34,7 @@ commands =
    coverage erase
    coverage run {envbindir}/trial crossbar
    coverage combine
-   coverage report
+   coverage report --include 'crossbar/*'
    coverage html
 setenv =
    COVERAGE_PROCESS_START = 1


### PR DESCRIPTION
A couple minor tox tweaks I find I need with pypy 2.6.x on Debian (if installing with ``pip install .[all]`` I get a build error from pycrypto under pypy).