### PR TITLE
pass fail as simple argument, not as keyword arg

### DIFF
--- a/crossbar/router/session.py
+++ b/crossbar/router/session.py
@@ -513,7 +513,7 @@ class RouterSession(BaseSession):
 
         DO NOT attach to Deferreds that are returned to calling code.
         """
-        self.log.failure("Internal error (2): {log_failure.value}", log_failure=fail)
+        self.log.failure("Internal error (2): {log_failure.value}", fail)
 
         # tell other side we're done
         reply = message.Abort(u"wamp.error.authorization_failed", u"Internal server error")


### PR DESCRIPTION
Otherwise logging itself will fail with:

```
  File "/usr/local/lib/python2.7/site-packages/crossbar/router/session.py", line 477, in _swallow_error_and_abort
    self.log.failure("Internal error (2): {log_failure.value}", log_failure=fail)
  File "/usr/local/lib/python2.7/site-packages/crossbar/_logging.py", line 362, in failure
    return self.logger.failure(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/twisted/logger/_logger.py", line 178, in failure
    self.emit(level, format, log_failure=failure, **kwargs)
exceptions.TypeError: emit() got multiple values for keyword argument 'log_failure'
```