### PR TITLE
Store challenge JSON in a serializable format

### DIFF
--- a/crossbar/router/auth.py
+++ b/crossbar/router/auth.py
@@ -101,8 +101,8 @@ class PendingAuthWampCra(PendingAuth):
         }
 
         # challenge must be bytes
-        self.challenge = json.dumps(challenge_obj, ensure_ascii=False).encode('utf8')
-        self.signature = auth.compute_wcs(secret, self.challenge)
+        self.challenge = json.dumps(challenge_obj, ensure_ascii=False)
+        self.signature = auth.compute_wcs(secret, self.challenge.encode('utf8'))
 
 
 class PendingAuthTicket(PendingAuth):


### PR DESCRIPTION
Storing `challenge` in `PendingAuthWampCra` as a UTF-8 JSON instead of
bytes is more natural; json spec states that json strings are utf-8,
so it usually will be required to be used throughout as such. For
example, the field is currently only required to be bytes during
signature calculation, which is done in its initialization.

This would fix #489.
