### PR TITLE
Disable return of wildcard registrations until they can be fixed

### DIFF
--- a/crossbar/router/service.py
+++ b/crossbar/router/service.py
@@ -307,7 +307,7 @@ class RouterServiceSession(ApplicationSession):
                 registrations_prefix.append(registration.id)
 
         registrations_wildcard = []
-        # FIXME 
+        # FIXME
         # for registration in registration_map._observations_wildcard.values():
         #     if not is_protected_uri(registration.uri):
         #         registrations_wildcard.append(registration.id)

--- a/crossbar/router/service.py
+++ b/crossbar/router/service.py
@@ -307,7 +307,7 @@ class RouterServiceSession(ApplicationSession):
                 registrations_prefix.append(registration.id)
 
         registrations_wildcard = []
-		# FIXME 
+        # FIXME 
         # for registration in registration_map._observations_wildcard.values():
         #     if not is_protected_uri(registration.uri):
         #         registrations_wildcard.append(registration.id)

--- a/crossbar/router/service.py
+++ b/crossbar/router/service.py
@@ -307,9 +307,10 @@ class RouterServiceSession(ApplicationSession):
                 registrations_prefix.append(registration.id)
 
         registrations_wildcard = []
-        for registration in registration_map._observations_wildcard.values():
-            if not is_protected_uri(registration.uri):
-                registrations_wildcard.append(registration.id)
+		# FIXME 
+        # for registration in registration_map._observations_wildcard.values():
+        #     if not is_protected_uri(registration.uri):
+        #         registrations_wildcard.append(registration.id)
 
         return {
             'exact': registrations_exact,


### PR DESCRIPTION
Currently if the uncommented code is run it will raise when this RPC is called. This PR seeks to re-institute partial functionality of wamp.registration.list without implementing the listing of wildcard subscriptions.