### PR TITLE
Log wrapping and indentation

### DIFF
--- a/crossbar/controller/cli.py
+++ b/crossbar/controller/cli.py
@@ -429,6 +429,7 @@ def _startlog(options, reactor):
 
     loglevel = getattr(options, "loglevel", "info")
     logformat = getattr(options, "logformat", "none")
+    logwidth = getattr(options, "logwidth", 0)
     colour = getattr(options, "colour", "auto")
 
     set_global_log_level(loglevel)
@@ -475,10 +476,12 @@ def _startlog(options, reactor):
             # Print info to stdout, warn+ to stderr
             observers.append(make_stdout_observer(show_source=False,
                                                   format=logformat,
-                                                  colour=colour))
+                                                  colour=colour,
+                                                  width=logwidth))
             observers.append(make_stderr_observer(show_source=False,
                                                   format=logformat,
-                                                  colour=colour))
+                                                  colour=colour,
+                                                  width=logwidth))
         elif loglevel == "debug":
             # Print debug+info to stdout, warn+ to stderr, with the class
             # source
@@ -487,16 +490,19 @@ def _startlog(options, reactor):
                                                   colour=colour))
             observers.append(make_stderr_observer(show_source=True,
                                                   format=logformat,
-                                                  colour=colour))
+                                                  colour=colour,
+                                                  width=logwidth))
         elif loglevel == "trace":
             # Print trace+, with the class source
             observers.append(make_stdout_observer(show_source=True,
                                                   format=logformat,
                                                   trace=True,
-                                                  colour=colour))
+                                                  colour=colour,
+                                                  width=logwidth))
             observers.append(make_stderr_observer(show_source=True,
                                                   format=logformat,
-                                                  colour=colour))
+                                                  colour=colour,
+                                                  width=logwidth))
         else:
             assert False, "Shouldn't ever get here."
 
@@ -805,6 +811,12 @@ def run(prog=None, args=None, reactor=None):
                               choices=['syslogd', 'standard', 'none'],
                               help=("The format of the logs -- suitable for "
                                     "syslogd, not coloured, or coloured."))
+
+    parser_start.add_argument('--logwidth',
+                              type=int,
+                              default="0",
+                              help="The log width used for wrapping console output. "
+                                   "0 (default) deactivates wrapping and indentation on newlines")
 
     # "stop" command
     #


### PR DESCRIPTION
The main motivation behind this PR was to have multiline logs properly indented. The result is something like this:

![image](https://cloud.githubusercontent.com/assets/1858546/12761787/b0d153d2-c9ec-11e5-8659-9eae89ba81fd.png)

This PR adds a `--logwidth` cli option which can be used to specify wrapping width (required for indentation). It defaults to 0 which leaves the current behaviour unmodified unless desired.

The drawback of this approach is, that it's not further possible to arbitrarly format logs but that formats can only be used to generate a prefix. So something like `[TIME] Log [SUFFIX]` is not possible anymore.

While implementing this I also slightly refactored the logging code to have redundant code in a single place.
