### PR TITLE
Client-side TLS config

### DIFF
--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -435,7 +435,7 @@ def check_listening_endpoint_tls(tls):
         raise InvalidConfigException("'tls' in endpoint must be dictionary ({} encountered)".format(type(tls)))
 
     for k in tls:
-        if k not in ['key', 'certificate', 'dhparam', 'ciphers']:
+        if k not in ['key', 'certificate', 'dhparam', 'ciphers', 'ca_certificates']:
             raise InvalidConfigException("encountered unknown attribute '{}' in listening endpoint TLS configuration".format(k))
 
     for k in [('key', True), ('certificate', True), ('dhparam', False), ('ciphers', False)]:
@@ -447,7 +447,7 @@ def check_listening_endpoint_tls(tls):
             if not isinstance(tls[k[0]], six.text_type):
                 raise InvalidConfigException("'{}' in listening endpoint TLS configuration must be string ({} encountered)".format(k[0], type(tls[k[0]])))
             # all options except "ciphers" are filenames
-            if k[0] != 'ciphers' and not exists(tls[k[0]]):
+            if k[0] not in ['ciphers', 'ca_certificates'] and not exists(tls[k[0]]):
                 raise InvalidConfigException(
                     "Path '{}' doesn't exist for '{}' in TLS config".format(tls[k[0]], k[0])
                 )

--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -467,8 +467,15 @@ def check_connecting_endpoint_tls(tls):
         raise InvalidConfigException("'tls' in endpoint must be dictionary ({} encountered)".format(type(tls)))
 
     for k in tls:
-        if k not in ['ca_certificates', 'hostname']:
+        if k not in ['ca_certificates', 'hostname', 'certificate', 'key']:
             raise InvalidConfigException("encountered unknown attribute '{}' in listening endpoint TLS configuration".format(k))
+
+    for k in ['certificate', 'key']:
+        if k in tls and not os.path.exists(tls[k]):
+            raise InvalidConfigException(
+                "File '{}' for '{}' in TLS configuration "
+                "not found".format(tls[k], k)
+            )
 
     if 'ca_certificates' in tls:
         if not isinstance(tls['ca_certificates'], list):

--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -467,8 +467,19 @@ def check_connecting_endpoint_tls(tls):
         raise InvalidConfigException("'tls' in endpoint must be dictionary ({} encountered)".format(type(tls)))
 
     for k in tls:
-        if k not in []:
+        if k not in ['ca_certificates', 'hostname']:
             raise InvalidConfigException("encountered unknown attribute '{}' in listening endpoint TLS configuration".format(k))
+
+    if 'ca_certificates' in tls:
+        if not isinstance(tls['ca_certificates'], list):
+            raise InvalidConfigException("'ca_certificates' must be a list")
+        for fname in tls['ca_certificates']:
+            if not os.path.exists(fname):
+                raise InvalidConfigException("'ca_certificates' contains non-existant path '{}'".format(fname))
+
+    for req_k in ['hostname']:
+        if req_k not in tls:
+            raise InvalidConfigException("listening endpoint TLS configuration requires '{}'".format(req_k))
 
 
 def check_listening_endpoint_tcp(endpoint):

--- a/crossbar/controller/cli.py
+++ b/crossbar/controller/cli.py
@@ -529,6 +529,9 @@ def run_command_start(options, reactor=None):
     log.info()
 
     log.info("Starting from node directory {}".format(options.cbdir))
+    # relative path validation won't work if we aren't in our
+    # working-dir when doing the validation
+    os.chdir(options.cbdir)
 
     from crossbar.controller.node import Node
     from crossbar.common.checkconfig import InvalidConfigException

--- a/crossbar/twisted/endpoint.py
+++ b/crossbar/twisted/endpoint.py
@@ -38,6 +38,7 @@ from twisted.internet import defer
 from twisted.internet._sslverify import OpenSSLCertificateAuthorities
 from twisted.internet.ssl import CertificateOptions, PrivateCertificate, Certificate, KeyPair
 from twisted.internet.ssl import optionsForClientTLS, DiffieHellmanParameters
