### PR TITLE
Add reverseproxy web service

### DIFF
--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -1074,6 +1074,24 @@ def check_web_path_service_redirect(config):
     }, config, "Web transport 'redirect' path service")
 
 
+def check_web_path_service_reverseproxy(config):
+    """
+    Check a "reverseproxy" path service on Web transport.
+
+    http://crossbar.io/docs/
+    https://github.com/crossbario/crossbardocs/blob/master/pages/docs/administration/web-service/Web-ReverseProxy-Service.md
+
+    :param config: The path service configuration.
+    :type config: dict
+    """
+    check_dict_args({
+        'type': (True, [six.text_type]),
+        'host': (True, [six.text_type]),
+        'port': (False, [int]),
+        'path': (False, [six.text_type])
+    }, config, "Web transport 'redirect' path service")
+
+
 def check_web_path_service_json(config):
     """
     Check a "json" path service on Web transport.
@@ -1368,10 +1386,10 @@ def check_web_path_service(path, config, nested):
 
     ptype = config['type']
     if path == '/' and not nested:
-        if ptype not in ['static', 'wsgi', 'redirect', 'publisher', 'caller', 'resource', 'webhook']:
+        if ptype not in ['static', 'wsgi', 'redirect', 'reverseproxy', 'publisher', 'caller', 'resource', 'webhook']:
             raise InvalidConfigException("invalid type '{}' for root-path service in Web transport path service '{}' configuration\n\n{}".format(ptype, path, config))
     else:
-        if ptype not in ['websocket', 'static', 'wsgi', 'redirect', 'json', 'cgi', 'longpoll', 'publisher', 'caller', 'webhook', 'schemadoc', 'path', 'resource', 'upload']:
+        if ptype not in ['websocket', 'static', 'wsgi', 'redirect', 'reverseproxy', 'json', 'cgi', 'longpoll', 'publisher', 'caller', 'webhook', 'schemadoc', 'path', 'resource', 'upload']:
             raise InvalidConfigException("invalid type '{}' for sub-path service in Web transport path service '{}' configuration\n\n{}".format(ptype, path, config))
 
     checkers = {
@@ -1381,6 +1399,7 @@ def check_web_path_service(path, config, nested):
         'websocket': check_web_path_service_websocket,
         'longpoll': check_web_path_service_longpoll,
         'redirect': check_web_path_service_redirect,
+        'reverseproxy': check_web_path_service_reverseproxy,
         'json': check_web_path_service_json,
         'cgi': check_web_path_service_cgi,
         'wsgi': check_web_path_service_wsgi,

--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -1087,9 +1087,9 @@ def check_web_path_service_reverseproxy(config):
     check_dict_args({
         'type': (True, [six.text_type]),
         'host': (True, [six.text_type]),
-        'port': (False, [int]),
+        'port': (False, [six.integer_types]),
         'path': (False, [six.text_type])
-    }, config, "Web transport 'redirect' path service")
+    }, config, "Web transport 'reverseproxy' path service")
 
 
 def check_web_path_service_json(config):

--- a/crossbar/twisted/resource.py
+++ b/crossbar/twisted/resource.py
@@ -37,6 +37,7 @@ from twisted.web import http, server
 from twisted.web.http import NOT_FOUND
 from twisted.web.resource import Resource, NoResource
 from twisted.web.static import File
+from twisted.web.proxy import ReverseProxyResource  # noqa (Republish resource)
 from twisted.python.filepath import FilePath
 
 import crossbar

--- a/crossbar/worker/router.py
+++ b/crossbar/worker/router.py
@@ -87,7 +87,8 @@ from crossbar.twisted.site import createHSTSRequestFactory
 
 from crossbar.twisted.resource import JsonResource, \
     Resource404, \
-    RedirectResource
+    RedirectResource, \
+    ReverseProxyResource
 
 from crossbar.twisted.fileupload import FileUploadResource
 
@@ -997,6 +998,14 @@ class RouterWorkerSession(NativeWorkerSession):
         elif path_config['type'] == 'redirect':
             redirect_url = path_config['url'].encode('ascii', 'ignore')
             return RedirectResource(redirect_url)
+
+        # Reverse proxy resource
+        #
+        elif path_config['type'] == 'reverseproxy':
+            host = path_config['host']
+            port = int(path_config.get('port', 80))
+            path = path_config.get('path', '').encode('ascii', 'ignore')
+            return ReverseProxyResource(host, port, path)
 
         # JSON value resource
         #


### PR DESCRIPTION
Hi,

This PR implement the ReverseProxy web service from #334.
This is done using `twisted.web.proxy.ReverseProxyResource` (as proposed by https://github.com/crossbario/crossbar/issues/390#issuecomment-132790280), tested with both Python2.7 and 3.4

Upon acceptation, a new chapter should be written about it in crossbardocs (https://github.com/crossbario/crossbardocs/blob/master/pages/docs/administration/web-service/Web-ReverseProxy-Service.md)