### PR TITLE
relax checks for PyPy

### DIFF
--- a/crossbar/router/test/test_authorize.py
+++ b/crossbar/router/test/test_authorize.py
@@ -90,5 +90,5 @@ class TestPendingAuth(unittest.TestCase):
         secret = os.urandom(32)
         pend = PendingAuthWampCra(1234, u'authid', u'authrole', None, secret)
 
-        self.assertTrue(isinstance(pend.challenge, six.text_type))
-        self.assertTrue(isinstance(pend.signature, six.text_type))
+        self.assertIsInstance(pend.challenge, (six.text_type, str))
+        self.assertIsInstance(pend.signature, (six.text_type, str))


### PR DESCRIPTION
I have also manually verified that this works against the latest portable PyPy release (4.0.1) using the crossbarexamples authentication demos.