### PR TITLE
Improve error logging (#588)

### DIFF
--- a/crossbar/worker/container.py
+++ b/crossbar/worker/container.py
@@ -36,6 +36,7 @@ from datetime import datetime
 from twisted import internet
 from twisted.internet.defer import Deferred, DeferredList, inlineCallbacks
 from twisted.internet.defer import returnValue
+from twisted.python.failure import Failure
 
 from autobahn.util import utcstr
 from autobahn.wamp.exception import ApplicationError
@@ -190,9 +191,8 @@ class ContainerWorkerSession(NativeWorkerSession):
         try:
             create_component = _appsession_loader(config)
         except ApplicationError as e:
-            msg = e.args[0]
-            self.log.error("Component loading failed:\n\n{err}", err=msg)
-            if 'No module named' in msg:
+            self.log.error("Component loading failed", log_failure=Failure())
+            if 'No module named' in str(e):
                 self.log.error("  Python module search paths:")
                 for path in e.kwargs['pythonpath']:
                     self.log.error("    {path}", path=path)

--- a/crossbar/worker/router.py
+++ b/crossbar/worker/router.py
@@ -41,6 +41,7 @@ from datetime import datetime
 
 from twisted.internet.defer import Deferred, DeferredList
 from twisted.internet.defer import inlineCallbacks
+from twisted.python.failure import Failure
 from twisted.python.threadpool import ThreadPool
 
 from autobahn.util import utcstr
@@ -613,12 +614,17 @@ class RouterWorkerSession(NativeWorkerSession):
 
             # any exception spilling out from user code in onXXX handlers is fatal!
             def panic(fail, msg):
-                self.log.error("Fatal error in component: {} - {}".format(msg, fail.value))
+                self.log.error(
+                    "Fatal error in component: {msg} - {log_failure.value}",
+                    msg=msg, log_failure=fail
+                )
                 session.disconnect()
             session._swallow_error = panic
-        except Exception as e:
-            msg = "{}".format(e).strip()
-            self.log.error("Component instantiation failed:\n\n{err}", err=msg)
+        except Exception:
+            self.log.error(
+                "Component instantiation failed",
+                log_failure=Failure(),
+            )
             raise
 
         self.components[id] = RouterComponent(id, config, session)


### PR DESCRIPTION
This leverages the ``log_failure`` attribute to the error-logger to get nice stack traces on the fatal errors mentioned in #588. All ``crossbarexamples/containers/failures`` anti-examples run properly as does manual testing.