### PR TITLE
better logging for component-instantiation failures

### DIFF
--- a/crossbar/worker/container.py
+++ b/crossbar/worker/container.py
@@ -212,13 +212,16 @@ class ContainerWorkerSession(NativeWorkerSession):
 
                 # any exception spilling out from user code in onXXX handlers is fatal!
                 def panic(fail, msg):
-                    self.log.error("Fatal error in component: {} - {}".format(msg, fail.value))
+                    self.log.error(
+                        "Fatal error in component: {msg} - {log_failure.value}",
+                        msg=msg, log_failure=fail,
+                    )
                     session.disconnect()
                 session._swallow_error = panic
                 return session
             except Exception as e:
                 msg = "{}".format(e).strip()
-                self.log.error("Component instantiation failed:\n\n{err}", err=msg)
+                self.log.failure("Component instantiation failed: {msg}", msg=msg)
                 raise
 
         # 2) create WAMP transport factory


### PR DESCRIPTION
This improves error-logging for the #473 issue. The error is actually logged, but the message was short (didn't include the exception class-name, for example) and didn't include a stack trace. Now, it does both those things.