### PR TITLE
Remove pycrypto from deps if using PyPy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,9 +123,10 @@ extras_require_dev = [
     'colorama>=0.3.3',              # BSD license
     'mock>=1.3.0',                  # BSD license
 ]
-if sys.platform != 'win32':
+if sys.platform != 'win32' and not PYPY:
     # Twisted manhole support
     # pycrypto does not provide wheels => disable on Windows
+    # can't compile under PyPy
     extras_require_dev.append('pycrypto>=2.6.1')   # Public Domain license
 
 # Crossbar.io/PostgreSQL integration


### PR DESCRIPTION
I can't run tox on any pypy environments because we install using ``crossbar[all]`` -- since there's already ifdefs in setup.py this adds another one since pycrypto won't install under PyPy.