### PR TITLE
Supporting code for checking logs without asserting the rendered value

### DIFF
--- a/crossbar/_log_categories.py
+++ b/crossbar/_log_categories.py
@@ -38,12 +38,17 @@ log_categories = {
 
     # ARXXX - Adapter, REST Bridge
     "AR100": "REST bridge request recieved.",
+    "AR200": "REST bridge publish succeeded.",
     "AR400": "Malformed request to the REST bridge.",
     "AR405": "Method not accepted by the REST bridge.",
     "AR413": "Request too long.",
     "AR450": "Non-accepted request encoding.",
     "AR451": "Non-decodable request body.",
     "AR452": "Non-accepted content type.",
+    "AR453": "Request body was invalid JSON.",
+    "AR454": "Request body was valid JSON, but not well formed (incorrect type).",
+    "AR455": "Request body was valid JSON, but not well formed (missing key).",
+    "AR456": "REST bridge publish failed.",
 }
 
 

--- a/crossbar/_log_categories.py
+++ b/crossbar/_log_categories.py
@@ -39,8 +39,11 @@ log_categories = {
     # ARXXX - Adapter, REST Bridge
     "AR100": "REST bridge request recieved.",
     "AR400": "Malformed request to the REST bridge.",
-    "AR405": "REST bridge does not support that method.",
-
+    "AR405": "Method not accepted by the REST bridge.",
+    "AR413": "Request too long.",
+    "AR450": "Non-accepted request encoding.",
+    "AR451": "Non-decodable request body.",
+    "AR452": "Non-accepted content type.",
 }
 
 

--- a/crossbar/_log_categories.py
+++ b/crossbar/_log_categories.py
@@ -1,0 +1,47 @@
+#####################################################################################
+#
+#  Copyright (C) Tavendo GmbH
+#
+#  Unless a separate license agreement exists between you and Tavendo GmbH (e.g. you
+#  have purchased a commercial license), the license terms below apply.
+#
+#  Should you enter into a separate license agreement after having received a copy of
+#  this software, then the terms of such license agreement replace the terms below at
+#  the time at which such license agreement becomes effective.
+#
+#  In case a separate license agreement ends, and such agreement ends without being
+#  replaced by another separate license agreement, the license terms below apply
+#  from the time at which said agreement ends.
+#
+#  LICENSE TERMS
+#
+#  This program is free software: you can redistribute it and/or modify it under the
+#  terms of the GNU Affero General Public License, version 3, as published by the
+#  Free Software Foundation. This program is distributed in the hope that it will be
+#  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU Affero General Public License Version 3 for more details.
+#
+#  You should have received a copy of the GNU Affero General Public license along
+#  with this program. If not, see <http://www.gnu.org/licenses/agpl-3.0.en.html>.
+#
+#####################################################################################
+
+from __future__ import absolute_import, division, print_function
+
+# The log categories
+log_categories = {
+
+    # CBXXX - Generic Crossbar logs
+    "CB500": "Unhandled exception in Crossbar.",
+
+    # ARXXX - Adapter, REST Bridge
+    "AR100": "REST bridge request recieved.",
+    "AR400": "Malformed request to the REST bridge.",
+    "AR405": "REST bridge does not support that method.",
+
+}
+
+
+log_keys = log_categories.keys()

--- a/crossbar/_logging.py
+++ b/crossbar/_logging.py
@@ -493,8 +493,10 @@ class LogCapturer(object):
     A context manager that captures logs inside of it, and makes it available
     through the logs attribute, or the get_id method.
     """
-    def __init__(self):
+    def __init__(self, level="info"):
         self.logs = []
+        self._old_log_level = _loglevel
+        self.desired_level = level
 
     def get_id(self, identifier):
         """
@@ -503,8 +505,10 @@ class LogCapturer(object):
         return [x for x in self.logs if x.get("cb_log_id") == identifier]
 
     def __enter__(self):
