### PR TITLE
Fix log.failure() usage and convert some log.error() calls

### DIFF
--- a/crossbar/adapter/postgres/common.py
+++ b/crossbar/adapter/postgres/common.py
@@ -79,8 +79,8 @@ class PostgreSQLAdapter(ApplicationSession):
 
         try:
             yield self.connect_and_observe(self._db_config, self.PG_CHANNEL, self.on_notify)
-        except Exception as e:
-            self.log.error("Could not connect to database: {error}", error=e)
+        except Exception:
+            self.log.failure("Could not connect to database: {log_failure.value}")
             self.leave()
 
         self.log.info("PostgreSQL database adapter (Publisher) ready")
@@ -165,8 +165,11 @@ class PostgreSQLAdapter(ApplicationSession):
         conn.addNotifyObserver(fun)
         try:
             yield conn.runOperation("LISTEN {0}".format(self._db_config['adapter_channel']))
-        except Exception as e:
-            self.log.error("Failed to listen on channel '{0}': {1}".format(self._db_config['adapter_channel'], e))
+        except Exception:
+            self.log.failure(
+                "Failed to listen on channel '{channel}': {log_failure.value}",
+                channel=self._db_config['adapter_channel'],
+            )
             self.leave()
         else:
             self.log.debug("Listening on PostgreSQL NOTIFY channel '{0}'' ...".format(self._db_config['adapter_channel']))
@@ -259,8 +262,11 @@ class PostgreSQLAdapter(ApplicationSession):
                     sql = str(sql)
                     try:
                         yield txn.execute(sql)
-                    except Exception as e:
-                        self.log.error("Error while running DDL script '{script}': {error}", script=script, error=e)
+                    except Exception:
+                        self.log.failure(
+                            "Error while running DDL script '{script}': {log_failure.value}",
+                            script=script,
+                        )
 
         return conn.runInteraction(upgrade)
 

--- a/crossbar/adapter/postgres/publisher.py
+++ b/crossbar/adapter/postgres/publisher.py
@@ -180,8 +180,8 @@ class PostgreSQLPublisher(PostgreSQLAdapter):
                 else:
                     raise Exception("logic error")
 
-            except Exception as e:
-                self.log.error(e)
+            except Exception:
+                self.log.failure(None)
 
         else:
             self.log.error("Received NOTIFY on unknown channel {channel}", channel=notify.channel)

--- a/crossbar/common/profiler.py
+++ b/crossbar/common/profiler.py
@@ -132,9 +132,12 @@ if _HAS_VMPROF:
 
                 try:
                     stats = vmprof.read_profile(profile_filename, virtual_only=True, include_extra_info=True)
-                except Exception as e:
-                    self.log.error("Fatal: could not read vmprof profile file '{}': {}".format(profile_filename, e))
-                    raise e
+                except Exception:
+                    self.log.error(
+                        "Fatal: could not read vmprof profile file '{fname}': {log_failure.value}",
+                        fname=profile_filename,
+                    )
+                    raise
 
                 tree = stats.get_tree()
                 total = float(tree.count)
@@ -201,7 +204,7 @@ if _HAS_VMPROF:
                     self._finished.callback(res)
 
                 def on_profile_conversaion_failed(err):
-                    self.log.error(err.value)
+                    self.log.failure("profile conversion failed", failure=err)
                     self._finished.errback(err)
 
                 d.addCallbacks(on_profile_converted, on_profile_conversaion_failed)

--- a/crossbar/controller/guest.py
+++ b/crossbar/controller/guest.py
@@ -101,7 +101,10 @@ class GuestWorkerClientProtocol(protocol.Protocol):
             else:
                 # get this when subprocess has exited early; should we just log error?
                 # should not arrive here
-                self.log.error("GuestWorkerClientProtocol: INTERNAL ERROR - should not arrive here - {}".format(reason))
+                self.log.error(
+                    "GuestWorkerClientProtocol: INTERNAL ERROR - should not arrive here - {reason}",
+                    reason=reason,
+                )
 
         except Exception:
             self.log.failure("GuestWorkerClientProtocol: INTERNAL ERROR - {log_failure}")

--- a/crossbar/controller/management.py
+++ b/crossbar/controller/management.py
@@ -139,8 +139,11 @@ class NodeManagementBridgeSession(ApplicationSession):
 
             try:
                 yield self._manager.publish(topic, *args, options=PublishOptions(acknowledge=True), **kwargs)
-            except Exception as e:
-                self.log.error("Failed to forward event on topic '{topic}': {error}", topic=topic, error=e)
+            except Exception:
+                self.log.failure(
+                    "Failed to forward event on topic '{topic}': {log_failure.value}",
+                    topic=topic,
+                )
             else:
                 self.log.debug("Forwarded management event on topic '{topic}'", topic=topic)
 
@@ -161,8 +164,11 @@ class NodeManagementBridgeSession(ApplicationSession):
 
             try:
                 reg = yield self._manager.register(forward_call, procedure)
-            except Exception as e:
-                self.log.error("Failed to register management procedure '{procedure}': {error}", procedure=procedure, error=e)
+            except Exception:
+                self.log.failure(
+                    "Failed to register management procedure '{procedure}': {log_failure.value}",
+                    procedure=procedure,
+                )
             else:
                 self._regs[registration['id']] = reg
                 self.log.debug("Management procedure registered: '{procedure}'", procedure=reg.procedure)

