### PR TITLE
Check our log-level before serializing messages

### DIFF
--- a/crossbar/_logging.py
+++ b/crossbar/_logging.py
@@ -259,11 +259,18 @@ def make_JSON_observer(outFile):
 
     @provider(ILogObserver)
     def _make_json(_event):
-
         event = dict(_event)
+        level = event.pop("log_level", LogLevel.info).name
+
+        # as soon as possible, we wish to give up if this event is
+        # outside our target log-level; this is to prevent
+        # (de-)serializing all the debug() messages (for example) from
+        # workers to the controller.
+        if POSSIBLE_LEVELS.index(level) > POSSIBLE_LEVELS.index(_loglevel):
+            return
 
         done_json = {
-            "level": event.pop("log_level", LogLevel.info).name,
+            "level": level,
             "namespace": event.pop("log_namespace", '')
         }
 


### PR DESCRIPTION
This might not be the best ultimate solution, as I don't fully grok how the observer interacts to provide messages to the controller from workers -- but at least for now this prevents us from (de-)serializing all the debug() and trace() messages from workers to the controller (when e.g. we're just at 'info' level).