### PR TITLE
file upload fix and features

### DIFF
--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -1094,7 +1094,9 @@ def check_web_path_service_upload(config):
         'total_chunks': (True, [six.text_type]),
         'content': (True, [six.text_type]),
         'on_progress': (False, [six.text_type]),
-        'session': (False, [six.text_type])
+        'session': (False, [six.text_type]),
+        'chunk_extra': (False, [six.text_type]),
+        'finish_extra': (False, [six.text_type])
     }, config['form_fields'], "File upload form field settings")
 
     if 'on_progress' in config['form_fields']:

--- a/crossbar/twisted/resource.py
+++ b/crossbar/twisted/resource.py
@@ -371,7 +371,8 @@ class FileUploadResource(Resource):
                                    "remaining": 0,
                                    "status": "finished",
                                    "progress": 1.,
-                                   "finish_extra": finish_extra
+                                   "finish_extra": finish_extra,
+                                   "chunk_extra": chunk_extra
                                    })
 
                 self._uploads.pop(fileId, None)
@@ -459,7 +460,8 @@ class FileUploadResource(Resource):
                                    "remaining": 0,
                                    "status": "finished",
                                    "progress": 1.,
-                                   "finish_extra": finish_extra
+                                   "finish_extra": finish_extra,
+                                   "chunk_extra": chunk_extra
                                    })
 
                 # remove the file temp folder

--- a/crossbar/twisted/test/test_resource.py
+++ b/crossbar/twisted/test/test_resource.py
@@ -199,3 +199,148 @@ class FileUploadTests(TestCase):
         self.assertEqual(len(upload_dir.listdir()), 1)
         with upload_dir.child("examplefile.txt").open("rb") as f:
             self.assertEqual(f.read(), b"hello Crossbar!\n")
