### PR TITLE
Support turning on/off coloured logging

### DIFF
--- a/crossbar/_logging.py
+++ b/crossbar/_logging.py
@@ -331,14 +331,16 @@ def make_logfile_observer(path, show_source=False):
         if event.get("log_format", None) is not None:
             eventText = formatEvent(event)
         else:
-            eventText = ""
+            eventText = u""
 
         if "log_failure" in event:
             # This is a traceback. Print it.
             eventText = eventText + event["log_failure"].getTraceback()
 
-        eventString = NOCOLOUR_FORMAT.format(
-            formatTime(event["log_time"]), logSystem, eventText) + os.linesep
+        eventString = strip_ansi(STANDARD_FORMAT.format(
+            startcolour=u'', time=formatTime(event["log_time"]),
+            system=logSystem, endcolour=u'',
+            text=eventText)) + os.linesep
 
         return eventString
 

--- a/crossbar/_logging.py
+++ b/crossbar/_logging.py
@@ -99,9 +99,9 @@ except ImportError:
         LIGHTWHITE_EX = ""
     Fore = _Fore()
 
-COLOUR_FORMAT = u"{}{} [{}]{} {}"
-NOCOLOUR_FORMAT = u"{} [{}] {}"
-SYSLOGD_FORMAT = u"[{}] {}"
+STANDARD_FORMAT = u"{startcolour}{time} [{system}]{endcolour} {text}"
+SYSLOGD_FORMAT = u"{startcolour}[{system}]{endcolour} {text}"
+NONE_FORMAT = u"{text}"
 
 POSSIBLE_LEVELS = ["none", "critical", "error", "warn", "info", "debug",
                    "trace"]
@@ -109,12 +109,6 @@ REAL_LEVELS = ["critical", "error", "warn", "info", "debug"]
 
 # Sanity check
 assert set(REAL_LEVELS).issubset(set(POSSIBLE_LEVELS))
-
-# Make our own copies of stdout and stderr, for printing to later
-# When we start logging, the logger will capture all outputs to the *new*
-# sys.stderr and sys.stdout. As we're printing to it, it'll get caught in an
-# infinite loop -- which we don't want.
-_stderr, _stdout = sys.stderr, sys.stdout
 
 # A regex that matches ANSI escape sequences
 # http://stackoverflow.com/a/33925425
@@ -136,13 +130,13 @@ def escape_formatting(text):
 
 
 def make_stdout_observer(levels=(LogLevel.info, LogLevel.debug),
-                         show_source=False, format="colour", trace=False,
-                         _file=None):
+                         show_source=False, format="standard", trace=False,
+                         colour=False, _file=None):
     """
     Create an observer which prints logs to L{sys.stdout}.
     """
     if _file is None:
-        _file = _stdout
+        _file = sys.__stdout__
 
     @provider(ILogObserver)
     def StandardOutObserver(event):