+        set_global_log_level(self.desired_level)
         globalLogPublisher.addObserver(self.logs.append)
         return self
 
     def __exit__(self, type, value, traceback):
         globalLogPublisher.removeObserver(self.logs.append)
+        set_global_log_level(self._old_log_level)

--- a/crossbar/_logging.py
+++ b/crossbar/_logging.py
@@ -373,8 +373,8 @@ class CrossbarLogger(object):
             if isinstance(level, NamedConstant):
                 level = level.name
 
-            if "cb_log_id" in kwargs:
-                if kwargs["cb_log_id"] not in log_keys:
+            if "log_category" in kwargs:
+                if kwargs["log_category"] not in log_keys:
                     warnings.warn("Invalid log ID")
 
             if POSSIBLE_LEVELS.index(level) <= POSSIBLE_LEVELS.index(self._log_level):
@@ -491,18 +491,18 @@ class JSON(object):
 class LogCapturer(object):
     """
     A context manager that captures logs inside of it, and makes it available
-    through the logs attribute, or the get_id method.
+    through the logs attribute, or the get_category method.
     """
-    def __init__(self, level="info"):
+    def __init__(self, level="debug"):
         self.logs = []
         self._old_log_level = _loglevel
         self.desired_level = level
 
-    def get_id(self, identifier):
+    def get_category(self, identifier):
         """
-        Get logs captured with the given log ID.
+        Get logs captured with the given log category.
         """
-        return [x for x in self.logs if x.get("cb_log_id") == identifier]
+        return [x for x in self.logs if x.get("log_category") == identifier]
 
     def __enter__(self):
         set_global_log_level(self.desired_level)

--- a/crossbar/adapter/rest/common.py
+++ b/crossbar/adapter/rest/common.py
@@ -41,7 +41,6 @@ from netaddr.ip import IPAddress, IPNetwork
 
 from twisted.web import server
 from twisted.web.resource import Resource
-from twisted.internet.defer import maybeDeferred
 
 from autobahn.websocket.utf8validator import Utf8Validator
 _validator = Utf8Validator()

--- a/crossbar/adapter/rest/common.py
+++ b/crossbar/adapter/rest/common.py
@@ -96,8 +96,8 @@ class _CommonResource(Resource):
         """
         Called when client request is denied.
         """
-        if "cb_log_id" not in kwargs.keys():
-            kwargs["cb_log_id"] = "AR" + str(code)
+        if "log_category" not in kwargs.keys():
+            kwargs["log_category"] = "AR" + str(code)
 
         self.log.debug("[request denied] - {code} / " + reason,
                        code=code, **kwargs)
@@ -176,7 +176,7 @@ class _CommonResource(Resource):
                 return self._deny_request(
                     request, 400,
                     u"bad content type: if a content type is present, it MUST be one of '{}', not '{}'".format(list(_ALLOWED_CONTENT_TYPES), content_type_elements[0]),
-                    cb_log_id="AR452"
+                    log_category="AR452"
                 )
 
         encoding_parts = {}
@@ -200,7 +200,7 @@ class _CommonResource(Resource):
             except:
                 return self._deny_request(request, 400,
                                           u"mangled Content-Type header",
-                                          cb_log_id="AR450")
+                                          log_category="AR450")
 
         charset_encoding = encoding_parts.get("charset", "utf-8")
 
@@ -209,7 +209,7 @@ class _CommonResource(Resource):
                 request, 400,
                 (u"'{charset_encoding}' is not an accepted charset encoding, "
                  u"must be utf-8"),
-                cb_log_id="AR450",
+                log_category="AR450",
                 charset_encoding=charset_encoding)
 
         # enforce "post_body_limit"
@@ -358,7 +358,7 @@ class _CommonResource(Resource):
             return self._deny_request(
                 request, 400,
                 u"invalid request event - HTTP/POST|PUT body was invalid UTF-8",
-                cb_log_id="AR451")
+                log_category="AR451")
 
         event = body.decode('utf8')
 