+
+    def test_multichunk_shuffle(self):
+        """
+        Uploading files that are in multiple chunks and are uploaded in different order works.
+        """
+        upload_dir = FilePath(self.mktemp())
+        upload_dir.makedirs()
+        temp_dir = FilePath(self.mktemp())
+        temp_dir.makedirs()
+
+        fields = {
+            "file_name": "resumableFilename",
+            "mime_type": "resumableType",
+            "total_size": "resumableTotalSize",
+            "chunk_number": "resumableChunkNumber",
+            "chunk_size": "resumableChunkSize",
+            "total_chunks": "resumableTotalChunks",
+            "content": "file",
+            "on_progress": "on_progress",
+            "session": "session"
+        }
+
+        mock_session = Mock()
+
+        resource = FileUploadResource(upload_dir.path, temp_dir.path, fields, mock_session)
+
+        #
+        # Chunk 2
+
+        multipart_body = b"""-----------------------------42560029919436807832069165364\r\nContent-Disposition: form-data; name="resumableChunkNumber"\r\n\r\n2\r\n-----------------------------42560029919436807832069165364\r\nContent-Disposition: form-data; name="resumableChunkSize"\r\n\r\n10\r\n-----------------------------42560029919436807832069165364\r\nContent-Disposition: form-data; name="resumableCurrentChunkSize"\r\n\r\n6\r\n-----------------------------42560029919436807832069165364\r\nContent-Disposition: form-data; name="resumableTotalSize"\r\n\r\n16\r\n-----------------------------42560029919436807832069165364\r\nContent-Disposition: form-data; name="resumableType"\r\n\r\ntext/plain\r\n-----------------------------42560029919436807832069165364\r\nContent-Disposition: form-data; name="resumableIdentifier"\r\n\r\n16-examplefiletxt\r\n-----------------------------42560029919436807832069165364\r\nContent-Disposition: form-data; name="resumableFilename"\r\n\r\nexamplefile.txt\r\n-----------------------------42560029919436807832069165364\r\nContent-Disposition: form-data; name="resumableRelativePath"\r\n\r\nexamplefile.txt\r\n-----------------------------42560029919436807832069165364\r\nContent-Disposition: form-data; name="resumableTotalChunks"\r\n\r\n2\r\n-----------------------------42560029919436807832069165364\r\nContent-Disposition: form-data; name="on_progress"\r\n\r\ncom.example.upload.on_progress\r\n-----------------------------42560029919436807832069165364\r\nContent-Disposition: form-data; name="session"\r\n\r\n8887465641628580\r\n-----------------------------42560029919436807832069165364\r\nContent-Disposition: form-data; name="file"; filename="blob"\r\nContent-Type: application/octet-stream\r\n\r\nsbar!\n\r\n-----------------------------42560029919436807832069165364--\r\n"""
+
+        d = renderResource(
+            resource, b"/", method="POST",
+            headers={
+                b"content-type": [b"multipart/form-data; boundary=---------------------------42560029919436807832069165364"],
+                b"Content-Length": [b"1688"]
+            },
+            body=multipart_body
+        )
+
+        res = self.successResultOf(d)
+        res.setResponseCode.assert_called_once_with(200)
+
+        # One directory in the temp dir, nothing in the upload dir, temp dir
+        # contains one chunk
+        self.assertEqual(len(temp_dir.listdir()), 1)
+        self.assertEqual(len(temp_dir.child("examplefile.txt").listdir()), 1)
+        with temp_dir.child("examplefile.txt").child("chunk_2").open("rb") as f:
+            # print(f.read())
+            self.assertEqual(f.read(), b"sbar!\n")
+        self.assertEqual(len(upload_dir.listdir()), 0)
+        #
+        # Chunk 1
+
+        multipart_body = b"""-----------------------------1311987731215707521443909311\r\nContent-Disposition: form-data; name="resumableChunkNumber"\r\n\r\n1\r\n-----------------------------1311987731215707521443909311\r\nContent-Disposition: form-data; name="resumableChunkSize"\r\n\r\n10\r\n-----------------------------1311987731215707521443909311\r\nContent-Disposition: form-data; name="resumableCurrentChunkSize"\r\n\r\n10\r\n-----------------------------1311987731215707521443909311\r\nContent-Disposition: form-data; name="resumableTotalSize"\r\n\r\n16\r\n-----------------------------1311987731215707521443909311\r\nContent-Disposition: form-data; name="resumableType"\r\n\r\ntext/plain\r\n-----------------------------1311987731215707521443909311\r\nContent-Disposition: form-data; name="resumableIdentifier"\r\n\r\n16-examplefiletxt\r\n-----------------------------1311987731215707521443909311\r\nContent-Disposition: form-data; name="resumableFilename"\r\n\r\nexamplefile.txt\r\n-----------------------------1311987731215707521443909311\r\nContent-Disposition: form-data; name="resumableRelativePath"\r\n\r\nexamplefile.txt\r\n-----------------------------1311987731215707521443909311\r\nContent-Disposition: form-data; name="resumableTotalChunks"\r\n\r\n2\r\n-----------------------------1311987731215707521443909311\r\nContent-Disposition: form-data; name="on_progress"\r\n\r\ncom.example.upload.on_progress\r\n-----------------------------1311987731215707521443909311\r\nContent-Disposition: form-data; name="session"\r\n\r\n8887465641628580\r\n-----------------------------1311987731215707521443909311\r\nContent-Disposition: form-data; name="file"; filename="blob"\r\nContent-Type: application/octet-stream\r\n\r\nhello Cros\r\n-----------------------------1311987731215707521443909311--\r\n"""
+
+        d = renderResource(
+            resource, b"/", method="POST",
+            headers={
+                b"content-type": [b"multipart/form-data; boundary=---------------------------1311987731215707521443909311"],
+                b"Content-Length": [b"1680"]
+            },
+            body=multipart_body
+        )
+
+        res = self.successResultOf(d)
+        res.setResponseCode.assert_called_once_with(200)
+
+        self.assertEqual(len(mock_session.method_calls), 4)
+
+        # Starting the upload
+        self.assertEqual(mock_session.method_calls[0][1][0], u"com.example.upload.on_progress")
+        self.assertEqual(mock_session.method_calls[0][1][1]["status"], "started")
+        self.assertEqual(mock_session.method_calls[0][1][1]["id"], "examplefile.txt")
+        self.assertEqual(mock_session.method_calls[0][1][1]["chunk"], 2)
+
+        # Progress, first chunk done
+        self.assertEqual(mock_session.method_calls[1][1][0], u"com.example.upload.on_progress")
+        self.assertEqual(mock_session.method_calls[1][1][1]["status"], "progress")
+        self.assertEqual(mock_session.method_calls[1][1][1]["id"], "examplefile.txt")
+        self.assertEqual(mock_session.method_calls[1][1][1]["chunk"], 2)
+
+        # Progress, second chunk done
+        self.assertEqual(mock_session.method_calls[2][1][0], u"com.example.upload.on_progress")
+        self.assertEqual(mock_session.method_calls[2][1][1]["status"], "progress")
+        self.assertEqual(mock_session.method_calls[2][1][1]["id"], "examplefile.txt")
+        self.assertEqual(mock_session.method_calls[2][1][1]["chunk"], 1)
+
+        # Upload complete
+        self.assertEqual(mock_session.method_calls[3][1][0], u"com.example.upload.on_progress")
+        self.assertEqual(mock_session.method_calls[3][1][1]["status"], "finished")
+        self.assertEqual(mock_session.method_calls[3][1][1]["id"], "examplefile.txt")
+        self.assertEqual(mock_session.method_calls[3][1][1]["chunk"], 1)
+
+        # Nothing in the temp dir, one file in the upload
+        self.assertEqual(len(temp_dir.listdir()), 0)
+        self.assertEqual(len(upload_dir.listdir()), 1)
+        with upload_dir.child("examplefile.txt").open("rb") as f:
+            self.assertEqual(f.read(), b"hello Crossbar!\n")
+
+    def test_remains_cleanup(self):
+        """
+        Upload a basic file using the FileUploadResource, in a single chunk on top of an old upload.
+        """
+
+        upload_dir = FilePath(self.mktemp())
+        upload_dir.makedirs()
+        temp_dir = FilePath(self.mktemp())
+        temp_dir.makedirs()
+        # create remaining file temp dir of a previous upload
+        x = temp_dir.child("examplefile.txt")
+        x.makedirs()
+
+        fields = {
+            "file_name": "resumableFilename",
+            "mime_type": "resumableType",
+            "total_size": "resumableTotalSize",
+            "chunk_number": "resumableChunkNumber",
+            "chunk_size": "resumableChunkSize",
+            "total_chunks": "resumableTotalChunks",
+            "content": "file",
+            "on_progress": "on_progress",
+            "session": "session"
+        }
+
+        mock_session = Mock()
+
+        resource = FileUploadResource(upload_dir.path, temp_dir.path, fields, mock_session)
+
+        multipart_body = b"""-----------------------------478904261175205671481632460\r\nContent-Disposition: form-data; name="resumableChunkNumber"\r\n\r\n1\r\n-----------------------------478904261175205671481632460\r\nContent-Disposition: form-data; name="resumableChunkSize"\r\n\r\n1048576\r\n-----------------------------478904261175205671481632460\r\nContent-Disposition: form-data; name="resumableCurrentChunkSize"\r\n\r\n16\r\n-----------------------------478904261175205671481632460\r\nContent-Disposition: form-data; name="resumableTotalSize"\r\n\r\n16\r\n-----------------------------478904261175205671481632460\r\nContent-Disposition: form-data; name="resumableType"\r\n\r\ntext/plain\r\n-----------------------------478904261175205671481632460\r\nContent-Disposition: form-data; name="resumableIdentifier"\r\n\r\n16-examplefiletxt\r\n-----------------------------478904261175205671481632460\r\nContent-Disposition: form-data; name="resumableFilename"\r\n\r\nexamplefile.txt\r\n-----------------------------478904261175205671481632460\r\nContent-Disposition: form-data; name="resumableRelativePath"\r\n\r\nexamplefile.txt\r\n-----------------------------478904261175205671481632460\r\nContent-Disposition: form-data; name="resumableTotalChunks"\r\n\r\n1\r\n-----------------------------478904261175205671481632460\r\nContent-Disposition: form-data; name="on_progress"\r\n\r\ncom.example.upload.on_progress\r\n-----------------------------478904261175205671481632460\r\nContent-Disposition: form-data; name="session"\r\n\r\n6891276359801283\r\n-----------------------------478904261175205671481632460\r\nContent-Disposition: form-data; name="file"; filename="blob"\r\nContent-Type: application/octet-stream\r\n\r\nhello Crossbar!\n\r\n-----------------------------478904261175205671481632460--\r\n"""
+
+        d = renderResource(
+            resource, b"/", method="POST",
+            headers={
+                b"content-type": [b"multipart/form-data; boundary=---------------------------478904261175205671481632460"],
+                b"Content-Length": [b"1678"]
+            },
+            body=multipart_body
+        )
+
+        res = self.successResultOf(d)
+        res.setResponseCode.assert_called_once_with(200)
+
+        with upload_dir.child("examplefile.txt").open("rb") as f:
+            self.assertEqual(f.read(), b"hello Crossbar!\n")

--- a/crossbar/worker/router.py
+++ b/crossbar/worker/router.py
@@ -1148,6 +1148,8 @@ class RouterWorkerSession(NativeWorkerSession):
 
             self._router_session_factory.add(upload_session, authrole=path_config.get('role', 'anonymous'))
 
+            self.log.info("File upload resource started. Uploads to {upl} using temp folder {tmp}.", upl=upload_directory, tmp=temp_directory)
+
             return FileUploadResource(upload_directory, temp_directory, path_config['form_fields'], upload_session, path_config.get('options', {}))
 
         # Generic Twisted Web resource


### PR DESCRIPTION
Fixes issues #505 and #504. 

Adds a feature to add extra info to the upload post form data. If using resumable.js in the front end you can add a property `chunk_extra` to the `query` property of the resumable Object. This `chunk_extra` property **must** be a JSON string. ( e.g. `JSON.stringify([your JS object])` ) The form field name `chunk_extra` can be configured in the config.

This json string will be added to the on progress event of the uploaded chunks.
Similarly the `finish_extra` stringified js object will be added to the finish event.

Also added two test cases.