### PR TITLE
Allow failures for twtrunk-abtrunk on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,7 @@ notifications:
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - env: TOX_ENV=py27-twtrunk-abtrunk
+    - env: TOX_ENV=py33-twtrunk-abtrunk
+    - env: TOX_ENV=py34-twtrunk-abtrunk


### PR DESCRIPTION
We should be aware of these failures (we read the Travis output all the time) -- but it shouldn't block things if Twisted or Autobahn trunk is temporarily broken.