### PR TITLE
Fix cli's check configfile read with python3

### DIFF
--- a/crossbar/controller/cli.py
+++ b/crossbar/controller/cli.py
@@ -653,7 +653,7 @@ def run_command_check(options, **kwargs):
     print("\nChecking node configuration file '{}':\n".format(configfile))
 
     color = color_json
-    with open(configfile, 'r') as f:
+    with open(configfile, 'rb') as f:
         print(color(f.read().decode('utf8')))
 
     old_dir = os.path.abspath(os.path.curdir)


### PR DESCRIPTION
Hi,

I encounter a little bug using `check` command with Python 3.4. Config file is read as a string type which doesn't have a `decode` method in python3.

```
$ crossbar check
Automatically choosing optimal Twisted reactor
Running on Linux and optimal reactor (epoll) was installed.

Checking node configuration file '/home/emmanuel/projects/flask-socketio-test/.crossbar/config.yaml':

Traceback (most recent call last):
  File "/home/emmanuel/.local/share/virtualenvs/flask/bin/crossbar", line 11, in <module>
    sys.exit(run())
  File "/home/emmanuel/.local/share/virtualenvs/flask/lib/python3.4/site-packages/crossbar/controller/cli.py", line 954, in run
    options.func(options, reactor=reactor)
  File "/home/emmanuel/.local/share/virtualenvs/flask/lib/python3.4/site-packages/crossbar/controller/cli.py", line 657, in run_command_check
    print(color(f.read().decode('utf8')))
AttributeError: 'str' object has no attribute 'decode'
```

So the fix is to force the read to be done in binary.