### PR TITLE
Fixed obsolete use of 'traceback'

### DIFF
--- a/crossbar/controller/cli.py
+++ b/crossbar/controller/cli.py
@@ -614,8 +614,8 @@ def run_command_start(options, reactor=None):
         d = node.start(cdc_mode=options.cdc)
 
         def on_error(err):
-            log.error("{e!s}", e=err.value)
-            log.error("Could not start node")
+            log.error("Uncaught exception while starting node:\n{msg}", msg=err.getTraceback())
+            log.critical("Could not start node")
             if reactor.running:
                 reactor.stop()
         d.addErrback(on_error)

--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -500,7 +500,7 @@ class Node(object):
             self.log.error("{msg}", msg=e.error_message())
         except Exception:
             panic = True
-            self.log.error("{msg}", msg=Failure().getTraceback())             
+            self.log.error("{msg}", msg=Failure().getTraceback())
 
         if panic:
             try:

--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -33,12 +33,12 @@ from __future__ import absolute_import
 import os
 import re
 import json
-import traceback
 import socket
 import getpass
 
 import twisted
 from twisted.internet.defer import inlineCallbacks, Deferred
+from twisted.python.failure import Failure
 from twisted.internet.ssl import optionsForClientTLS
 
 from autobahn.util import utcnow
@@ -500,7 +500,7 @@ class Node(object):
             self.log.error("{msg}", msg=e.error_message())
         except Exception:
             panic = True
-            traceback.print_exc()
+            self.log.error("{msg}", msg=Failure().getTraceback())             
 
         if panic:
             try:

--- a/crossbar/router/protocol.py
+++ b/crossbar/router/protocol.py
@@ -31,7 +31,8 @@
 from __future__ import absolute_import
 
 import os
-import traceback
+
+from twisted.python.failure import Failure
 
 from autobahn.twisted import websocket
 from autobahn.twisted import rawsocket
@@ -260,7 +261,7 @@ class WampWebSocketServerProtocol(websocket.WampWebSocketServerProtocol):
             return (protocol, headers)
 
         except Exception:
-            traceback.print_exc()
+            self.log.error("{msg}", msg=Failure().getTraceback())
 
     def sendServerStatus(self, redirectUrl=None, redirectAfter=0):
         """


### PR DESCRIPTION
In case we work with @inlineCallbacks, *traceback* is not able to show the interessting part (where the actual exception is thrown). For consistency we should always use twisteds *Failure* class instead of *traceback*.

EDIT: Fixed another similiar issue resulting in no log message at all. (btw the travis-ci flake8 runner seems broken)