### PR TITLE
Nicer output on errors and fix 'expected' message

### DIFF
--- a/crossbar/controller/test/test_run.py
+++ b/crossbar/controller/test/test_run.py
@@ -112,11 +112,15 @@ class ContainerRunningTests(CLITestBase):
                  "--logformat=syslogd"],
                 reactor=reactor)
 
+        out = self.stdout.getvalue()
+        err = self.stderr.getvalue()
         for i in stdout_expected:
-            self.assertIn(i, self.stdout.getvalue())
+            if i not in out:
+                self.fail(u"Error: '{}' not in:\n{}".format(i, out))
 
         for i in stderr_expected:
-            self.assertIn(i, self.stderr.getvalue())
+            if i not in err:
+                self.fail(u"Error: '{}' not in:\n{}".format(i, err))
 
     def test_start_run(self):
         """


### PR DESCRIPTION
Python3 changes the error-message text somewhat versus python2