### PR TITLE
Fixes missing tracebacks for exceptions during class imports

### DIFF
--- a/crossbar/worker/__init__.py
+++ b/crossbar/worker/__init__.py
@@ -65,7 +65,7 @@ def _appsession_loader(config):
 
         except Exception as e:
             emsg = "Failed to import class '{}'\n{}".format(
-                klassname, Failure(e).getTraceback())
+                klassname, Failure().getTraceback())
             log.debug(emsg)
             log.debug("PYTHONPATH: {pythonpath}", pythonpath=sys.path)
             raise ApplicationError(
@@ -88,7 +88,7 @@ def _appsession_loader(config):
 
         except Exception as e:
             emsg = "Failed to import wamplet '{}/{}'\n{}".format(
-                dist, name, Failure(e).getTraceback())
+                dist, name, Failure().getTraceback())
             log.error(emsg)
             raise ApplicationError(u"crossbar.error.class_import_failed", emsg)
 

--- a/crossbar/worker/__init__.py
+++ b/crossbar/worker/__init__.py
@@ -63,7 +63,7 @@ def _appsession_loader(config):
                     u"crossbar.error.class_import_failed", "session not derived of ApplicationSession"
                 )
 
-        except Exception as e:
+        except Exception:
             emsg = "Failed to import class '{}'\n{}".format(
                 klassname, Failure().getTraceback())
             log.debug(emsg)
@@ -86,7 +86,7 @@ def _appsession_loader(config):
             component = pkg_resources.load_entry_point(
                 dist, 'autobahn.twisted.wamplet', name)
 
-        except Exception as e:
+        except Exception:
             emsg = "Failed to import wamplet '{}/{}'\n{}".format(
                 dist, name, Failure().getTraceback())
             log.error(emsg)


### PR DESCRIPTION
The default ctor of `Failure` automatically invokes `sys.exc_info()`, otherwise we would need to unpack `sys.exc_info()` and not only pass the exception object.

Maybe one should check whether this happens in other places as well.