### PR TITLE
Fixed crash during node start under Python 2.x

### DIFF
--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -331,7 +331,7 @@ class Node(object):
 
         # the node controller realm
         #
-        self._realm = controller_config.get('realm', six.u'crossbar')
+        self._realm = controller_config.get('realm', six.u('crossbar'))
 
         # the node's name (must be unique within the management realm when running
         # in "managed mode")

--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -36,6 +36,7 @@ import json
 import traceback
 import socket
 import getpass
+import six
 
 import twisted
 from twisted.internet.defer import inlineCallbacks, Deferred
@@ -330,7 +331,7 @@ class Node(object):
 
         # the node controller realm
         #
-        self._realm = controller_config.get('realm', 'crossbar')
+        self._realm = controller_config.get('realm', six.u'crossbar')
 
         # the node's name (must be unique within the management realm when running
         # in "managed mode")


### PR DESCRIPTION
ComponentConfig fires an assertion otherwise.