### PR TITLE
fix python3 related file upload issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ clean:
 install:
 	pip install --upgrade -e .[all]
 
+install3:
+	pip3 install --upgrade -e .[all]
+
 publish: clean
 	python setup.py register
 	python setup.py sdist upload


### PR DESCRIPTION
#504 

There is another thing, that’s kind of hard to solve:
If you don’t want to check for already uploaded chunks with those GET requests, then 
you still get the full file as soon as every chunk has been transfered at least once.
If later you send duplicate chunks, then there is no way for the backend to stop or even 
recognize, that this is not a new upload. So the backend  currently starts a new upload for 
those files. And that will never finish. 

---
### Example:

You upload a file consisting of three chunks two times.
#### First upload:
- chunk 1
- chunk 2
- break

#### Second upload:
- chunk 3
- chunk 1
- chunk 2

After the upload of chunk 3 in the second upload the file will be complete and will be merged and moved because for the backend there is no way to tell if chunk 3 does not belong to the first upload.
After that chunk 2 and chunk 1 arrive. Maybe that’s a new upload ? Backend can’t tell.

For that to work one would need a common request_id which is the same for all chunks of one file, but different for two upload actions.
I wonder how the other resumable.js backends do this. 