### PR TITLE
Add shared registrations balanced mode

### DIFF
--- a/crossbar/controller/cli.py
+++ b/crossbar/controller/cli.py
@@ -198,7 +198,7 @@ def run_command_version(options, reactor=None, **kwargs):
     Subcommand "crossbar version".
     """
     log = make_logger()
-    verbose = True
+    # verbose = True
 
     # Python
     py_ver = '.'.join([str(x) for x in list(sys.version_info[:3])])

--- a/crossbar/router/dealer.py
+++ b/crossbar/router/dealer.py
@@ -1,4 +1,4 @@
-##########################################################################
+#####################################################################################
 #
 #  Copyright (C) Tavendo GmbH
 #
@@ -26,7 +26,7 @@
 #  You should have received a copy of the GNU Affero General Public license along
 #  with this program. If not, see <http://www.gnu.org/licenses/agpl-3.0.en.html>.
 #
-##########################################################################
+#####################################################################################
 
 from __future__ import absolute_import
 
@@ -117,8 +117,7 @@ class Dealer(object):
         if session not in self._session_to_registrations:
             self._session_to_registrations[session] = set()
         else:
-            raise Exception(
-                "session with ID {} already attached".format(session._session_id))
+            raise Exception("session with ID {} already attached".format(session._session_id))
 
     def detach(self, session):
         """
@@ -128,8 +127,7 @@ class Dealer(object):
 
             for registration in self._session_to_registrations[session]:
 
-                was_registered, was_last_callee = self._registration_map.drop_observer(
-                    session, registration)
+                was_registered, was_last_callee = self._registration_map.drop_observer(session, registration)
 
                 # publish WAMP meta events
                 #
@@ -137,17 +135,14 @@ class Dealer(object):
                     service_session = self._router._realm.session
                     if service_session and not registration.uri.startswith(u'wamp.'):
                         if was_registered:
-                            service_session.publish(
-                                u'wamp.registration.on_unregister', session._session_id, registration.id)
+                            service_session.publish(u'wamp.registration.on_unregister', session._session_id, registration.id)
                         if was_last_callee:
-                            service_session.publish(
-                                u'wamp.registration.on_delete', session._session_id, registration.id)
+                            service_session.publish(u'wamp.registration.on_delete', session._session_id, registration.id)
 
             del self._session_to_registrations[session]
 
         else:
