### PR TITLE
Remove FilePath

### DIFF
--- a/crossbar/controller/process.py
+++ b/crossbar/controller/process.py
@@ -398,7 +398,7 @@ class NodeControllerSession(NativeProcessSession):
 
         # all native workers (routers and containers for now) start from the same script
         #
-        filename = os.path.join(crossbar.__file__, "..", "worker", "process.py")
+        filename = os.path.abspath(os.path.join(crossbar.__file__, "..", "worker", "process.py"))
 
         # assemble command line for forking the worker
         #

--- a/crossbar/controller/process.py
+++ b/crossbar/controller/process.py
@@ -42,7 +42,6 @@ from twisted.internet.error import ReactorNotRunning
 from twisted.internet.defer import Deferred, DeferredList, inlineCallbacks, returnValue
 from twisted.internet.error import ProcessExitedAlready
 from twisted.internet.threads import deferToThread
-from twisted.python.filepath import FilePath
 from twisted.python.runtime import platform
 
 from autobahn.util import utcnow, utcstr
@@ -399,7 +398,7 @@ class NodeControllerSession(NativeProcessSession):
 
         # all native workers (routers and containers for now) start from the same script
         #
-        filename = FilePath(crossbar.__file__).parent().child("worker").child("process.py").path
+        filename = os.path.join(crossbar.__file__, "..", "worker", "process.py")
 
         # assemble command line for forking the worker
         #

--- a/crossbar/controller/test/test_cli.py
+++ b/crossbar/controller/test/test_cli.py
@@ -32,7 +32,6 @@ from __future__ import absolute_import, division, print_function
 
 from six import StringIO as NativeStringIO
 
-from twisted.python.filepath import FilePath
 from twisted.internet.selectreactor import SelectReactor
 
 from crossbar.test import TestCase
@@ -222,14 +221,14 @@ class ConvertTests(CLITestBase):
         Running `crossbar convert` with an unknown config file produces an
         error.
         """
-        cbdir = FilePath(self.mktemp())
-        cbdir.makedirs()
-        config_file = cbdir.child("config.blah")
-        config_file.setContent(b'')
+        cbdir = self.mktemp()
+        os.makedirs(cbdir)
+        config_file = os.path.join(cbdir, "config.blah")
+        open(config_file, 'wb').close()
 
         with self.assertRaises(SystemExit) as e:
             cli.run("crossbar",
-                    ["convert", "--config={}".format(config_file.path)])
+                    ["convert", "--config={}".format(config_file)])
 
         self.assertEqual(e.exception.args[0], 1)
         self.assertIn(
@@ -241,10 +240,11 @@ class ConvertTests(CLITestBase):
         Running `crossbar convert` with a YAML config file will convert it to
         JSON.
         """