--- a/crossbar/adapter/rest/common.py
+++ b/crossbar/adapter/rest/common.py
@@ -142,8 +142,7 @@ class _CommonResource(Resource):
                 else:
                     return self._render_request(request)
         except Exception as e:
-            self._deny_request(request, 500, "Unhandled server error.",
-                               exc=e)
+            return self._deny_request(request, 500, "Unhandled server error.", exc=e)
 
     def _render_request(self, request):
         """
@@ -176,7 +175,7 @@ class _CommonResource(Resource):
                content_type_elements[0] not in _ALLOWED_CONTENT_TYPES:
                 return self._deny_request(
                     request, 400,
-                    u"bad content type: if a content type is present, it MUST be one of '{}', not '{}'".format(_ALLOWED_CONTENT_TYPES, content_type_elements[0]),
+                    u"bad content type: if a content type is present, it MUST be one of '{}', not '{}'".format(list(_ALLOWED_CONTENT_TYPES), content_type_elements[0]),
                     cb_log_id="AR452"
                 )
 

--- a/crossbar/adapter/rest/test/test_common.py
+++ b/crossbar/adapter/rest/test/test_common.py
@@ -282,7 +282,7 @@ class RequestBodyTestCase(TestCase):
 
         self.assertEqual(request.code, 400)
 
-        errors = l.get_category("AR400")
+        errors = l.get_category("AR453")
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0]["code"], 400)
 
@@ -301,7 +301,7 @@ class RequestBodyTestCase(TestCase):
 
         self.assertEqual(request.code, 400)
 
-        errors = l.get_category("AR400")
+        errors = l.get_category("AR454")
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0]["code"], 400)
 

--- a/crossbar/adapter/rest/test/test_common.py
+++ b/crossbar/adapter/rest/test/test_common.py
@@ -31,7 +31,6 @@
 from __future__ import absolute_import
 
 from crossbar.test import TestCase
-from crossbar._compat import native_string
 from crossbar._logging import LogCapturer
 from crossbar.adapter.rest import PublisherResource
 from crossbar.adapter.rest.test import MockPublisherSession, renderResource
@@ -183,6 +182,8 @@ class RequestBodyTestCase(TestCase):
                 resource, b"/", method=b"POST",
                 headers={b"Content-Type": [b"application/text"]},
                 body=publishBody))
+
+        self.assertEqual(request.code, 400)
 
         errors = l.get_id("AR452")
         self.assertEqual(len(errors), 1)

--- a/crossbar/adapter/rest/test/test_common.py
+++ b/crossbar/adapter/rest/test/test_common.py
@@ -185,7 +185,7 @@ class RequestBodyTestCase(TestCase):
 
         self.assertEqual(request.code, 400)
 
-        errors = l.get_id("AR452")
+        errors = l.get_category("AR452")
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0]["code"], 400)
 
@@ -203,7 +203,7 @@ class RequestBodyTestCase(TestCase):
                 body=publishBody))
 
         self.assertEqual(request.code, 405)
-        errors = l.get_id("AR405")
+        errors = l.get_category("AR405")
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0]["code"], 405)
 
@@ -222,7 +222,7 @@ class RequestBodyTestCase(TestCase):
 
         self.assertEqual(request.code, 413)
 
-        errors = l.get_id("AR413")
+        errors = l.get_category("AR413")
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0]["code"], 413)
 
@@ -242,7 +242,7 @@ class RequestBodyTestCase(TestCase):
 
         self.assertEqual(request.code, 400)
 
-        errors = l.get_id("AR400")
+        errors = l.get_category("AR400")
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0]["code"], 400)
 
@@ -263,7 +263,7 @@ class RequestBodyTestCase(TestCase):
 
         self.assertEqual(request.code, 400)
 
-        errors = l.get_id("AR400")
+        errors = l.get_category("AR400")
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0]["code"], 400)
 
@@ -282,7 +282,7 @@ class RequestBodyTestCase(TestCase):
 
         self.assertEqual(request.code, 400)
 
-        errors = l.get_id("AR400")
+        errors = l.get_category("AR400")
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0]["code"], 400)
 
@@ -301,7 +301,7 @@ class RequestBodyTestCase(TestCase):
 
         self.assertEqual(request.code, 400)
 
-        errors = l.get_id("AR400")
+        errors = l.get_category("AR400")
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0]["code"], 400)
 
@@ -336,7 +336,7 @@ class RequestBodyTestCase(TestCase):
 
         self.assertEqual(request.code, 400)
 
-        errors = l.get_id("AR450")
+        errors = l.get_category("AR450")
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0]["code"], 400)
 
@@ -372,7 +372,7 @@ class RequestBodyTestCase(TestCase):
 
         self.assertEqual(request.code, 400)
 
-        errors = l.get_id("AR451")
+        errors = l.get_category("AR451")
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0]["code"], 400)
 
@@ -392,7 +392,7 @@ class RequestBodyTestCase(TestCase):
 
         self.assertEqual(request.code, 400)
 
-        errors = l.get_id("AR450")
+        errors = l.get_category("AR450")
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0]["code"], 400)
 
@@ -409,7 +409,7 @@ class RequestBodyTestCase(TestCase):
                 headers={b"Content-Type": [b"application/json;charset=blarg;charset=boo"]},
                 body=b'{"foo": "\xe2\x98\x83"}'))
 
-        errors = l.get_id("AR450")
+        errors = l.get_category("AR450")
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0]["code"], 400)
 
@@ -423,6 +423,6 @@ class RequestBodyTestCase(TestCase):
 
         self.assertEqual(request.code, 400)
 
-        errors = l.get_id("AR452")
+        errors = l.get_category("AR452")
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0]["code"], 400)

--- a/crossbar/adapter/rest/test/test_common.py
+++ b/crossbar/adapter/rest/test/test_common.py
@@ -32,6 +32,7 @@ from __future__ import absolute_import
 
 from crossbar.test import TestCase
 from crossbar._compat import native_string
+from crossbar._logging import LogCapturer
 from crossbar.adapter.rest import PublisherResource
 from crossbar.adapter.rest.test import MockPublisherSession, renderResource
 
@@ -138,25 +139,6 @@ class RequestBodyTestCase(TestCase):
     """
     Unit tests for the body validation parts of L{_CommonResource}.
     """
-
-    skip = True
-
-    def test_empty_content_type(self):
-        """
-        A request lacking a content-type header will be rejected.
-        """
-        session = MockPublisherSession(self)
-        resource = PublisherResource({}, session)
-
-        request = self.successResultOf(renderResource(
-            resource, b"/", method=b"POST", headers={},
-            body=publishBody))
-
-        self.assertEqual(request.code, 400)
-        self.assertEqual((b"bad or missing content type, "
-                          b"should be 'application/json'\n"),
-                         request.get_written_data())
-
     def test_allow_charset_in_content_type(self):
         """
         A charset in the content-type will be allowed.
