### PR TITLE
WAMP-CRA auth

### DIFF
--- a/crossbar/router/auth.py
+++ b/crossbar/router/auth.py
@@ -100,9 +100,8 @@ class PendingAuthWampCra(PendingAuth):
             'timestamp': util.utcnow()
         }
 
-        # challenge must be bytes
-        self.challenge = json.dumps(challenge_obj, ensure_ascii=False).encode('utf8')
-        self.signature = auth.compute_wcs(secret, self.challenge)
+        self.challenge = json.dumps(challenge_obj, ensure_ascii=False)
+        self.signature = auth.compute_wcs(secret, self.challenge.encode('utf8')).decode('ascii')
 
 
 class PendingAuthTicket(PendingAuth):

--- a/crossbar/router/session.py
+++ b/crossbar/router/session.py
@@ -461,7 +461,7 @@ class _RouterSession(BaseSession):
 
         DO NOT attach to Deferreds that are returned to calling code.
         """
-        self.log.failure("Internal error (2): {log_failure.value}", failure=fail)
+        self.log.error("Internal error (2): {log_failure.value}", log_failure=fail)
 
         # tell other side we're done
         reply = message.Abort(u"wamp.error.authorization_failed", u"Internal server error")

--- a/crossbar/router/session.py
+++ b/crossbar/router/session.py
@@ -111,7 +111,7 @@ class _RouterApplicationSession(object):
     def _swallow_error(self, fail, msg):
         try:
             if self._session:
-                self._session.onUserError(fail.value, msg)
+                self._session.onUserError(fail, msg)
         except:
             pass
         return None

--- a/crossbar/router/session.py
+++ b/crossbar/router/session.py
@@ -840,7 +840,7 @@ class RouterSession(_RouterSession):
         """
         Callback fired when a client responds to an authentication challenge.
         """
-        print("onAuthenticate: {} {}".format(signature, extra))
+        self.log.debug("onAuthenticate: {signature} {extra}", signature=signature, extra=extra)
 
         # if there is a pending auth, check the challenge response. The specifics
         # of how to check depend on the authentication method
@@ -861,6 +861,11 @@ class RouterSession(_RouterSession):
                 else:
                     # WAMP-CRA authentication signature was invalid: deny client
                     #
+                    self.log.debug(
+                        'Invalid sig: "{got}" != "{wanted}"',
+                        got=signature,
+                        wanted=self._pending_auth.signature,
+                    )
                     return types.Deny(message=u"signature is invalid")
 
             # WAMP-Ticket

--- a/crossbar/router/session.py
+++ b/crossbar/router/session.py
@@ -611,11 +611,13 @@ class RouterSession(_RouterSession):
 
                                         # construct a pending WAMP-CRA authentication
                                         #
-                                        self._pending_auth = PendingAuthWampCra(details.pending_session,
-                                                                                authid,
-                                                                                user['role'],
-                                                                                u'static',
-                                                                                user['secret'].encode('utf8'))
+                                        self._pending_auth = PendingAuthWampCra(
+                                            details.pending_session,
+                                            authid,
+                                            user['role'],
+                                            u'static',
+                                            user['secret'].encode('utf8'),
+                                        )
 
                                         # send challenge to client
                                         #

--- a/crossbar/router/session.py
+++ b/crossbar/router/session.py
@@ -461,7 +461,7 @@ class _RouterSession(BaseSession):
 
         DO NOT attach to Deferreds that are returned to calling code.
         """
-        self.log.error("Internal error (2): {log_failure.value}", log_failure=fail)
+        self.log.failure("Internal error (2): {log_failure.value}", log_failure=fail)
 
         # tell other side we're done
         reply = message.Abort(u"wamp.error.authorization_failed", u"Internal server error")

--- a/crossbar/router/test/test_authorize.py
+++ b/crossbar/router/test/test_authorize.py
@@ -31,6 +31,8 @@
 from __future__ import absolute_import
 
 import os
+import six
+
 from twisted.trial import unittest
 
 from crossbar.router.role import RouterRoleStaticAuth
@@ -88,5 +90,5 @@ class TestPendingAuth(unittest.TestCase):
         secret = os.urandom(32)
         pend = PendingAuthWampCra(1234, u'authid', u'authrole', None, secret)
 
-        self.assertTrue(isinstance(pend.challenge, bytes))
-        self.assertTrue(isinstance(pend.signature, bytes))
+        self.assertTrue(isinstance(pend.challenge, six.text_type))
+        self.assertTrue(isinstance(pend.signature, six.text_type))

--- a/crossbar/router/test/test_broker.py
+++ b/crossbar/router/test/test_broker.py
@@ -121,7 +121,7 @@ class TestBrokerPublish(unittest.TestCase):
 
             if True:
                 self.assertEqual(1, len(errors), "Didn't see our error")
