### PR TITLE
Fire on_component_start and on_component_stop properly

### DIFF
--- a/crossbar/_util.py
+++ b/crossbar/_util.py
@@ -1,0 +1,42 @@
+#####################################################################################
+#
+#  Copyright (C) Tavendo GmbH
+#
+#  Unless a separate license agreement exists between you and Tavendo GmbH (e.g. you
+#  have purchased a commercial license), the license terms below apply.
+#
+#  Should you enter into a separate license agreement after having received a copy of
+#  this software, then the terms of such license agreement replace the terms below at
+#  the time at which such license agreement becomes effective.
+#
+#  In case a separate license agreement ends, and such agreement ends without being
+#  replaced by another separate license agreement, the license terms below apply
+#  from the time at which said agreement ends.
+#
+#  LICENSE TERMS
+#
+#  This program is free software: you can redistribute it and/or modify it under the
+#  terms of the GNU Affero General Public License, version 3, as published by the
+#  Free Software Foundation. This program is distributed in the hope that it will be
+#  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU Affero General Public License Version 3 for more details.
+#
+#  You should have received a copy of the GNU Affero General Public license along
+#  with this program. If not, see <http://www.gnu.org/licenses/agpl-3.0.en.html>.
+#
+#####################################################################################
+
+import inspect
+
+def class_name(obj):
+    """
+    This returns a name like "module.Class" given either an instance, or a class.
+    """
+
+    if inspect.isclass(obj):
+        cls = obj
+    else:
+        cls = obj.__class__
+    return '{}.{}'.format(cls.__module__, cls.__name__)

--- a/crossbar/_util.py
+++ b/crossbar/_util.py
@@ -30,6 +30,7 @@
 
 import inspect
 
+
 def class_name(obj):
     """
     This returns a name like "module.Class" given either an instance, or a class.

--- a/crossbar/router/session.py
+++ b/crossbar/router/session.py
@@ -174,8 +174,8 @@ class RouterApplicationSession(object):
             d.addErrback(lambda fail: self._log_error(fail, "While notifying 'join'"))
             # now fire onJoin (since _log_error returns None, we'll be
             # back in the callback chain even on errors from 'join'
-            d.addCallback(lambda _: self._session.onJoin(details))
-            d.addErrback(lambda fail: self._log_error(fail, "While firing onJoin"))
+            d.addCallback(lambda _: txaio.as_future(self._session.onJoin, details))
+            d.addErrback(lambda fail: self._swallow_error(fail, "While firing onJoin"))
             d.addCallback(lambda _: self._session.fire('ready', self._session))
             d.addErrback(lambda fail: self._log_error(fail, "While notifying 'ready'"))
 

--- a/crossbar/router/session.py
+++ b/crossbar/router/session.py
@@ -113,6 +113,10 @@ class RouterApplicationSession(object):
             pass
         return None
 
+    def _log_error(self, fail, msg):
+        self.log.failure(msg, failure=fail)
+        return None
+
     def isOpen(self):
         """
         Implements :func:`autobahn.wamp.interfaces.ITransport.isOpen`
@@ -164,19 +168,16 @@ class RouterApplicationSession(object):
                                      self._session._authprovider,
                                      self._session._authextra)
 
-            # have to fire the 'join' notification ourselves too. the
-            # "return_arg" idiom is equivalent to defer.returnValue(arg)
-            def success(arg):
-                d = self._session.fire('join', self._session, details)
-
-                def return_arg(_):
-                    return arg
-                txaio.add_callbacks(d, return_arg, None)
-                return d
-
-            # fire onOpen callback and handle any exception escaping from there
-            d = txaio.as_future(self._session.onJoin, details)
-            txaio.add_callbacks(d, success, lambda fail: self._swallow_error(fail, "While firing onJoin"))
+            # have to fire the 'join' notification ourselves, as we're
+            # faking out what the protocol usually does.
+            d = self._session.fire('join', self._session, details)
+            d.addErrback(lambda fail: self._log_error(fail, "While notifying 'join'"))
+            # now fire onJoin (since _log_error returns None, we'll be
+            # back in the callback chain even on errors from 'join'
+            d.addCallback(lambda _: self._session.onJoin(details))
+            d.addErrback(lambda fail: self._log_error(fail, "While firing onJoin"))
+            d.addCallback(lambda _: self._session.fire('ready', self._session))
+            d.addErrback(lambda fail: self._log_error(fail, "While notifying 'ready'"))
 
         # app-to-router
         #