@@ -196,14 +178,15 @@ class RequestBodyTestCase(TestCase):
         session = MockPublisherSession(self)
         resource = PublisherResource({}, session)
 
-        request = self.successResultOf(renderResource(
-            resource, b"/", method=b"POST",
-            headers={b"Content-Type": [b"application/text"]},
-            body=publishBody))
+        with LogCapturer("debug") as l:
+            request = self.successResultOf(renderResource(
+                resource, b"/", method=b"POST",
+                headers={b"Content-Type": [b"application/text"]},
+                body=publishBody))
 
-        self.assertEqual(request.code, 400)
-        self.assertIn(b"bad or missing content type",
-                      request.get_written_data())
+        errors = l.get_id("AR452")
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["code"], 400)
 
     def test_bad_method(self):
         """
@@ -212,14 +195,16 @@ class RequestBodyTestCase(TestCase):
         session = MockPublisherSession(self)
         resource = PublisherResource({}, session)
 
-        request = self.successResultOf(renderResource(
-            resource, b"/", method=b"PUT",
-            headers={b"Content-Type": [b"application/json"]},
-            body=publishBody))
+        with LogCapturer("debug") as l:
+            request = self.successResultOf(renderResource(
+                resource, b"/", method=b"BLBLBLB",
+                headers={b"Content-Type": [b"application/json"]},
+                body=publishBody))
 
         self.assertEqual(request.code, 405)
-        self.assertIn(b"HTTP/PUT not allowed",
-                      request.get_written_data())
+        errors = l.get_id("AR405")
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["code"], 405)
 
     def test_too_large_body(self):
         """