@@ -158,7 +152,16 @@ def make_stdout_observer(levels=(LogLevel.info, LogLevel.debug),
         if show_source and event.get("log_namespace") is not None:
             logSystem += " " + event.get("cb_namespace", event.get("log_namespace", ''))
 
-        if format == "colour":
+        if format == "standard":
+            FORMAT_STRING = STANDARD_FORMAT
+        elif format == "syslogd":
+            FORMAT_STRING = SYSLOGD_FORMAT
+        elif format == "none":
+            FORMAT_STRING = NONE_FORMAT
+        else:
+            assert False
+
+        if colour:
             # Choose a colour depending on where the log came from.
             if "Controller" in logSystem:
                 fore = Fore.BLUE
@@ -169,21 +172,15 @@ def make_stdout_observer(levels=(LogLevel.info, LogLevel.debug),
             else:
                 fore = Fore.WHITE
 
-            eventString = COLOUR_FORMAT.format(
-                fore, formatTime(event["log_time"]), logSystem, Fore.RESET,
-                formatEvent(event))
-        elif format == "nocolour":
-            eventString = NOCOLOUR_FORMAT.format(
-                formatTime(event["log_time"]), logSystem, formatEvent(event))
-        elif format == "syslogd":
-            eventString = SYSLOGD_FORMAT.format(logSystem, formatEvent(event))
-        elif format == "none":
-            eventString = formatEvent(event)
+            eventString = FORMAT_STRING.format(
+                startcolour=fore, time=formatTime(event["log_time"]),
+                system=logSystem, endcolour=Fore.RESET,
+                text=formatEvent(event))
         else:
-            assert False
-
-        if not format == "colour":
-            eventString = strip_ansi(eventString)
+            eventString = strip_ansi(FORMAT_STRING.format(
+                startcolour=u'', time=formatTime(event["log_time"]),
+                system=logSystem, endcolour=u'',
+                text=formatEvent(event)))
 
         print(eventString, file=_file)
 
@@ -192,13 +189,13 @@ def make_stdout_observer(levels=(LogLevel.info, LogLevel.debug),
 
 def make_stderr_observer(levels=(LogLevel.warn, LogLevel.error,
                                  LogLevel.critical),
-                         show_source=False, format="colour",
-                         _file=None):
+                         show_source=False, format="standard",
+                         colour=False, _file=None):
     """
     Create an observer which prints logs to L{sys.stderr}.
     """
     if _file is None:
-        _file = _stderr
+        _file = sys.__stderr__
 
     @provider(ILogObserver)
     def StandardErrorObserver(event):
@@ -217,29 +214,34 @@ def make_stderr_observer(levels=(LogLevel.warn, LogLevel.error,
         if event.get("log_format", None) is not None:
             eventText = formatEvent(event)
         else:
-            eventText = ""
+            eventText = u""
 
         if "log_failure" in event:
             # This is a traceback. Print it.
             eventText = eventText + event["log_failure"].getTraceback()
 
-        if format == "colour":
-            # Errors are always red, no matter the system they came from.
-            eventString = COLOUR_FORMAT.format(
-                Fore.RED, formatTime(event["log_time"]), logSystem, Fore.RESET,
-                eventText)
-        elif format == "nocolour":
-            eventString = NOCOLOUR_FORMAT.format(
-                formatTime(event["log_time"]), logSystem, eventText)
+        if format == "standard":
+            FORMAT_STRING = STANDARD_FORMAT
         elif format == "syslogd":
-            eventString = SYSLOGD_FORMAT.format(logSystem, eventText)
+            FORMAT_STRING = SYSLOGD_FORMAT
         elif format == "none":
-            eventString = formatEvent(event)
+            FORMAT_STRING = NONE_FORMAT
         else:
             assert False
 
-        if not format == "colour":
-            eventString = strip_ansi(eventString)
+        if colour:
+            # Errors are always red.
+            fore = Fore.RED
+
+            eventString = FORMAT_STRING.format(
+                startcolour=fore, time=formatTime(event["log_time"]),
+                system=logSystem, endcolour=Fore.RESET,
+                text=formatEvent(event))
+        else:
+            eventString = strip_ansi(FORMAT_STRING.format(
+                startcolour=u'', time=formatTime(event["log_time"]),
+                system=logSystem, endcolour=u'',
+                text=formatEvent(event)))
 
         print(eventString, file=_file)
 

--- a/crossbar/controller/cli.py
+++ b/crossbar/controller/cli.py
@@ -570,7 +570,8 @@ def run_command_start(options, reactor=None):
     # bannerFormat = "{:<18} {:<24}"
     bannerFormat = "    {} {}"
     log.info(bannerFormat.format("Crossbar.io Version:", click.style(crossbar.__version__, fg='yellow', bold=True)))
-    log.info(bannerFormat.format("Node Public Key:", click.style(pubkey, fg='yellow', bold=True)))
+    if pubkey:
+        log.info(bannerFormat.format("Node Public Key:", click.style(pubkey, fg='yellow', bold=True)))
     log.info()
 
     log.info("Running from node directory '{cbdir}'", cbdir=options.cbdir)

--- a/crossbar/controller/cli.py
+++ b/crossbar/controller/cli.py
@@ -806,8 +806,8 @@ def run(prog=None, args=None, reactor=None):
                               type=six.text_type,
                               default='standard',
                               choices=['syslogd', 'standard', 'none'],
-                              help="The format of the logs -- suitable for syslogd, not coloured, or coloured.")
-
+                              help=("The format of the logs -- suitable for "
+                                    "syslogd, not coloured, or coloured."))
 
     # "stop" command
     #

--- a/crossbar/router/session.py
+++ b/crossbar/router/session.py
@@ -51,7 +51,12 @@ from autobahn.wamp.interfaces import ITransportHandler
 from crossbar._logging import make_logger
 from crossbar.twisted.endpoint import extract_peer_certificate
 from crossbar.router.auth import PendingAuthWampCra, PendingAuthTicket
-from crossbar.router.auth import AUTHMETHODS, AUTHMETHOD_MAP, PendingAuthCryptosign
+from crossbar.router.auth import AUTHMETHODS, AUTHMETHOD_MAP
+
+try:
+    from crossbar.router.auth import PendingAuthCryptosign
+except ImportError:
+    PendingAuthCryptosign = None
 
 
 __all__ = ('RouterSessionFactory',)

--- a/crossbar/test/test_logger.py
+++ b/crossbar/test/test_logger.py
@@ -365,14 +365,14 @@ class StdoutObserverTests(TestCase):
         result = stream.getvalue()
         self.assertIn(u"[foo]", result)
 
-    def test_output_nocolour(self):
+    def test_output_standard(self):
         """
         The output format is the time, the system in square brackets, and the
         message.
         """
         stream = NativeStringIO()
         observer = _logging.make_stdout_observer(_file=stream,
-                                                 format="nocolour")
+                                                 format="standard")
         event = {'log_level': LogLevel.info,
                  'log_namespace': 'crossbar.test.test_logger.StdoutObserverTests',
                  'log_source': None, 'log_format': 'Hi there!',

--- a/crossbar/worker/process.py
+++ b/crossbar/worker/process.py
@@ -31,7 +31,6 @@
 from __future__ import absolute_import, print_function
 
 import six
-import sys
 
 from twisted.internet.error import ReactorNotRunning
 

--- a/crossbar/worker/process.py
+++ b/crossbar/worker/process.py
@@ -31,6 +31,7 @@
 from __future__ import absolute_import, print_function
 
 import six
+import sys
 
 from twisted.internet.error import ReactorNotRunning
 
@@ -109,7 +110,7 @@ def run():
 
     # make sure logging to something else than stdio is setup _first_
     #
-    from crossbar._logging import make_JSON_observer, cb_logging_aware, _stderr
+    from crossbar._logging import make_JSON_observer, cb_logging_aware
     from crossbar._logging import make_logger, start_logging, set_global_log_level
     from twisted.logger import globalLogPublisher
 
@@ -120,10 +121,10 @@ def run():
 
     # Print a magic phrase that tells the capturing logger that it supports
     # Crossbar's rich logging
-    print(cb_logging_aware, file=_stderr)
-    _stderr.flush()
+    print(cb_logging_aware, file=sys.__stderr__)
+    sys.__stderr__.flush()
 
-    flo = make_JSON_observer(_stderr)
+    flo = make_JSON_observer(sys.__stderr__)
     globalLogPublisher.addObserver(flo)
     start_logging()
 


### PR DESCRIPTION
This fixes #600, and makes the split between format and colouring nicer. It also makes piping to a file better, as it'll automatically disable colouring.