-                self.assertEqual(the_exception, errors[0][0])
+                self.assertEqual(the_exception, errors[0][0].value)
 
             else:
                 # check we got the right log.failure() call
@@ -160,8 +160,8 @@ class TestBrokerPublish(unittest.TestCase):
             # for a MagicMock call-object, 0th thing is the method-name, 1st
             # thing is the arg-tuple, 2nd thing is the kwargs.
             self.assertEqual(call[0], 'failure')
-            self.assertTrue('failure' in call[2])
-            self.assertEqual(call[2]['failure'].value, the_exception)
+            self.assertTrue('log_failure' in call[2])
+            self.assertEqual(call[2]['log_failure'].value, the_exception)
 
     def test_router_session_internal_error_onAuthenticate(self):
         """
@@ -191,8 +191,8 @@ class TestBrokerPublish(unittest.TestCase):
             # for a MagicMock call-object, 0th thing is the method-name, 1st
             # thing is the arg-tuple, 2nd thing is the kwargs.
             self.assertEqual(call[0], 'failure')
-            self.assertTrue('failure' in call[2])
-            self.assertEqual(call[2]['failure'].value, the_exception)
+            self.assertTrue('log_failure' in call[2])
+            self.assertEqual(call[2]['log_failure'].value, the_exception)
 
     def test_add_and_subscribe(self):
         """

--- a/crossbar/router/test/test_router.py
+++ b/crossbar/router/test/test_router.py
@@ -118,8 +118,8 @@ class TestEmbeddedSessions(unittest.TestCase):
             # for a MagicMock call-object, 0th thing is the method-name, 1st
             # thing is the arg-tuple, 2nd thing is the kwargs.
             self.assertEqual(call[0], 'failure')
-            self.assertTrue('failure' in call[2])
-            self.assertEqual(call[2]['failure'].value, the_exception)
+            self.assertTrue('log_failure' in call[2])
+            self.assertEqual(call[2]['log_failure'].value, the_exception)
 
     def test_router_session_internal_error_onHello(self):
         """
@@ -149,8 +149,8 @@ class TestEmbeddedSessions(unittest.TestCase):
             # for a MagicMock call-object, 0th thing is the method-name, 1st
             # thing is the arg-tuple, 2nd thing is the kwargs.
             self.assertEqual(call[0], 'failure')
-            self.assertTrue('failure' in call[2])
-            self.assertEqual(call[2]['failure'].value, the_exception)
+            self.assertTrue('log_failure' in call[2])
+            self.assertEqual(call[2]['log_failure'].value, the_exception)
 
     def test_router_session_internal_error_onAuthenticate(self):
         """
@@ -180,8 +180,8 @@ class TestEmbeddedSessions(unittest.TestCase):
             # for a MagicMock call-object, 0th thing is the method-name, 1st
             # thing is the arg-tuple, 2nd thing is the kwargs.
             self.assertEqual(call[0], 'failure')
-            self.assertTrue('failure' in call[2])
-            self.assertEqual(call[2]['failure'].value, the_exception)
+            self.assertTrue('log_failure' in call[2])
+            self.assertEqual(call[2]['log_failure'].value, the_exception)
 
     def test_add_and_subscribe(self):
         """

--- a/crossbar/twisted/tlsctx.py
+++ b/crossbar/twisted/tlsctx.py
@@ -254,8 +254,8 @@ class TlsServerContextFactory(DefaultOpenSSLContextFactory):
                  chainedCertificate=True,
                  dhParamFilename=None,
                  ciphers=None):
-        self._privateKeyString = str(privateKeyString)
-        self._certificateString = str(certificateString)
+        self._privateKeyString = str(privateKeyString).encode('utf8')
+        self._certificateString = str(certificateString).encode('utf8')
         self._chainedCertificate = chainedCertificate
         self._dhParamFilename = str(dhParamFilename) if dhParamFilename else None
         self._ciphers = str(ciphers) if ciphers else None

--- a/crossbar/worker/worker.py
+++ b/crossbar/worker/worker.py
@@ -64,11 +64,7 @@ class NativeWorkerSession(NativeProcessSession):
     log = make_logger()
 
     def onUserError(self, err, errmsg):
-        # FIXME: this works for me now ..
-        sys.stderr.write(errmsg)
-        # .. not sure why this doesn't:
-        # self.log.error(errmsg)
-        # print(errmsg)
+        self.log.error("NativeWorkerSession.onUserError", log_failure=err)
 
     def onConnect(self):
         """


### PR DESCRIPTION
For #489. Although previous discussion concluded that the challenge should be a ``bytes``, that can't work very well, as the json module won't serialize a ``bytes``. So, this switches both the signature and challenge to be a UTF8 string.

This works with the client-side code given in the current crossbar.io docs.

This is probably incomplete; it's failing on some log unittest for some reason in particular tox environments and I want to see if it runs on travis or not.