@@ -228,14 +213,17 @@ class RequestBodyTestCase(TestCase):
         session = MockPublisherSession(self)
         resource = PublisherResource({"post_body_limit": 1}, session)
 
-        request = self.successResultOf(renderResource(
-            resource, b"/", method=b"POST",
-            headers={b"Content-Type": [b"application/json"]},
-            body=publishBody))
+        with LogCapturer("debug") as l:
+            request = self.successResultOf(renderResource(
+                resource, b"/", method=b"POST",
+                headers={b"Content-Type": [b"application/json"]},
+                body=publishBody))
 
-        self.assertEqual(request.code, 400)
-        self.assertIn("HTTP/POST body length ({}) exceeds maximum ({})".format(len(publishBody), 1),
-                      native_string(request.get_written_data()))
+        self.assertEqual(request.code, 413)
+
+        errors = l.get_id("AR413")
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["code"], 413)
 
     def test_multiple_content_length(self):
         """
@@ -244,15 +232,18 @@ class RequestBodyTestCase(TestCase):
         session = MockPublisherSession(self)
         resource = PublisherResource({}, session)
 
-        request = self.successResultOf(renderResource(
-            resource, b"/", method=b"POST",
-            headers={b"Content-Type": [b"application/json"],
-                     b"Content-Length": ["1", "10"]},
-            body=publishBody))
+        with LogCapturer("debug") as l:
+            request = self.successResultOf(renderResource(
+                resource, b"/", method=b"POST",
+                headers={b"Content-Type": [b"application/json"],
+                         b"Content-Length": ["1", "10"]},
+                body=publishBody))
 
         self.assertEqual(request.code, 400)
-        self.assertIn("Multiple Content-Length headers are not allowed",
-                      native_string(request.get_written_data()))
+
+        errors = l.get_id("AR400")
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["code"], 400)
 
     def test_not_matching_bodylength(self):
         """
@@ -262,15 +253,18 @@ class RequestBodyTestCase(TestCase):
         session = MockPublisherSession(self)
         resource = PublisherResource({"post_body_limit": 1}, session)
 
-        request = self.successResultOf(renderResource(
-            resource, b"/", method=b"POST",
-            headers={b"Content-Type": [b"application/json"],
-                     b"Content-Length": [1]},
-            body=publishBody))
+        with LogCapturer("debug") as l:
+            request = self.successResultOf(renderResource(
+                resource, b"/", method=b"POST",
+                headers={b"Content-Type": [b"application/json"],
+                         b"Content-Length": [1]},
+                body=publishBody))
 
         self.assertEqual(request.code, 400)
-        self.assertIn("HTTP/POST body length ({}) is different to Content-Length ({})".format(len(publishBody), 1),
-                      native_string(request.get_written_data()))
+
+        errors = l.get_id("AR400")
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["code"], 400)
 
     def test_invalid_JSON_body(self):
         """
@@ -279,14 +273,17 @@ class RequestBodyTestCase(TestCase):
         session = MockPublisherSession(self)
         resource = PublisherResource({}, session)
 
-        request = self.successResultOf(renderResource(
-            resource, b"/", method=b"POST",
-            headers={b"Content-Type": [b"application/json"]},
-            body=b"sometext"))
+        with LogCapturer("debug") as l:
+            request = self.successResultOf(renderResource(
+                resource, b"/", method=b"POST",
+                headers={b"Content-Type": [b"application/json"]},
+                body=b"sometext"))
 
         self.assertEqual(request.code, 400)
-        self.assertIn(b"invalid request event - HTTP/POST body must be valid JSON:",
-                      request.get_written_data())
+
+        errors = l.get_id("AR400")
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["code"], 400)
 
     def test_JSON_list_body(self):
         """
