### PR TITLE
Templates version 2

### DIFF
--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -2797,12 +2797,14 @@ def upgrade_config_file(configfile):
     config = OrderedDict([(u'version', version)] + list(config.items()))
 
     with open(configfile, 'wb') as outfile:
-        data = json.dumps(config,
-                          skipkeys=False,
-                          sort_keys=False,
-                          ensure_ascii=False,
-                          separators=(',', ': '),
-                          indent=3)
+        data = json.dumps(
+            config,
+            skipkeys=False,
+            sort_keys=False,
+            ensure_ascii=False,
+            separators=(',', ': '),
+            indent=4,
+        )
         # ensure newline at end of file
         data += u'\n'
         outfile.write(data.encode('utf8'))

--- a/crossbar/controller/cli.py
+++ b/crossbar/controller/cli.py
@@ -539,7 +539,7 @@ def run_command_start(options, reactor=None):
                 json.dumps(
                     pid_data,
                     sort_keys=False,
-                    indent=3,
+                    indent=4,
                     separators=(', ', ': '),
                     ensure_ascii=False
                 )
@@ -661,7 +661,14 @@ def run_command_check(options, **kwargs):
         print("Ok, node configuration looks good!\n")
 
         import json
-        config_content = json.dumps(config, skipkeys=False, sort_keys=False, ensure_ascii=False, separators=(',', ': '), indent=3)
+        config_content = json.dumps(
+            config,
+            skipkeys=False,
+            sort_keys=False,
+            ensure_ascii=False,
+            separators=(',', ': '),
+            indent=4,
+        )
         print(color_json(config_content))
         sys.exit(0)
 