@@ -222,8 +223,14 @@ class RouterApplicationSession(object):
         #
         elif isinstance(msg, message.Goodbye):
             # fire onClose callback and handle any exception escaping from there
+            # FIXME onClose should receive True/False (clean or unclean exit)
             d = txaio.as_future(self._session.onClose, None)
-            txaio.add_callbacks(d, None, lambda fail: self._swallow_error(fail, "While firing onClose"))
+            # note that onClose will fire 'leave' to listeners when
+            # the session is still connected, so we don't have to do
+            # that.
+            d.addErrback(lambda fail: self._log_error(fail, "While firing onClose"))
+            d.addCallback(lambda _: self._session.fire('disconnect', self._session))
+            d.addErrback(lambda fail: self._log_error(fail, "While notifying 'disconnect'"))
 
         else:
             # should not arrive here

--- a/crossbar/worker/router.py
+++ b/crossbar/worker/router.py
@@ -46,7 +46,7 @@ from twisted.python.threadpool import ThreadPool
 
 from autobahn.util import utcstr
 from autobahn.twisted.wamp import ApplicationSession
-from autobahn.wamp.exception import ApplicationError, TransportLost
+from autobahn.wamp.exception import ApplicationError
 
 from crossbar.twisted.resource import StaticResource, StaticResourceNoListing
 

--- a/crossbar/worker/router.py
+++ b/crossbar/worker/router.py
@@ -46,10 +46,11 @@ from twisted.python.threadpool import ThreadPool
 
 from autobahn.util import utcstr
 from autobahn.twisted.wamp import ApplicationSession
-from autobahn.wamp.exception import ApplicationError
+from autobahn.wamp.exception import ApplicationError, TransportLost
 
 from crossbar.twisted.resource import StaticResource, StaticResourceNoListing
 
+from crossbar._util import class_name
 from crossbar.router import uplink
 from crossbar.router.session import RouterSessionFactory
 from crossbar.router.service import RouterServiceSession
@@ -663,23 +664,43 @@ class RouterWorkerSession(NativeWorkerSession):
             )
             raise
 
-        def publish_stopped(session, details):
+        # Note that 'join' is fired to listeners *before* onJoin runs,
+        # so if you do 'yield self.leave()' in onJoin we'll still
+        # publish "started" before "stopped".
+
+        def publish_stopped(session, stop_details):
+            self.log.info(
+                "stopped component: {session} id={session_id}",
+                session=class_name(session),
+                session_id=session._session_id,
+            )
             topic = self._uri_prefix + '.container.on_component_stop'
             event = {u'id': id}
-            session.publish(topic, event, options=PublishOptions(exclude=details.caller))
+            caller = details.caller if details else None
+            self.publish(topic, event, options=PublishOptions(exclude=caller))
             return event
 
-        def publish_started(session, details):
+        def publish_started(session, start_details):
+            self.log.info(
+                "started component: {session} id={session_id}",
+                session=class_name(session),
+                session_id=session._session_id,
+            )
             topic = self._uri_prefix + '.container.on_component_start'
             event = {u'id': id}
-            session.publish(topic, event, options=PublishOptions(exclude=details.caller))
+            caller = details.caller if details else None
+            self.publish(topic, event, options=PublishOptions(exclude=caller))
             return event
-        session.on('join', publish_started)
         session.on('leave', publish_stopped)
+        session.on('join', publish_started)
 
         self.components[id] = RouterComponent(id, config, session)
         self._router_session_factory.add(session, authrole=config.get('role', u'anonymous'))
-        self.log.debug("Added component {id}", id=id)
+        self.log.debug(
+            "Added component {id} (type '{name}')",
+            id=id,
+            name=class_name(session),
+        )
 
     def stop_router_component(self, id, details=None):
         """


### PR DESCRIPTION
This fixes (some of the) behavior required for #615 -- specifically in this case firing on_component_start and on_component_stop properly for router workers.

Requires https://github.com/crossbario/autobahn-python/pull/593 to work correctly.