@@ -295,15 +292,17 @@ class RequestBodyTestCase(TestCase):
         session = MockPublisherSession(self)
         resource = PublisherResource({}, session)
 
-        request = self.successResultOf(renderResource(
-            resource, b"/", method=b"POST",
-            headers={b"Content-Type": [b"application/json"]},
-            body=b"[{},{}]"))
+        with LogCapturer("debug") as l:
+            request = self.successResultOf(renderResource(
+                resource, b"/", method=b"POST",
+                headers={b"Content-Type": [b"application/json"]},
+                body=b"[{},{}]"))
 
         self.assertEqual(request.code, 400)
-        self.assertIn(
-            b"invalid request event - HTTP/POST body must be a JSON dict",
-            request.get_written_data())
+
+        errors = l.get_id("AR400")
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["code"], 400)
 
     def test_UTF8_assumption(self):
         """
@@ -328,15 +327,17 @@ class RequestBodyTestCase(TestCase):
         session = MockPublisherSession(self)
         resource = PublisherResource({}, session)
 
-        request = self.successResultOf(renderResource(
-            resource, b"/", method=b"POST",
-            headers={b"Content-Type": [b"application/json; charset=ascii"]},
-            body=b''))
+        with LogCapturer("debug") as l:
+            request = self.successResultOf(renderResource(
+                resource, b"/", method=b"POST",
+                headers={b"Content-Type": [b"application/json; charset=ascii"]},
+                body=b''))
 
         self.assertEqual(request.code, 400)
-        self.assertIn((b"'ascii' is not an accepted charset encoding, must be "
-                       b"utf-8"),
-                      request.get_written_data())
+
+        errors = l.get_id("AR450")
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["code"], 400)
 
     def test_decodes_UTF8(self):
         """
@@ -362,15 +363,17 @@ class RequestBodyTestCase(TestCase):
         session = MockPublisherSession(self)
         resource = PublisherResource({}, session)
 
-        request = self.successResultOf(renderResource(
-            resource, b"/", method=b"POST",
-            headers={b"Content-Type": [b"application/json;charset=utf-8"]},
-            body=b'{"topic": "com.test.messages", "args": ["\x61\x62\x63\xe9"]}'))
+        with LogCapturer("debug") as l:
+            request = self.successResultOf(renderResource(
+                resource, b"/", method=b"POST",
+                headers={b"Content-Type": [b"application/json;charset=utf-8"]},
+                body=b'{"topic": "com.test.messages", "args": ["\x61\x62\x63\xe9"]}'))
 
         self.assertEqual(request.code, 400)
-        self.assertEqual(
-            (b"invalid request event - HTTP/POST body was invalid UTF-8\n"),
-            request.get_written_data())
+
+        errors = l.get_id("AR451")
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["code"], 400)
 
     def test_unknown_encoding(self):
         """
@@ -380,15 +383,17 @@ class RequestBodyTestCase(TestCase):
         session = MockPublisherSession(self)
         resource = PublisherResource({}, session)
 
-        request = self.successResultOf(renderResource(
-            resource, b"/", method=b"POST",
-            headers={b"Content-Type": [b"application/json;charset=blarg"]},
-            body=b'{"args": ["\x61\x62\x63\xe9"]}'))
+        with LogCapturer("debug") as l:
+            request = self.successResultOf(renderResource(
+                resource, b"/", method=b"POST",
+                headers={b"Content-Type": [b"application/json;charset=blarg"]},
+                body=b'{"args": ["\x61\x62\x63\xe9"]}'))
 
         self.assertEqual(request.code, 400)
-        self.assertEqual(
-            (b"'blarg' is not an accepted charset encoding, must be utf-8\n"),
-            request.get_written_data())
+
+        errors = l.get_id("AR450")
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["code"], 400)
 
     def test_broken_contenttype(self):
         """