+from twisted.internet.ssl import AcceptableCiphers
 from twisted.internet.endpoints import TCP4ServerEndpoint, \
     TCP6ServerEndpoint, \
     TCP4ClientEndpoint, \
@@ -143,12 +144,22 @@ def create_listening_endpoint_from_config(config, cbdir, reactor):
                                 with open(fname, 'r') as f:
                                     ca_certs.append(Certificate.loadPEM(f.read()).original)
 
+                        crossbar_ciphers = AcceptableCiphers.fromOpenSSLCipherString(
+                            'ECDHE-RSA-AES128-GCM-SHA256:'
+                            'DHE-RSA-AES128-GCM-SHA256:'
+                            'ECDHE-RSA-AES128-SHA256:'
+                            'DHE-RSA-AES128-SHA256:'
+                            'ECDHE-RSA-AES128-SHA:'
+                            'DHE-RSA-AES128-SHA'
+                        )
+
                         ctx = CertificateOptions(
                             privateKey=KeyPair.load(key, crypto.FILETYPE_PEM).original,
                             certificate=Certificate.loadPEM(cert).original,
                             verify=True,
                             caCerts=ca_certs,
                             dhParameters=dh_params,
+                            acceptableCiphers=crossbar_ciphers,
                         )
                         if ctx._ecCurve is None:
                             log.warn("OpenSSL failed to set ECDH default curve")

--- a/crossbar/twisted/endpoint.py
+++ b/crossbar/twisted/endpoint.py
@@ -33,7 +33,6 @@ from __future__ import absolute_import, division
 import os
 import six
 
-from OpenSSL import crypto
 from twisted.internet import defer
 from twisted.internet._sslverify import OpenSSLCertificateAuthorities
 from twisted.internet.ssl import CertificateOptions, PrivateCertificate, Certificate, KeyPair
@@ -49,19 +48,15 @@ from twisted.python.filepath import FilePath
 from crossbar._logging import make_logger
 from crossbar.twisted.sharedport import SharedPort
 
-_HAS_TLS = None
-_LACKS_TLS_MSG = None
-
 try:
     from twisted.internet.endpoints import SSL4ServerEndpoint, \
         SSL4ClientEndpoint
-    from crossbar.twisted.tlsctx import TlsServerContextFactory, \
-        TlsClientContextFactory
+    from OpenSSL import crypto
+    _HAS_TLS = True
+    _LACKS_TLS_MSG = None
 except ImportError as e:
     _HAS_TLS = False
     _LACKS_TLS_MSG = "{}".format(e)
-else:
-    _HAS_TLS = True
 
 __all__ = ('create_listening_endpoint_from_config',
            'create_listening_port_from_config',
@@ -153,13 +148,6 @@ def create_listening_endpoint_from_config(config, cbdir, reactor):
                             caCerts=ca_certs,
                             dhParameters=dh_params,
                         )
-                        print("BLAMMO", ctx)
-                        # ctx = TlsServerContextFactory(
-                        #     key, cert,
-                        #     ciphers=ciphers,
-                        #     dhParamFilename=dhparam_filepath,
-                        #     ca_certs=ca_certs,
-                        # )
 
                 # create a TLS server endpoint
                 #

