### PR TITLE
Fix upgrade command for python2.7

### DIFF
--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -2775,7 +2775,7 @@ def upgrade_config_file(configfile):
 
         version += 1
 
-    config = OrderedDict([(u'version', version)]+ [i for i in config.items()])
+    config = OrderedDict([(u'version', version)] + [i for i in config.items()])
 
     with open(configfile, 'wb') as outfile:
         data = json.dumps(config,

--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -2775,7 +2775,7 @@ def upgrade_config_file(configfile):
 
         version += 1
 
-    config = OrderedDict([(u'version', version)] + [i for i in config.items()])
+    config = OrderedDict([(u'version', version)] + list(config.items()))
 
     with open(configfile, 'wb') as outfile:
         data = json.dumps(config,

--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -2775,8 +2775,7 @@ def upgrade_config_file(configfile):
 
         version += 1
 
-    config[u'version'] = version
-    config.move_to_end(u'version', last=False)
+    config = OrderedDict([(u'version', version)]+ [i for i in config.items()])
 
     with open(configfile, 'wb') as outfile:
         data = json.dumps(config,


### PR DESCRIPTION
Following issue #642, a fix to get rid of `move_to_end` in the upgrade command