@@ -397,22 +402,26 @@ class RequestBodyTestCase(TestCase):
         session = MockPublisherSession(self)
         resource = PublisherResource({}, session)
 
-        request = self.successResultOf(renderResource(
-            resource, b"/", method=b"POST",
-            headers={b"Content-Type": [b"application/json;charset=blarg;charset=boo"]},
-            body=b'{"foo": "\xe2\x98\x83"}'))
+        with LogCapturer("debug") as l:
+            request = self.successResultOf(renderResource(
+                resource, b"/", method=b"POST",
+                headers={b"Content-Type": [b"application/json;charset=blarg;charset=boo"]},
+                body=b'{"foo": "\xe2\x98\x83"}'))
+
+        errors = l.get_id("AR450")
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["code"], 400)
+
+        del l
+
+        with LogCapturer("debug") as l:
+            request = self.successResultOf(renderResource(
+                resource, b"/", method=b"POST",
+                headers={b"Content-Type": [b"charset=blarg;application/json"]},
+                body=b'{"foo": "\xe2\x98\x83"}'))
 
         self.assertEqual(request.code, 400)
-        self.assertEqual(
-            b"mangled Content-Type header\n",
-            request.get_written_data())
 
-        request = self.successResultOf(renderResource(
-            resource, b"/", method=b"POST",
-            headers={b"Content-Type": [b"charset=blarg;application/json"]},
-            body=b'{"foo": "\xe2\x98\x83"}'))
-
-        self.assertEqual(request.code, 400)
-        self.assertEqual(
-            b"bad or missing content type, should be 'application/json'\n",
-            request.get_written_data())
+        errors = l.get_id("AR452")
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["code"], 400)

--- a/crossbar/test/test_logger.py
+++ b/crossbar/test/test_logger.py
@@ -401,3 +401,19 @@ class StdoutObserverTests(TestCase):
 
         result = stream.getvalue()
         self.assertEqual(result[:-1], "[foo] Hi there!")
+
+
+class LogCapturerTests(TestCase):
+
+    def test_capturer(self):
+        """
+        The log capturer is a context manager that captures the logs emitted
+        inside it.
+        """
+        log = _logging.make_logger("info")
+
+        with _logging.LogCapturer() as l:
+            log.info("Whee!", cb_log_id="CB500", foo="bar")
+
+        self.assertEqual(len(l.get_id("CB500")), 1)
+        self.assertEqual(l.get_id("CB500")[0]["foo"], "bar")

--- a/crossbar/test/test_logger.py
+++ b/crossbar/test/test_logger.py
@@ -413,7 +413,7 @@ class LogCapturerTests(TestCase):
         log = _logging.make_logger("info")
 
         with _logging.LogCapturer() as l:
-            log.info("Whee!", cb_log_id="CB500", foo="bar")
+            log.info("Whee!", log_category="CB500", foo="bar")
 
-        self.assertEqual(len(l.get_id("CB500")), 1)
-        self.assertEqual(l.get_id("CB500")[0]["foo"], "bar")
+        self.assertEqual(len(l.get_category("CB500")), 1)
+        self.assertEqual(l.get_category("CB500")[0]["foo"], "bar")


### PR DESCRIPTION
cc @oberstet @meejah 

As a proof of concept, I modified the `test_common` tests to use something that might line up with what both of you mentioned -- including a nicer way of capturing logs.

This puts the log cateories and their general meanings in `_log_categories.py` -- the idea behind this is that this could be pulled out in docs generation, or something.

Thoughts?