### PR TITLE
proper logging, early error on missing TLS files

### DIFF
--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -34,6 +34,7 @@ import os
 import json
 import re
 import six
+from os.path import exists
 
 from pprint import pformat
 
@@ -445,6 +446,11 @@ def check_listening_endpoint_tls(tls):
         if k[0] in tls:
             if not isinstance(tls[k[0]], six.text_type):
                 raise InvalidConfigException("'{}' in listening endpoint TLS configuration must be string ({} encountered)".format(k[0], type(tls[k[0]])))
+            # all options except "ciphers" are filenames
+            if k[0] != 'ciphers' and not exists(tls[k[0]]):
+                raise InvalidConfigException(
+                    "Path '{}' doesn't exist for {} in tls config".format(tls[k[0]], k[0])
+                )
 
 
 def check_connecting_endpoint_tls(tls):

--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -449,7 +449,7 @@ def check_listening_endpoint_tls(tls):
             # all options except "ciphers" are filenames
             if k[0] != 'ciphers' and not exists(tls[k[0]]):
                 raise InvalidConfigException(
-                    "Path '{}' doesn't exist for {} in tls config".format(tls[k[0]], k[0])
+                    "Path '{}' doesn't exist for '{}' in TLS config".format(tls[k[0]], k[0])
                 )
 
 

--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -215,8 +215,7 @@ class Node(object):
             yield self._startup(self._config)
         except ApplicationError as e:
             panic = True
-            for line in e.args[0].strip().splitlines():
-                self.log.error(line)
+            self.log.error("{msg}", msg=e.error_message())
         except Exception:
             panic = True
             traceback.print_exc()

--- a/crossbar/test/test_checkconfig.py
+++ b/crossbar/test/test_checkconfig.py
@@ -64,6 +64,24 @@ class CheckDictArgsTests(TestCase):
                          str(e.exception))
 
 
+class CheckTlsTests(TestCase):
+    """
+    Tests for L{crossbar.common.checkconfig.check_container}.
+    """
+    def test_missing_dhparams(self):
+        cfg = dict(
+            key=u'/invalid',
+            certificate=u'/invalid',
+            dhparam=u'/invalid',
+            ciphers=u'/invalid',
+        )
+
+        with self.assertRaises(checkconfig.InvalidConfigException) as e:
+            checkconfig.check_listening_endpoint_tls(cfg)
+
+        self.assertTrue("doesn't exist" in str(e))
+
+
 class CheckContainerTests(TestCase):
     """
     Tests for L{crossbar.common.checkconfig.check_container}.

--- a/crossbar/test/test_checkconfig.py
+++ b/crossbar/test/test_checkconfig.py
@@ -76,10 +76,10 @@ class CheckTlsTests(TestCase):
             ciphers=u'/invalid',
         )
 
-        with self.assertRaises(checkconfig.InvalidConfigException) as e:
+        with self.assertRaises(checkconfig.InvalidConfigException) as err:
             checkconfig.check_listening_endpoint_tls(cfg)
 
-        self.assertTrue("doesn't exist" in str(e))
+        self.assertTrue("doesn't exist" in str(err.exception))
 
 
 class CheckContainerTests(TestCase):

--- a/crossbar/twisted/endpoint.py
+++ b/crossbar/twisted/endpoint.py
@@ -236,9 +236,11 @@ def create_listening_port_from_config(config, factory, cbdir, reactor):
             return defer.fail(e)
 
     else:
-
-        endpoint = create_listening_endpoint_from_config(config, cbdir, reactor)
-        return endpoint.listen(factory)
+        try:
+            endpoint = create_listening_endpoint_from_config(config, cbdir, reactor)
+            return endpoint.listen(factory)
+        except Exception:
+            return defer.fail()
 
 
 def create_connecting_endpoint_from_config(config, cbdir, reactor):


### PR DESCRIPTION
Per issue #517 this fixes a couple problems: first, errors weren't being logged properly coming out of ``Node.start()`` and further the TLS configuration wasn't validating the existence of files (where we can give a nicer error-message before even trying to start the node).

There was also a helper function that should have been returning a ``Failure`` but was instead throwing an immediate exception.