### PR TITLE
Add systemd notification support.

### DIFF
--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -495,6 +495,15 @@ class Node(object):
 
         try:
             yield self._startup(self._config)
+
+            # Notify systemd that crossbar is fully up and running
+            # This has no effect on non-systemd platforms
+            try:
+                import sdnotify
+                sdnotify.SystemdNotifier().notify("READY=1")
+            except:
+                pass
+
         except ApplicationError as e:
             panic = True
             self.log.error("{msg}", msg=e.error_message())

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ install_requires = [
     'pygments>=2.0.2',            # BSD license
     'pyyaml>=3.11',               # MIT license
     'shutilwhich>=1.1.0',         # PSF license
+    'sdnotify>=0.3.0',            # MIT license
 
     'psutil>=3.2.1',              # BSD license
     'lmdb>=0.88',                 # OpenLDAP BSD


### PR DESCRIPTION
This allows running crossbar as a systemd service unit that notifies systemd
when it is up and running. This allows other services that depend on crossbar
being up to be started correctly.

Addresses #612 