--- a/crossbar/templates/default/.crossbar/config.json
+++ b/crossbar/templates/default/.crossbar/config.json
@@ -1,47 +1,54 @@
-
 {
-   "controller": {
-   },
-   "workers": [
-      {
-         "type": "router",
-         "realms": [
-            {
-               "name": "realm1",
-               "roles": [
-                  {
-                     "name": "anonymous",
-                     "permissions": [
+    "version": 2,
+    "controller": {},
+    "workers": [
+        {
+            "type": "router",
+            "realms": [
+                {
+                    "name": "realm1",
+                    "roles": [
                         {
-                           "uri": "*",
-                           "publish": true,
-                           "subscribe": true,
-                           "call": true,
-                           "register": true
+                            "name": "anonymous",
+                            "permissions": [
+                                {
+                                    "uri": "",
+                                    "match": "prefix",
+                                    "allow": {
+                                        "call": true,
+                                        "register": true,
+                                        "publish": true,
+                                        "subscribe": true
+                                    },
+                                    "disclose": {
+                                        "caller": false,
+                                        "publisher": false
+                                    },
+                                    "cache": true
+                                }
+                            ]
                         }
-                     ]
-                  }
-               ]
-            }
-         ],
-         "transports": [
-            {
-               "type": "web",
-               "endpoint": {
-                  "type": "tcp",
-                  "port": 8080
-               },
-               "paths": {
-                  "/": {
-                     "type": "static",
-                     "directory": ".."
-                  },
-                  "ws": {
-                     "type": "websocket"
-                  }
-               }
-            }
-         ]
-      }
-   ]
+                    ]
+                }
+            ],
+            "transports": [
+                {
+                    "type": "web",
+                    "endpoint": {
+                        "type": "tcp",
+                        "port": 8080
+                    },
+                    "paths": {
+                        "/": {
+                            "type": "static",
+                            "directory": ".."
+                        },
+                        "ws": {
+                            "type": "websocket"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
 }

--- a/crossbar/templates/hello/browser/.crossbar/config.json
+++ b/crossbar/templates/hello/browser/.crossbar/config.json
@@ -1,46 +1,54 @@
 {
-   "controller": {
-   },
-   "workers": [
-      {
-         "type": "router",
-         "realms": [
-            {
-               "name": "{{ realm }}",
-               "roles": [
-                  {
-                     "name": "anonymous",
-                     "permissions": [
+    "version": 2,
+    "controller": {},
+    "workers": [
+        {
+            "type": "router",
+            "realms": [
+                {
+                    "name": "{{ realm }}",
+                    "roles": [
                         {
-                           "uri": "*",
-                           "publish": true,
-                           "subscribe": true,
-                           "call": true,
-                           "register": true
+                            "name": "anonymous",
+                            "permissions": [
+                                {
+                                    "uri": "",
+                                    "match": "prefix",
+                                    "allow": {
+                                        "call": true,
+                                        "register": true,
+                                        "publish": true,
+                                        "subscribe": true
+                                    },
+                                    "disclose": {
+                                        "caller": false,
+                                        "publisher": false
+                                    },
+                                    "cache": true
+                                }
+                            ]
                         }
-                     ]
-                  }
-               ]
-            }
-         ],
-         "transports": [
-            {
-               "type": "web",
-               "endpoint": {
-                  "type": "tcp",
-                  "port": 8080
-               },
-               "paths": {
-                  "/": {
-                     "type": "static",
-                     "directory": "../web"
-                  },
-                  "ws": {
-                     "type": "websocket"
-                  }
-               }
-            }
-         ]
-      }
-   ]
+                    ]
+                }
+            ],
+            "transports": [
+                {
+                    "type": "web",
+                    "endpoint": {
+                        "type": "tcp",
+                        "port": 8080
+                    },
+                    "paths": {
+                        "/": {
+                            "type": "static",
+                            "directory": "../web"
+                        },
+                        "ws": {
+                            "type": "websocket"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
 }

--- a/crossbar/templates/hello/cpp/.crossbar/config.json
+++ b/crossbar/templates/hello/cpp/.crossbar/config.json
@@ -1,56 +1,65 @@
 {
-   "workers": [
-      {
-         "type": "router",
-         "realms": [
-            {
-               "name": "realm1",
-               "roles": [
-                  {
-                     "name": "anonymous",
-                     "permissions": [
+    "version": 2,
+    "workers": [
+        {
+            "type": "router",
+            "realms": [
+                {
+                    "name": "realm1",
+                    "roles": [
                         {
-                           "uri": "*",
-                           "publish": true,
-                           "subscribe": true,
-                           "call": true,
-                           "register": true
+                            "name": "anonymous",
+                            "permissions": [
+                                {
+                                    "uri": "",
+                                    "match": "prefix",
+                                    "allow": {
+                                        "call": true,
+                                        "register": true,
+                                        "publish": true,
+                                        "subscribe": true
+                                    },
+                                    "disclose": {
+                                        "caller": false,
+                                        "publisher": false
+                                    },
+                                    "cache": true
+                                }
+                            ]
                         }
-                     ]
-                  }
-               ]
-            }
-         ],
-         "transports": [
-            {
-               "type": "web",
-               "endpoint": {
-                  "type": "tcp",
-                  "port": 8080
-               },
-               "paths": {
-                  "/": {
-                     "type": "static",
-                     "directory": "../web/"
-                  },
-                  "ws": {
-                     "type": "websocket"
-                  }
-               }
-            },
-            {
-               "type": "rawsocket",
-               "endpoint": {
-                  "type": "tcp",
-                  "port": 8000
-               }
-            }
-         ]
-      },
-      {
-         "type": "guest",
-         "executable": "../hello",
-         "arguments": []
-      }
-   ]
+                    ]
+                }
+            ],
+            "transports": [
+                {
+                    "type": "web",
+                    "endpoint": {
+                        "type": "tcp",
+                        "port": 8080
+                    },
+                    "paths": {
+                        "/": {
+                            "type": "static",
+                            "directory": "../web/"
+                        },
+                        "ws": {
+                            "type": "websocket"
+                        }
+                    }
+                },
+                {
+                    "type": "rawsocket",
+                    "endpoint": {
+                        "type": "tcp",
+                        "port": 8000
+                    }
+                }
+            ]
+        },
+        {
+            "type": "guest",
+            "executable": "../hello",
+            "arguments": []
+        }
+    ]
 }

--- a/crossbar/templates/hello/csharp/.crossbar/config.json
+++ b/crossbar/templates/hello/csharp/.crossbar/config.json
@@ -1,57 +1,70 @@
 {
-   "controller": {
-   },
-   "workers": [
-      {
-         "type": "router",
-         "options": {
-            "pythonpath": [".."]
-         },
-         "realms": [
-            {
-               "name": "realm1",
-               "roles": [
-                  {
-                     "name": "anonymous",
-                     "permissions": [
+    "version": 2,
+    "controller": {},
+    "workers": [
+        {
+            "type": "router",
+            "options": {
+                "pythonpath": [
+                    ".."
+                ]
+            },
+            "realms": [
+                {
+                    "name": "realm1",
+                    "roles": [
                         {
-                           "uri": "*",
-                           "publish": true,
-                           "subscribe": true,
-                           "call": true,
-                           "register": true
+                            "name": "anonymous",
+                            "permissions": [
+                                {
+                                    "uri": "",
+                                    "match": "prefix",
+                                    "allow": {
+                                        "call": true,
+                                        "register": true,
+                                        "publish": true,
+                                        "subscribe": true
+                                    },
+                                    "disclose": {
+                                        "caller": false,
+                                        "publisher": false
+                                    },
+                                    "cache": true
+                                }
+                            ]
                         }
-                     ]
-                  }
-               ]
+                    ]
+                }
+            ],
+            "transports": [
+                {
+                    "type": "web",
+                    "endpoint": {
+                        "type": "tcp",
+                        "port": 8080
+                    },
+                    "paths": {
+                        "/": {
+                            "type": "static",
+                            "directory": "../web"
+                        },
+                        "ws": {
+                            "type": "websocket"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "type": "guest",
+            "executable": "Hello.exe",
+            "arguments": [
+                "ws://127.0.0.1:8080/ws",
+                "realm1"
+            ],
+            "options": {
+                "workdir": "../src/Hello/bin/Debug/"
             }
-         ],
-         "transports": [
-            {
-               "type": "web",
-               "endpoint": {
-                  "type": "tcp",
-                  "port": 8080
-               },
-               "paths": {
-                  "/": {
-                     "type": "static",
-                     "directory": "../web"
-                  },
-                  "ws": {
-                     "type": "websocket"
-                  }
-               }
-            }
-         ]
-      },
-      {
-         "type": "guest",
-         "executable": "Hello.exe",
-         "arguments": ["ws://127.0.0.1:8080/ws", "realm1"],
-         "options": {
-            "workdir": "../src/Hello/bin/Debug/"
-         }
-      }
-   ]
+        }
+    ]
 }

--- a/crossbar/templates/hello/erlang/.crossbar/config.json
+++ b/crossbar/templates/hello/erlang/.crossbar/config.json
@@ -1,59 +1,69 @@
 {
-   "controller": {
-   },
-   "workers": [
-      {
-         "type": "router",
-         "realms": [
-            {
-               "name": "realm1",
-               "roles": [
-                  {
-                     "name": "anonymous",
-                     "permissions": [
+    "version": 2,
+    "controller": {},
+    "workers": [
+        {
+            "type": "router",
+            "realms": [
+                {
+                    "name": "realm1",
+                    "roles": [
                         {
-                           "uri": "*",
-                           "publish": true,
-                           "subscribe": true,
-                           "call": true,
-                           "register": true
+                            "name": "anonymous",
+                            "permissions": [
+                                {
+                                    "uri": "",
+                                    "match": "prefix",
+                                    "allow": {
+                                        "call": true,
+                                        "register": true,
+                                        "publish": true,
+                                        "subscribe": true
+                                    },
+                                    "disclose": {
+                                        "caller": false,
+                                        "publisher": false
+                                    },
+                                    "cache": true
+                                }
+                            ]
                         }
-                     ]
-                  }
-               ]
-            }
-         ],
-         "transports": [
-            {
-               "type": "rawsocket",
-               "endpoint": {
-                  "type": "tcp",
-                  "port": 5555
-               },
-               "serializer": "msgpack"
-            },
-            {
-               "type": "web",
-               "endpoint": {
-                  "type": "tcp",
-                  "port": 8080
-               },
-               "paths": {
-                  "/": {
-                     "type": "static",
-                     "directory": "../web/"
-                  },
-                  "ws": {
-                     "type": "websocket"
-                  }
-               }
-            }
-         ]
-      },
-      {
-         "type": "guest",
-         "executable": "../_rel/crossbar_client/bin/crossbar_client",
-         "arguments": ["foreground"]
-      }
-   ]
+                    ]
+                }
+            ],
+            "transports": [
+                {
+                    "type": "rawsocket",
+                    "endpoint": {
+                        "type": "tcp",
+                        "port": 5555
+                    },
+                    "serializer": "msgpack"
+                },
+                {
+                    "type": "web",
+                    "endpoint": {
+                        "type": "tcp",
+                        "port": 8080
+                    },
+                    "paths": {
+                        "/": {
+                            "type": "static",
+                            "directory": "../web/"
+                        },
+                        "ws": {
+                            "type": "websocket"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "type": "guest",
+            "executable": "../_rel/crossbar_client/bin/crossbar_client",
+            "arguments": [
+                "foreground"
+            ]
+        }
+    ]
 }

--- a/crossbar/templates/hello/java/.crossbar/config.json
+++ b/crossbar/templates/hello/java/.crossbar/config.json
@@ -1,59 +1,68 @@
-
 {
-   "controller": {
-   },
-   "workers": [
-      {
-         "type": "router",
-         "realms": [
-            {
-               "name": "realm1",
-               "roles": [
-                  {
-                     "name": "anonymous",
-                     "permissions": [
+    "version": 2,
+    "controller": {},
+    "workers": [
+        {
+            "type": "router",
+            "realms": [
+                {
+                    "name": "realm1",
+                    "roles": [
                         {
-                           "uri": "*",
-                           "publish": true,
-                           "subscribe": true,
-                           "call": true,
-                           "register": true
+                            "name": "anonymous",
+                            "permissions": [
+                                {
+                                    "uri": "",
+                                    "match": "prefix",
+                                    "allow": {
+                                        "call": true,
+                                        "register": true,
+                                        "publish": true,
+                                        "subscribe": true
+                                    },
+                                    "disclose": {
+                                        "caller": false,
+                                        "publisher": false
+                                    },
+                                    "cache": true
+                                }
+                            ]
                         }
-                     ]
-                  }
-               ]
+                    ]
+                }
+            ],
+            "transports": [
+                {
+                    "type": "web",
+                    "endpoint": {
+                        "type": "tcp",
+                        "port": 8080
+                    },
+                    "paths": {
+                        "/": {
+                            "type": "static",
+                            "directory": "../web"
+                        },
+                        "ws": {
+                            "type": "websocket"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "type": "guest",
+            "executable": "java",
+            "arguments": [
+                "-classpath",
+                "./target/classes:./target/dependency/*",
+                "ws.wamp.jawampa.CrossbarExample",
+                "ws://127.0.0.1:8080/ws",
+                "realm1"
+            ],
+            "options": {
+                "workdir": ".."
             }
-         ],
-         "transports": [
-            {
-               "type": "web",
-               "endpoint": {
-                  "type": "tcp",
-                  "port": 8080
-               },
-               "paths": {
-                  "/": {
-                     "type": "static",
-                     "directory": "../web"
-                  },
-                  "ws": {
-                     "type": "websocket"
-                  }
-               }
-            }
-         ]
-      },
-      {
-         "type": "guest",
-         "executable": "java",
-         "arguments": [
-            "-classpath", "./target/classes:./target/dependency/*",
-            "ws.wamp.jawampa.CrossbarExample",
-            "ws://127.0.0.1:8080/ws", "realm1"
-         ],
-         "options": {
-            "workdir": ".."
-         }
-      }
-   ]
+        }
+    ]
 }

--- a/crossbar/templates/hello/nodejs/.crossbar/config.json
+++ b/crossbar/templates/hello/nodejs/.crossbar/config.json
@@ -1,58 +1,70 @@
 {
-   "controller": {
-   },
-   "workers": [
-      {
-         "type": "router",
-         "realms": [
-            {
-               "name": "{{ realm }}",
-               "roles": [
-                  {
-                     "name": "anonymous",
-                     "permissions": [
+    "version": 2,
+    "controller": {},
+    "workers": [
+        {
+            "type": "router",
+            "realms": [
+                {
+                    "name": "{{ realm }}",
+                    "roles": [
                         {
-                           "uri": "*",
-                           "publish": true,
-                           "subscribe": true,
-                           "call": true,
-                           "register": true
+                            "name": "anonymous",
+                            "permissions": [
+                                {
+                                    "uri": "",
+                                    "match": "prefix",
+                                    "allow": {
+                                        "call": true,
+                                        "register": true,
+                                        "publish": true,
+                                        "subscribe": true
+                                    },
+                                    "disclose": {
+                                        "caller": false,
+                                        "publisher": false
+                                    },
+                                    "cache": true
+                                }
+                            ]
                         }
-                     ]
-                  }
-               ]
+                    ]
+                }
+            ],
+            "transports": [
+                {
+                    "type": "web",
+                    "endpoint": {
+                        "type": "tcp",
+                        "port": 8080
+                    },
+                    "paths": {
+                        "/": {
+                            "type": "static",
+                            "directory": "../web"
+                        },
+                        "ws": {
+                            "type": "websocket"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "type": "guest",
+            "executable": "node",
+            "arguments": [
+                "{{ appname }}.js"
+            ],
+            "options": {
+                "workdir": "../node",
+                "watch": {
+                    "directories": [
+                        "../node"
+                    ],
+                    "action": "restart"
+                }
             }
-         ],
-         "transports": [
-            {
-               "type": "web",
-               "endpoint": {
-                  "type": "tcp",
-                  "port": 8080
-               },
-               "paths": {
-                  "/": {
-                     "type": "static",
-                     "directory": "../web"
-                  },
-                  "ws": {
-                     "type": "websocket"
-                  }
-               }
-            }
-         ]
-      },
-      {
-         "type": "guest",
-         "executable": "node",
-         "arguments": ["{{ appname }}.js"],
-         "options": {
-            "workdir": "../node",
-            "watch": {
-               "directories": ["../node"],
-               "action": "restart"
-            }
-         }
-      }
-   ]
+        }
+    ]
 }

--- a/crossbar/templates/hello/php/.crossbar/config.json
+++ b/crossbar/templates/hello/php/.crossbar/config.json
@@ -1,51 +1,61 @@
 {
-   "controller": {
-   },
-   "workers": [
-      {
-         "type": "router",
-         "realms": [
-            {
-               "name": "realm1",
-               "roles": [
-                  {
-                     "name": "anonymous",
-                     "permissions": [
+    "version": 2,
+    "controller": {},
+    "workers": [
+        {
+            "type": "router",
+            "realms": [
+                {
+                    "name": "realm1",
+                    "roles": [
                         {
-                           "uri": "*",
-                           "publish": true,
-                           "subscribe": true,
-                           "call": true,
-                           "register": true
+                            "name": "anonymous",
+                            "permissions": [
+                                {
+                                    "uri": "",
+                                    "match": "prefix",
+                                    "allow": {
+                                        "call": true,
+                                        "register": true,
+                                        "publish": true,
+                                        "subscribe": true
+                                    },
+                                    "disclose": {
+                                        "caller": false,
+                                        "publisher": false
+                                    },
+                                    "cache": true
+                                }
+                            ]
                         }
-                     ]
-                  }
-               ]
-            }
-         ],
-         "transports": [
-            {
-               "type": "web",
-               "endpoint": {
-                  "type": "tcp",
-                  "port": 8080
-               },
-               "paths": {
-                  "/": {
-                     "type": "static",
-                     "directory": "../web/"
-                  },
-                  "ws": {
-                     "type": "websocket"
-                  }
-               }
-            }
-         ]
-      },
-      {
-         "type": "guest",
-         "executable": "php",
-         "arguments": ["../client.php"]
-      }
-   ]
+                    ]
+                }
+            ],
+            "transports": [
+                {
+                    "type": "web",
+                    "endpoint": {
+                        "type": "tcp",
+                        "port": 8080
+                    },
+                    "paths": {
+                        "/": {
+                            "type": "static",
+                            "directory": "../web/"
+                        },
+                        "ws": {
+                            "type": "websocket"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "type": "guest",
+            "executable": "php",
+            "arguments": [
+                "../client.php"
+            ]
+        }
+    ]
 }

--- a/crossbar/templates/hello/python/.crossbar/config.json
+++ b/crossbar/templates/hello/python/.crossbar/config.json
@@ -1,66 +1,77 @@
 {
-   "workers": [
-      {
-         "type": "router",
-         "realms": [
-            {
-               "name": "realm1",
-               "roles": [
-                  {
-                     "name": "anonymous",
-                     "permissions": [
+    "version": 2,
+    "workers": [
+        {
+            "type": "router",
+            "realms": [
+                {
+                    "name": "realm1",
+                    "roles": [
                         {
-                           "uri": "*",
-                           "publish": true,
-                           "subscribe": true,
-                           "call": true,
-                           "register": true
+                            "name": "anonymous",
+                            "permissions": [
+                                {
+                                    "uri": "",
+                                    "match": "prefix",
+                                    "allow": {
+                                        "call": true,
+                                        "register": true,
+                                        "publish": true,
+                                        "subscribe": true
+                                    },
+                                    "disclose": {
+                                        "caller": false,
+                                        "publisher": false
+                                    },
+                                    "cache": true
+                                }
+                            ]
                         }
-                     ]
-                  }
-               ]
-            }
-         ],
-         "transports": [
-            {
-               "type": "web",
-               "endpoint": {
-                  "type": "tcp",
-                  "port": 8080
-               },
-               "paths": {
-                  "/": {
-                     "type": "static",
-                     "directory": "../web"
-                  },
-                  "ws": {
-                     "type": "websocket"
-                  }
-               }
-            }
-         ]
-      },
-      {
-         "type": "container",
-         "options": {
-            "pythonpath": [".."]
-         },
-         "components": [
-            {
-               "type": "class",
-               "classname": "hello.AppSession",
-               "realm": "realm1",
-               "transport": {
-                  "type": "websocket",
-                  "endpoint": {
-                     "type": "tcp",
-                     "host": "127.0.0.1",
-                     "port": 8080
-                  },
-                  "url": "ws://127.0.0.1:8080/ws"
-               }
-            }
-         ]
-      }
-   ]
+                    ]
+                }
+            ],
+            "transports": [
+                {
+                    "type": "web",
+                    "endpoint": {
+                        "type": "tcp",
+                        "port": 8080
+                    },
+                    "paths": {
+                        "/": {
+                            "type": "static",
+                            "directory": "../web"
+                        },
+                        "ws": {
+                            "type": "websocket"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "type": "container",
+            "options": {
+                "pythonpath": [
+                    ".."
+                ]
+            },
+            "components": [
+                {
+                    "type": "class",
+                    "classname": "hello.AppSession",
+                    "realm": "realm1",
+                    "transport": {
+                        "type": "websocket",
+                        "endpoint": {
+                            "type": "tcp",
+                            "host": "127.0.0.1",
+                            "port": 8080
+                        },
+                        "url": "ws://127.0.0.1:8080/ws"
+                    }
+                }
+            ]
+        }
+    ]
 }

--- a/crossbar/templates/hello/tessel/.crossbar/config.json
+++ b/crossbar/templates/hello/tessel/.crossbar/config.json
@@ -1,50 +1,57 @@
-
 {
-   "controller": {
-   },
-   "workers": [
-      {
-         "type": "router",
-         "realms": [
-            {
-               "name": "realm1",
-               "roles": [
-                  {
-                     "name": "anonymous",
-                     "permissions": [
+    "version": 2,
+    "controller": {},
+    "workers": [
+        {
+            "type": "router",
+            "realms": [
+                {
+                    "name": "realm1",
+                    "roles": [
                         {
-                           "uri": "*",
-                           "publish": true,
-                           "subscribe": true,
-                           "call": true,
-                           "register": true
+                            "name": "anonymous",
+                            "permissions": [
+                                {
+                                    "uri": "",
+                                    "match": "prefix",
+                                    "allow": {
+                                        "call": true,
+                                        "register": true,
+                                        "publish": true,
+                                        "subscribe": true
+                                    },
+                                    "disclose": {
+                                        "caller": false,
+                                        "publisher": false
+                                    },
+                                    "cache": true
+                                }
+                            ]
                         }
-                     ]
-                  }
-               ]
-            }
-         ],
-         "transports": [
-            {
-               "type": "web",
-               "endpoint": {
-                  "type": "tcp",
-                  "port": 8080
-               },
-               "paths": {
-                  "/": {
-                     "type": "static",
-                     "directory": "../web"
-                  },
-                  "ws": {
-                     "type": "websocket",
-                     "options": {
-                        "require_websocket_subprotocol": false   
-                     }
-                  }
-               }
-            }
-         ]
-      }
-   ]
+                    ]
+                }
+            ],
+            "transports": [
+                {
+                    "type": "web",
+                    "endpoint": {
+                        "type": "tcp",
+                        "port": 8080
+                    },
+                    "paths": {
+                        "/": {
+                            "type": "static",
+                            "directory": "../web"
+                        },
+                        "ws": {
+                            "type": "websocket",
+                            "options": {
+                                "require_websocket_subprotocol": false
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
This upgrades all the templates' ``config.json`` files to version 2, changes the indenting to 4 spaces to match the Python source, and changes indent option in CLI commands so they output 4-space indented config files too (e.g. "crossbar upgrade")