-            raise Exception(
-                u"session with ID {} not attached".format(session._session_id))
+            raise Exception(u"session with ID {} not attached".format(session._session_id))
 
     def processRegister(self, session, register):
         """
@@ -160,18 +155,15 @@ class Dealer(object):
             if register.match == u"wildcard":
                 uri_is_valid = _URI_PAT_STRICT_EMPTY.match(register.procedure)
             else:
-                uri_is_valid = _URI_PAT_STRICT_NON_EMPTY.match(
-                    register.procedure)
+                uri_is_valid = _URI_PAT_STRICT_NON_EMPTY.match(register.procedure)
         else:
             if register.match == u"wildcard":
                 uri_is_valid = _URI_PAT_LOOSE_EMPTY.match(register.procedure)
             else:
-                uri_is_valid = _URI_PAT_LOOSE_NON_EMPTY.match(
-                    register.procedure)
+                uri_is_valid = _URI_PAT_LOOSE_NON_EMPTY.match(register.procedure)
 
         if not uri_is_valid:
-            reply = message.Error(message.Register.MESSAGE_TYPE, register.request, ApplicationError.INVALID_URI, [
-                                  u"register for invalid procedure URI '{0}' (URI strict checking {1})".format(register.procedure, self._option_uri_strict)])
+            reply = message.Error(message.Register.MESSAGE_TYPE, register.request, ApplicationError.INVALID_URI, [u"register for invalid procedure URI '{0}' (URI strict checking {1})".format(register.procedure, self._option_uri_strict)])
             self._router.send(session, reply)
             return
 
@@ -179,26 +171,22 @@ class Dealer(object):
         # trusted sessions (that are sessions built into Crossbar.io)
         #
         if session._authrole is not None and session._authrole != u"trusted":
-            is_restricted = register.procedure.startswith(
-                u"wamp.") or register.procedure.startswith(u"crossbar.")
+            is_restricted = register.procedure.startswith(u"wamp.") or register.procedure.startswith(u"crossbar.")
             if is_restricted:
-                reply = message.Error(message.Register.MESSAGE_TYPE, register.request, ApplicationError.INVALID_URI, [
-                                      u"register for restricted procedure URI '{0}')".format(register.procedure)])
+                reply = message.Error(message.Register.MESSAGE_TYPE, register.request, ApplicationError.INVALID_URI, [u"register for restricted procedure URI '{0}')".format(register.procedure)])
                 self._router.send(session, reply)
                 return
 
         # get existing registration for procedure / matching strategy - if any
         #
-        registration = self._registration_map.get_observation(
-            register.procedure, register.match)
+        registration = self._registration_map.get_observation(register.procedure, register.match)
         if registration:
 
             # there is an existing registration, and that has an invocation strategy that only allows a single callee
             # on a the given registration
             #
             if registration.extra.invoke == message.Register.INVOKE_SINGLE:
-                reply = message.Error(message.Register.MESSAGE_TYPE, register.request, ApplicationError.PROCEDURE_ALREADY_EXISTS, [
-                                      u"register for already registered procedure '{0}'".format(register.procedure)])
+                reply = message.Error(message.Register.MESSAGE_TYPE, register.request, ApplicationError.PROCEDURE_ALREADY_EXISTS, [u"register for already registered procedure '{0}'".format(register.procedure)])
                 self._router.send(session, reply)
                 return
 
@@ -206,8 +194,7 @@ class Dealer(object):
             # requested by the new callee
             #
             if registration.extra.invoke != register.invoke:
-                reply = message.Error(message.Register.MESSAGE_TYPE, register.request, ApplicationError.PROCEDURE_EXISTS_INVOCATION_POLICY_CONFLICT, [
-                                      u"register for already registered procedure '{0}' with conflicting invocation policy (has {1} and {2} was requested)".format(register.procedure, registration.extra.invoke, register.invoke)])
+                reply = message.Error(message.Register.MESSAGE_TYPE, register.request, ApplicationError.PROCEDURE_EXISTS_INVOCATION_POLICY_CONFLICT, [u"register for already registered procedure '{0}' with conflicting invocation policy (has {1} and {2} was requested)".format(register.procedure, registration.extra.invoke, register.invoke)])
                 self._router.send(session, reply)
                 return
 
@@ -220,15 +207,13 @@ class Dealer(object):
             if not authorized:
                 # error reply since session is not authorized to register
                 #
-                reply = message.Error(message.Register.MESSAGE_TYPE, register.request, ApplicationError.NOT_AUTHORIZED, [
-                                      u"session is not authorized to register procedure '{0}'".format(register.procedure)])
+                reply = message.Error(message.Register.MESSAGE_TYPE, register.request, ApplicationError.NOT_AUTHORIZED, [u"session is not authorized to register procedure '{0}'".format(register.procedure)])
 
             else:
                 # ok, session authorized to register. now get the registration
                 #
                 registration_extra = RegistrationExtra(register.invoke)
-                registration, was_already_registered, is_first_callee = self._registration_map.add_observer(
-                    session, register.procedure, register.match, registration_extra)
+                registration, was_already_registered, is_first_callee = self._registration_map.add_observer(session, register.procedure, register.match, registration_extra)
 
                 if not was_already_registered:
                     self._session_to_registrations[session].add(registration)
@@ -246,11 +231,9 @@ class Dealer(object):
                                 'match': registration.match,
                                 'invoke': registration.extra.invoke,
                             }
-                            service_session.publish(
-                                u'wamp.registration.on_create', session._session_id, registration_details)
+                            service_session.publish(u'wamp.registration.on_create', session._session_id, registration_details)
                         if not was_already_registered:
-                            service_session.publish(
-                                u'wamp.registration.on_register', session._session_id, registration.id)
+                            service_session.publish(u'wamp.registration.on_register', session._session_id, registration.id)
 
                 # acknowledge register with registration ID
                 #
@@ -271,8 +254,7 @@ class Dealer(object):
                 message.Register.MESSAGE_TYPE,
                 register.request,
                 ApplicationError.AUTHORIZATION_FAILED,
-                [u"failed to authorize session for registering procedure '{0}': {1}".format(
-                    register.procedure, err.value)]
+                [u"failed to authorize session for registering procedure '{0}': {1}".format(register.procedure, err.value)]
             )
             self._router.send(session, reply)
 
@@ -284,8 +266,7 @@ class Dealer(object):
         """
         # get registration by registration ID or None (if it doesn't exist on this broker)
         #