--- a/crossbar/twisted/endpoint.py
+++ b/crossbar/twisted/endpoint.py
@@ -156,7 +156,7 @@ def create_listening_endpoint_from_config(config, cbdir, reactor):
                         ctx = CertificateOptions(
                             privateKey=KeyPair.load(key, crypto.FILETYPE_PEM).original,
                             certificate=Certificate.loadPEM(cert).original,
-                            verify=True,
+                            verify=(ca_certs is not None),
                             caCerts=ca_certs,
                             dhParameters=dh_params,
                             acceptableCiphers=crossbar_ciphers,
@@ -359,11 +359,18 @@ def create_connecting_endpoint_from_config(config, cbdir, reactor):
                         client_cert = PrivateCertificate.fromCertificateAndKeyPair(
                             cert, private_key)
 
-                    # XXX FIXME private class OpenSSLCertificateAuthorities...
+                    # XXX OpenSSLCertificateAuthorities is a "private"
+                    # class, in _sslverify, so we shouldn't really be
+                    # using it. However, while you can pass a single
+                    # Certificate as trustRoot= there's no way to pass
+                    # multiple ones.
+                    # XXX ...but maybe the config should only allow
+                    # the user to configure a single cert to trust
+                    # here anyway?
                     options = optionsForClientTLS(
                         config['tls']['hostname'],
-                        OpenSSLCertificateAuthorities(ca_certs),
-                        client_cert,
+                        trustRoot=OpenSSLCertificateAuthorities(ca_certs),
+                        clientCertificate=client_cert,
                     )
                 else:
                     options = optionsForClientTLS(config['tls']['hostname'])

--- a/crossbar/twisted/tlsctx.py
+++ b/crossbar/twisted/tlsctx.py
@@ -270,6 +270,22 @@ class TlsServerContextFactory(DefaultOpenSSLContextFactory):
         self.cacheContext()
 
     def _verify_peer(self, conn, cert, errno, depth, preverify_ok):
+        if not preverify_ok:
+            self.log.info(
+                "TLS verification failing at depth {depth}; err={err}",
+                depth=depth,
+                err=errno,  # can we convert this to string/symbolic code?
+            )
+            # X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN		19
+            # X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY	20
+            if errno in [19, 20]:
+                self.log.debug(
+                    "Can't find CA certificate to verify against or self-signed "
+                    "certificate."
+                )
+                self.log.debug(
+                    "Is 'ca_certificates' endpoint configuration missing a cert?"
+                )
         return preverify_ok
 
     def cacheContext(self):

--- a/crossbar/twisted/tlsctx.py
+++ b/crossbar/twisted/tlsctx.py
@@ -350,9 +350,8 @@ class TlsServerContextFactory(DefaultOpenSSLContextFactory):
                 ctx.use_certificate_chain_file(f.name)
 
             store = ctx.get_cert_store()
-            for certdata in self._ca_certs:
-                cert = crypto.load_certificate(crypto.FILETYPE_PEM, certdata)
-                store.add_cert(cert)
+            for cert in self._ca_certs:
+                store.add_cert(cert.original)
             ctx.set_verify(SSL.VERIFY_PEER | SSL.VERIFY_FAIL_IF_NO_PEER_CERT, self._verify_peer)
 
             # load private key into context

--- a/crossbar/worker/router.py
+++ b/crossbar/worker/router.py
@@ -705,8 +705,8 @@ class RouterWorkerSession(NativeWorkerSession):
             return
 
         def fail(err):
-            emsg = "Cannot listen on transport endpoint: {}".format(err.value)
-            self.log.error(emsg)
+            emsg = "Cannot listen on transport endpoint: {log_failure}"
+            self.log.error(emsg, log_failure=err)
             raise ApplicationError(u"crossbar.error.cannot_listen", emsg)
 
         d.addCallbacks(ok, fail)


### PR DESCRIPTION
This adds a first-cut at usable client-side TLS configuration, including support for specifying acceptable CA certificates and client-side certificates (see #128)

There's a full-worked example with generated root and intermediate CAs in https://github.com/meejah/crossbarexamples/tree/client-side-tls-example.1

Currently, the server-side requests client certs if it has a ``ca_certificates`` list specified (otherwise, it doesn't). I don't particularly like this; it should probably be more explicit. We also almost certainly want a way to assign an auth-role to a client that successfully presents a TLS certificate, but that doesn't exist.

From the client-side, you enable TLS verification by putting config like:

```
"tls": {
    "hostname": "example.com"
}
```
...where "hostname" is a required field, and indicates the expected CN of the cert the server presents. You can additionally specify a ``ca_certificates`` list of acceptable roots to trust (e.g. so the server cert can be created by an untrusted CA, like a self-signed one or your company's internal CA etc).

This uses all-Twisted APIs, so tlsctx.py can be deleted too (but is still there right now).