### PR TITLE
Fix update cookies while reading from file

### DIFF
--- a/crossbar/router/cookiestore.py
+++ b/crossbar/router/cookiestore.py
@@ -264,7 +264,9 @@ class CookieStoreFileBacked(CookieStore):
         n = 0
         for cookie in self._iter_persisted():
             id = cookie.pop('id')
-            self._cookies[id] = cookie
+            if id not in self._cookies:
+                self._cookies[id] = {}
+            self._cookies[id].update(cookie)
             n += 1
 
         self.log.info("Loaded {cnt_cookie_records} cookie records from file. Cookie store has {cnt_cookies} entries.", cnt_cookie_records=n, cnt_cookies=len(self._cookies))


### PR DESCRIPTION
CookieStorage now updates cookie dictionaries rather than overwriting them. This fixes the following bug: sometimes at line 256 the 'created' key was not present.