-        registration = self._registration_map.get_observation_by_id(
-            unregister.registration)
+        registration = self._registration_map.get_observation_by_id(unregister.registration)
 
         if registration:
 
@@ -327,11 +308,9 @@ class Dealer(object):
             service_session = self._router._realm.session
             if service_session and not registration.uri.startswith(u'wamp.'):
                 if was_registered:
-                    service_session.publish(
-                        u'wamp.registration.on_unregister', session._session_id, registration.id)
+                    service_session.publish(u'wamp.registration.on_unregister', session._session_id, registration.id)
                 if was_last_callee:
-                    service_session.publish(
-                        u'wamp.registration.on_delete', session._session_id, registration.id)
+                    service_session.publish(u'wamp.registration.on_delete', session._session_id, registration.id)
 
         return was_registered, was_last_callee
 
@@ -363,8 +342,7 @@ class Dealer(object):
             uri_is_valid = _URI_PAT_LOOSE_NON_EMPTY.match(call.procedure)
 
         if not uri_is_valid:
-            reply = message.Error(message.Call.MESSAGE_TYPE, call.request, ApplicationError.INVALID_URI, [
-                                  u"call with invalid procedure URI '{0}' (URI strict checking {1})".format(call.procedure, self._option_uri_strict)])
+            reply = message.Error(message.Call.MESSAGE_TYPE, call.request, ApplicationError.INVALID_URI, [u"call with invalid procedure URI '{0}' (URI strict checking {1})".format(call.procedure, self._option_uri_strict)])
             self._router.send(session, reply)
             return
 
@@ -382,8 +360,7 @@ class Dealer(object):
                     self._router.validate(
                         'call', call.procedure, call.args, call.kwargs)
                 except Exception as e:
-                    reply = message.Error(message.Call.MESSAGE_TYPE, call.request, ApplicationError.INVALID_ARGUMENT, [
-                                          u"call of procedure '{0}' with invalid application payload: {1}".format(call.procedure, e)])
+                    reply = message.Error(message.Call.MESSAGE_TYPE, call.request, ApplicationError.INVALID_ARGUMENT, [u"call of procedure '{0}' with invalid application payload: {1}".format(call.procedure, e)])
                     self._router.send(session, reply)
                     return
 
@@ -398,8 +375,7 @@ class Dealer(object):
                 # the action was actually authorized or not ..
                 #
                 if not authorized:
-                    reply = message.Error(message.Call.MESSAGE_TYPE, call.request, ApplicationError.NOT_AUTHORIZED, [
-                                          u"session is not authorized to call procedure '{0}'".format(call.procedure)])
+                    reply = message.Error(message.Call.MESSAGE_TYPE, call.request, ApplicationError.NOT_AUTHORIZED, [u"session is not authorized to call procedure '{0}'".format(call.procedure)])
                     self._router.send(session, reply)
 
                 else:
@@ -413,8 +389,7 @@ class Dealer(object):
                         callee = registration.observers[0]
 
                     elif registration.extra.invoke == message.Register.INVOKE_LAST:
-                        callee = registration.observers[
-                            len(registration.observers) - 1]
+                        callee = registration.observers[len(registration.observers) - 1]
 
                     elif registration.extra.invoke == message.Register.INVOKE_ROUNDROBIN:
                         callee = registration.observers[
@@ -428,13 +403,11 @@ class Dealer(object):
                     elif registration.extra.invoke == message.Register.INVOKE_BALANCE:
                         nonbusy = set(
                             registration.observers) - set([v.callee for k, v in self._invocations.items()])
-                        # choose randomly from non busy observers to balance in
-                        # low traffic scenarios as well
+                        # choose randomly from non busy observers to balance in a low traffic scenarios as well
                         if len(nonbusy) > 0:
                             callee = random.choice(list(nonbusy))
                         else:
                             callee = random.choice(registration.observers)
-
                     else:
                         # should not arrive here
                         raise Exception(u"logic error")
@@ -479,8 +452,7 @@ class Dealer(object):
                                                         caller=caller,
                                                         procedure=procedure)
 