-        cbdir = FilePath(self.mktemp())
-        cbdir.makedirs()
-        config_file = cbdir.child("config.yaml")
-        config_file.setContent(b"""
+        cbdir = self.mktemp()
+        os.makedirs(cbdir)
+        config_file = os.path.join(cbdir, "config.yaml")
+        with open(config_file, 'w') as f:
+            f.write("""
 foo:
     bar: spam
     baz:
@@ -252,13 +252,13 @@ foo:
         """)
 
         cli.run("crossbar",
-                ["convert", "--config={}".format(config_file.path)])
+                ["convert", "--config={}".format(config_file)])
 
         self.assertIn(
             ("JSON formatted configuration written"),
             self.stdout.getvalue())
 
-        with open(cbdir.child("config.json").path) as f:
+        with open(os.path.join(cbdir, "config.json"), 'r') as f:
             self.assertEqual(f.read(), """{
    "foo": {
       "bar": "spam",
@@ -273,14 +273,15 @@ foo:
         Running `crossbar convert` with an invalid YAML config file will error
         saying it is invalid.
         """
-        cbdir = FilePath(self.mktemp())
-        cbdir.makedirs()
-        config_file = cbdir.child("config.yaml")
-        config_file.setContent(b"""{{{{{{{{""")
+        cbdir = self.mktemp()
+        os.makedirs(cbdir)
+        config_file = os.path.join(cbdir, "config.yaml")
+        with open(config_file, 'w') as f:
+            f.write("""{{{{{{{{""")
 
         with self.assertRaises(SystemExit) as e:
             cli.run("crossbar",
-                    ["convert", "--config={}".format(config_file.path)])
+                    ["convert", "--config={}".format(config_file)])
 
         self.assertEqual(e.exception.args[0], 1)
         self.assertIn(
@@ -292,10 +293,11 @@ foo:
         Running `crossbar convert` with a YAML config file will convert it to
         JSON.
         """
-        cbdir = FilePath(self.mktemp())
-        cbdir.makedirs()
-        config_file = cbdir.child("config.json")
-        config_file.setContent(b"""{
+        cbdir = self.mktemp()
+        os.makedirs(cbdir)
+        config_file = os.path.join(cbdir, "config.json")
+        with open(config_file, 'w') as f:
+            f.write("""{
    "foo": {
       "bar": "spam",
       "baz": {
@@ -305,13 +307,13 @@ foo:
 }""")
 
         cli.run("crossbar",
-                ["convert", "--config={}".format(config_file.path)])
+                ["convert", "--config={}".format(config_file)])
 
         self.assertIn(
             ("YAML formatted configuration written"),
             self.stdout.getvalue())
 
-        with open(cbdir.child("config.yaml").path) as f:
+        with open(os.path.join(cbdir, "config.yaml"), 'r') as f:
             self.assertEqual(f.read(), """foo:
   bar: spam
   baz:
@@ -323,14 +325,15 @@ foo:
         Running `crossbar convert` with an invalid JSON config file will error
         saying it is invalid.
         """
-        cbdir = FilePath(self.mktemp())
-        cbdir.makedirs()
-        config_file = cbdir.child("config.json")
-        config_file.setContent(b"""{{{{{{{{""")
+        cbdir = self.mktemp()
+        os.makedirs(cbdir)
+        config_file = os.path.join(cbdir, "config.json")
+        with open(config_file, 'w') as f:
+            f.write("""{{{{{{{{""")
 
         with self.assertRaises(SystemExit) as e:
             cli.run("crossbar",
-                    ["convert", "--config={}".format(config_file.path)])
+                    ["convert", "--config={}".format(config_file)])
 
         self.assertEqual(e.exception.args[0], 1)
         self.assertIn(

--- a/crossbar/controller/test/test_run.py
+++ b/crossbar/controller/test/test_run.py
@@ -36,7 +36,6 @@ import sys
 
 from six import PY3
 
-from twisted.python.filepath import FilePath
 from twisted.internet.selectreactor import SelectReactor
 from twisted.internet.task import LoopingCall
 
@@ -1234,13 +1233,13 @@ class InitTests(CLITestBase):
                 except:
                     pass
 
-        appdir = FilePath(self.mktemp())
-        cbdir = appdir.child(".crossbar")
+        appdir = self.mktemp()
+        cbdir = os.path.join(appdir, ".crossbar")
 
         reactor = SelectReactor()
         cli.run("crossbar",
                 ["init",
-                 "--appdir={}".format(appdir.path),
+                 "--appdir={}".format(appdir),
                  "--template=hello:python"],
                 reactor=reactor)
 

--- a/crossbar/twisted/test/test_resource.py
+++ b/crossbar/twisted/test/test_resource.py
@@ -36,8 +36,6 @@ from crossbar.adapter.rest.test import renderResource
 from crossbar.twisted.resource import FileUploadResource
 from crossbar.test import TestCase
 
-from twisted.python.filepath import FilePath
-
 from mock import Mock
 
 from .multipart import Multipart

--- a/crossbar/worker/router.py
+++ b/crossbar/worker/router.py
@@ -1110,7 +1110,7 @@ class RouterWorkerSession(NativeWorkerSession):
             if '/' in nested_paths:
                 nested_resource = self._create_resource(nested_paths['/'])
             else:
-                nested_resource = Resource()
+                nested_resource = Resource404(self._templates, b'')
 
             # nest subpaths under the current entry
             #

--- a/crossbar/worker/router.py
+++ b/crossbar/worker/router.py
@@ -82,8 +82,6 @@ from twisted.web.server import Site
 import twisted
 import crossbar
 
-from twisted.web.resource import Resource
-
 from crossbar.twisted.site import createHSTSRequestFactory
 
 from crossbar.twisted.resource import JsonResource, \

--- a/crossbar/worker/test/test_router.py
+++ b/crossbar/worker/test/test_router.py
@@ -357,11 +357,11 @@ class WSGITests(TestCase):
     skip = WSGI_TESTS
 
     def setUp(self):
-        self.cbdir = FilePath(self.mktemp())
-        self.cbdir.createDirectory()
+        self.cbdir = self.mktemp()
+        os.makedirs(self.cbdir)
         config_extras = DottableDict({"node": "testnode",
                                       "worker": "worker1",
-                                      "cbdir": self.cbdir.path})
+                                      "cbdir": self.cbdir})
         self.config = ComponentConfig("realm1", extra=config_extras)
 
     def test_basic(self):

--- a/crossbar/worker/test/test_router.py
+++ b/crossbar/worker/test/test_router.py
@@ -284,8 +284,8 @@ class WebTests(TestCase):
         config_extras = DottableDict({"node": u"testnode",
                                       "worker": u"worker1",
                                       "cbdir": self.cbdir.decode('utf8')
-                                               if not isinstance(self.cbdir, six.text_type)
-                                               else self.cbdir})
+                                      if not isinstance(self.cbdir, six.text_type)
+                                      else self.cbdir})
         self.config = ComponentConfig("realm1", extra=config_extras)
 
     def test_root_not_required(self):

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ install_requires = [
     'pynacl>=0.3.0',              # Apache license
 
     # HTTP/REST bridge (also pulls in TLS packages!)
-    'treq>=15.0.0',               # MIT license
+    'treq>=15.1.0',               # MIT license
 ]
 
 # FIXME: https://github.com/crossbario/crossbar/issues/581


### PR DESCRIPTION
This removes FilePath usage except where it's required by the Twisted API.

Refs #584 

cc @oberstet 