--- a/crossbar/controller/process.py
+++ b/crossbar/controller/process.py
@@ -999,7 +999,9 @@ class NodeControllerSession(NativeProcessSession):
         def on_connect_error(err):
 
             # not sure when this errback is triggered at all .. see above.
-            self.log.error("Internal error: connection to forked guest worker failed ({})".format(err))
+            self.log.failure(
+                "Internal error: connection to forked guest worker failed ({log_failure.value})",
+            )
 
             # in any case, forward the error ..
             worker.ready.errback(err)

--- a/crossbar/router/broker.py
+++ b/crossbar/router/broker.py
@@ -334,7 +334,7 @@ class Broker(object):
                 different from the call to authorize succeed, but the
                 authorization being denied)
                 """
-                self.log.failure(err)
+                self.log.failure("Authorization failed", failure=err)
                 if publish.acknowledge:
                     reply = message.Error(
                         message.Publish.MESSAGE_TYPE,
@@ -424,7 +424,7 @@ class Broker(object):
             authorization being denied)
             """
             # XXX same as another code-block, can we collapse?
-            self.log.failure(err)
+            self.log.failure("Authorization failed", failure=err)
             reply = message.Error(
                 message.Subscribe.MESSAGE_TYPE,
                 subscribe.request,

--- a/crossbar/router/longpoll.py
+++ b/crossbar/router/longpoll.py
@@ -161,7 +161,11 @@ class WampLongPollResourceSessionReceive(Resource):
                 if type(msg) == six.binary_type:
                     self._request.write(msg)
                 else:
-                    self.log.error("internal error: cannot write data of type {} - {}".format(type(msg), msg))
+                    self.log.error(
+                        "internal error: cannot write data of type {type_} - {msg}",
+                        type_=type(msg),
+                        msg=msg,
+                    )
 
             self._request.finish()
             self._request = None
@@ -326,7 +330,7 @@ class WampLongPollResourceSession(Resource):
                 self._session.onClose(wasClean)
             except Exception:
                 # ignore exceptions raised here, but log ..
-                self.log.failure()
+                self.log.failure("invoking session's onClose failed")
             self._session = None
 
     def onOpen(self):
@@ -339,7 +343,7 @@ class WampLongPollResourceSession(Resource):
             self._session.onOpen(self)
         except Exception:
             # ignore exceptions raised here, but log ..
-            self.log.failure()
+            self.log.failure("Invoking session's onOpen failed")
 
     def onMessage(self, payload, isBinary):
         """

--- a/crossbar/twisted/resource.py
+++ b/crossbar/twisted/resource.py
@@ -269,7 +269,7 @@ class WampLongPollResource(longpoll.WampLongPollResource):
             content = content.encode('utf8')
             return content
         except Exception:
-            self.log.failure("Error rendering LongPoll notice page template: {failure}")
+            self.log.failure("Error rendering LongPoll notice page template: {log_failure.value}")
 
 
 class SchemaDocResource(Resource):

--- a/crossbar/worker/container.py
+++ b/crossbar/worker/container.py
@@ -220,8 +220,7 @@ class ContainerWorkerSession(NativeWorkerSession):
                 session._swallow_error = panic
                 return session
             except Exception as e:
-                msg = "{}".format(e).strip()
-                self.log.failure("Component instantiation failed: {msg}", msg=msg)
+                self.log.failure("Component instantiation failed: {log_failure.value}")
                 raise
 
         # 2) create WAMP transport factory

--- a/crossbar/worker/router.py
+++ b/crossbar/worker/router.py
@@ -526,8 +526,8 @@ class RouterWorkerSession(NativeWorkerSession):
         # wait until the uplink is ready
         try:
             uplink_session = yield extra['onready']
-        except Exception as e:
-            self.log.error(e)
+        except Exception:
+            self.log.failure(None)
             raise e
 
         self.realms[realm_id].uplinks[uplink_id].session = uplink_session

--- a/crossbar/worker/worker.py
+++ b/crossbar/worker/worker.py
@@ -68,7 +68,7 @@ class NativeWorkerSession(NativeProcessSession):
     log = make_logger()
 
     def onUserError(self, err, errmsg):
-        self.log.error("NativeWorkerSession.onUserError", log_failure=err)
+        self.log.error("NativeWorkerSession.onUserError", failure=err)
 
     def onConnect(self):
         """
@@ -485,7 +485,7 @@ class NativeWorkerSession(NativeProcessSession):
                 paths_added.append({'requested': p, 'resolved': path_to_add})
             else:
                 emsg = "Cannot add Python search path '{}': resolved path '{}' is not a directory".format(p, path_to_add)
-                self.log.failure(emsg)
+                self.log.error(emsg)
                 raise ApplicationError(u'crossbar.error.invalid_argument', emsg, requested=p, resolved=path_to_add)
 
         # now extend python module search path


### PR DESCRIPTION
This is a result of auditing all log.failure() and log.error()
calls in crossbar, "upgrading" some .error calls to failure and
properly invoking .failure() in others. See also #660 for context.