-                    self._invocations[invocation_request_id] = InvocationRequest(
-                        invocation_request_id, session, call, callee)
+                    self._invocations[invocation_request_id] = InvocationRequest(invocation_request_id, session, call, callee)
                     self._router.send(callee, invocation)
 
             def on_authorize_error(err):
@@ -494,16 +466,14 @@ class Dealer(object):
                     message.Call.MESSAGE_TYPE,
                     call.request,
                     ApplicationError.AUTHORIZATION_FAILED,
-                    [u"failed to authorize session for calling procedure '{0}': {1}".format(
-                        call.procedure, err.value)]
+                    [u"failed to authorize session for calling procedure '{0}': {1}".format(call.procedure, err.value)]
                 )
                 self._router.send(session, reply)
 
             txaio.add_callbacks(d, on_authorize_success, on_authorize_error)
 
         else:
-            reply = message.Error(message.Call.MESSAGE_TYPE, call.request, ApplicationError.NO_SUCH_PROCEDURE, [
-                                  u"no callee registered for procedure <{0}>".format(call.procedure)])
+            reply = message.Error(message.Call.MESSAGE_TYPE, call.request, ApplicationError.NO_SUCH_PROCEDURE, [u"no callee registered for procedure <{0}>".format(call.procedure)])
             self._router.send(session, reply)
 
     # noinspection PyUnusedLocal
@@ -535,14 +505,11 @@ class Dealer(object):
                         'call_result', invocation_request.call.procedure, yield_.args, yield_.kwargs)
                 except Exception as e:
                     is_valid = False
-                    reply = message.Error(message.Call.MESSAGE_TYPE, invocation_request.call.request, ApplicationError.INVALID_ARGUMENT, [
-                                          u"call result from procedure '{0}' with invalid application payload: {1}".format(invocation_request.call.procedure, e)])
+                    reply = message.Error(message.Call.MESSAGE_TYPE, invocation_request.call.request, ApplicationError.INVALID_ARGUMENT, [u"call result from procedure '{0}' with invalid application payload: {1}".format(invocation_request.call.procedure, e)])
                 else:
-                    reply = message.Result(
-                        invocation_request.call.request, args=yield_.args, kwargs=yield_.kwargs, progress=yield_.progress)
+                    reply = message.Result(invocation_request.call.request, args=yield_.args, kwargs=yield_.kwargs, progress=yield_.progress)
             else:
-                reply = message.Result(invocation_request.call.request, payload=yield_.payload, progress=yield_.progress,
-                                       enc_algo=yield_.enc_algo, enc_key=yield_.enc_key, enc_serializer=yield_.enc_serializer)
+                reply = message.Result(invocation_request.call.request, payload=yield_.payload, progress=yield_.progress, enc_algo=yield_.enc_algo, enc_key=yield_.enc_key, enc_serializer=yield_.enc_serializer)
 
             # the calling session might have been lost in the meantime ..
             #

--- a/crossbar/router/dealer.py
+++ b/crossbar/router/dealer.py
@@ -398,6 +398,7 @@ class Dealer(object):
                             # pick the callee with the least number of pending calls
                             d = Counter(busylist)
                             s = sorted(d, key=d.get)
+                            # print ('{}'.format([v for k,v in d.items()]))
                             callee = s[0]
                     else:
                         # should not arrive here

--- a/crossbar/router/dealer.py
+++ b/crossbar/router/dealer.py
@@ -312,8 +312,7 @@ class Dealer(object):
         """
         Actively unregister a callee session from a registration.
         """
-        was_registered, was_last_callee = self._unregister(
-            registration, session)
+        was_registered, was_last_callee = self._unregister(registration, session)
 
         # actively inform the callee that it has been unregistered
         #
@@ -495,7 +494,7 @@ class Dealer(object):
                 else:
                     reply = message.Result(invocation_request.call.request, args=yield_.args, kwargs=yield_.kwargs, progress=yield_.progress)
             else:
-                reply = message.Result(invocation_request.call.request, payload=yield_.payload, progress=yield_.progress, 
+                reply = message.Result(invocation_request.call.request, payload=yield_.payload, progress=yield_.progress,
                                        enc_algo=yield_.enc_algo, enc_key=yield_.enc_key, enc_serializer=yield_.enc_serializer)
 
             # the calling session might have been lost in the meantime ..

--- a/crossbar/router/dealer.py
+++ b/crossbar/router/dealer.py
@@ -66,7 +66,6 @@ class RegistrationExtra(object):
 
 
 class Dealer(object):
-
     """
     Basic WAMP dealer.
     """
@@ -200,8 +199,7 @@ class Dealer(object):
 
         # authorize action
         #
-        d = txaio.as_future(self._router.authorize, session,
-                            register.procedure, RouterAction.ACTION_REGISTER)
+        d = txaio.as_future(self._router.authorize, session, register.procedure, RouterAction.ACTION_REGISTER)
 
         def on_authorize_success(authorized):
             if not authorized:
@@ -272,21 +270,18 @@ class Dealer(object):
 
             if session in registration.observers:
 
-                was_registered, was_last_callee = self._unregister(
-                    registration, session)
+                was_registered, was_last_callee = self._unregister(registration, session)
 
                 reply = message.Unregistered(unregister.request)
             else:
                 # registration exists on this dealer, but the session that wanted to unregister wasn't registered
                 #
-                reply = message.Error(
-                    message.Unregister.MESSAGE_TYPE, unregister.request, ApplicationError.NO_SUCH_REGISTRATION)
+                reply = message.Error(message.Unregister.MESSAGE_TYPE, unregister.request, ApplicationError.NO_SUCH_REGISTRATION)
 
         else:
             # registration doesn't even exist on this broker
             #
-            reply = message.Error(
-                message.Unregister.MESSAGE_TYPE, unregister.request, ApplicationError.NO_SUCH_REGISTRATION)
+            reply = message.Error(message.Unregister.MESSAGE_TYPE, unregister.request, ApplicationError.NO_SUCH_REGISTRATION)
 
         self._router.send(session, reply)
 
@@ -294,8 +289,7 @@ class Dealer(object):
 
         # drop session from registration observers
         #
-        was_registered, was_last_callee = self._registration_map.drop_observer(
-            session, registration)
+        was_registered, was_last_callee = self._registration_map.drop_observer(session, registration)
 
         # remove registration from session->registrations map
         #
@@ -324,8 +318,7 @@ class Dealer(object):
         # actively inform the callee that it has been unregistered
         #
         if 'callee' in session._session_roles and session._session_roles['callee'] and session._session_roles['callee'].registration_revocation:
-            reply = message.Unregistered(
-                0, registration=registration.id, reason=reason)
+            reply = message.Unregistered(0, registration=registration.id, reason=reason)
             self._router.send(session, reply)
 
         return was_registered, was_last_callee
@@ -348,8 +341,7 @@ class Dealer(object):
 
         # get registrations active on the procedure called
         #
-        registration = self._registration_map.best_matching_observation(
-            call.procedure)
+        registration = self._registration_map.best_matching_observation(call.procedure)
 
         if registration:
 
@@ -357,8 +349,7 @@ class Dealer(object):
             #
             if call.payload is None:
                 try:
-                    self._router.validate(
-                        'call', call.procedure, call.args, call.kwargs)
+                    self._router.validate('call', call.procedure, call.args, call.kwargs)
                 except Exception as e:
                     reply = message.Error(message.Call.MESSAGE_TYPE, call.request, ApplicationError.INVALID_ARGUMENT, [u"call of procedure '{0}' with invalid application payload: {1}".format(call.procedure, e)])
                     self._router.send(session, reply)
@@ -366,8 +357,7 @@ class Dealer(object):
 
             # authorize CALL action
             #
-            d = txaio.as_future(
-                self._router.authorize, session, call.procedure, RouterAction.ACTION_CALL)
+            d = txaio.as_future(self._router.authorize, session, call.procedure, RouterAction.ACTION_CALL)
 
             def on_authorize_success(authorized):
 
@@ -392,17 +382,14 @@ class Dealer(object):
                         callee = registration.observers[len(registration.observers) - 1]
 
                     elif registration.extra.invoke == message.Register.INVOKE_ROUNDROBIN:
-                        callee = registration.observers[
-                            registration.extra.roundrobin_current % len(registration.observers)]
+                        callee = registration.observers[registration.extra.roundrobin_current % len(registration.observers)]
                         registration.extra.roundrobin_current += 1
 
                     elif registration.extra.invoke == message.Register.INVOKE_RANDOM:
-                        callee = registration.observers[
-                            random.randint(0, len(registration.observers) - 1)]
+                        callee = registration.observers[random.randint(0, len(registration.observers) - 1)]
 
                     elif registration.extra.invoke == message.Register.INVOKE_BALANCE:
-                        nonbusy = set(
-                            registration.observers) - set([v.callee for k, v in self._invocations.items()])
+                        nonbusy = set(registration.observers) - set([v.callee for k, v in self._invocations.items()])
                         # choose randomly from non busy observers to balance in a low traffic scenarios as well
                         if len(nonbusy) > 0:
                             callee = random.choice(list(nonbusy))
@@ -501,15 +488,15 @@ class Dealer(object):
             if yield_.payload is None:
                 # validate normal args/kwargs payload
                 try:
-                    self._router.validate(
-                        'call_result', invocation_request.call.procedure, yield_.args, yield_.kwargs)
+                    self._router.validate('call_result', invocation_request.call.procedure, yield_.args, yield_.kwargs)
                 except Exception as e:
                     is_valid = False
                     reply = message.Error(message.Call.MESSAGE_TYPE, invocation_request.call.request, ApplicationError.INVALID_ARGUMENT, [u"call result from procedure '{0}' with invalid application payload: {1}".format(invocation_request.call.procedure, e)])
                 else:
                     reply = message.Result(invocation_request.call.request, args=yield_.args, kwargs=yield_.kwargs, progress=yield_.progress)
             else:
-                reply = message.Result(invocation_request.call.request, payload=yield_.payload, progress=yield_.progress, enc_algo=yield_.enc_algo, enc_key=yield_.enc_key, enc_serializer=yield_.enc_serializer)
+                reply = message.Result(invocation_request.call.request, payload=yield_.payload, progress=yield_.progress, 
+                                       enc_algo=yield_.enc_algo, enc_key=yield_.enc_key, enc_serializer=yield_.enc_serializer)
 
             # the calling session might have been lost in the meantime ..
             #
@@ -522,8 +509,7 @@ class Dealer(object):
                 del self._invocations[yield_.request]
 
         else:
-            raise ProtocolError(
-                u"Dealer.onYield(): YIELD received for non-pending request ID {0}".format(yield_.request))
+            raise ProtocolError(u"Dealer.onYield(): YIELD received for non-pending request ID {0}".format(yield_.request))
 
     def processInvocationError(self, session, error):
         """
@@ -540,8 +526,7 @@ class Dealer(object):
             if error.payload is None:
                 # validate normal args/kwargs payload
                 try:
-                    self._router.validate(
-                        'call_error', invocation_request.call.procedure, error.args, error.kwargs)
+                    self._router.validate('call_error', invocation_request.call.procedure, error.args, error.kwargs)
                 except Exception as e:
                     reply = message.Error(message.Call.MESSAGE_TYPE,
                                           invocation_request.call.request,
@@ -572,5 +557,4 @@ class Dealer(object):
             del self._invocations[error.request]
 
         else:
-            raise ProtocolError(
-                u"Dealer.onInvocationError(): ERROR received for non-pending request_type {0} and request ID {1}".format(error.request_type, error.request))
+            raise ProtocolError(u"Dealer.onInvocationError(): ERROR received for non-pending request_type {0} and request ID {1}".format(error.request_type, error.request))


### PR DESCRIPTION
This is a suggested extra mode for shared registrations.
Shared registrations can be used with mode "balance" in addition to the existing "roundrobin, random, ..." in this pull request.

If a call is requested on the shared URI then crossbar randomly picks one of the registered callees that is not currently busy with an ongoing request. If all registrations are busy then crossbar picks ~~a busy callee randomly~~ the least busy callee by number of pending invocations.

Hope the feature is welcome. I'm happy to discuss...