### PR TITLE
CookieStoreFileBacked: purge expired cookies

### DIFF
--- a/crossbar/router/cookiestore.py
+++ b/crossbar/router/cookiestore.py
@@ -30,6 +30,7 @@
 
 import os
 import json
+import datetime
 
 from six.moves import http_cookies
 
@@ -299,6 +300,12 @@ class CookieStoreFileBacked(CookieStore):
     def _clean_cookie_file(self):
         with open(self._cookie_file_name, 'w') as cookie_file:
             for cbtid, cookie in self._cookies.items():
+                expiration_delta = datetime.timedelta(seconds=int(cookie['max_age']))
+                upper_limit = util.utcstr(datetime.datetime.now() - expiration_delta)
+                if cookie['created'] < upper_limit:
+                    # This cookie is expired, discard
+                    continue
+
                 cookie_record = json.dumps({
                     'id': cbtid,
                     'created': cookie['created'],

--- a/crossbar/router/test/test_cookiestore.py
+++ b/crossbar/router/test/test_cookiestore.py
@@ -2,20 +2,104 @@ from crossbar.router.cookiestore import CookieStoreFileBacked
 import json
 import tempfile
 import unittest
+import time
+from datetime import datetime
+from autobahn import util
 
 
 class TestCookieStore(unittest.TestCase):
 
+    def write_cookies_to_file(self, cookies, file):
+        for cookie in cookies:
+            file.write((json.dumps(cookie) + '\n').encode('utf-8'))
+        file.flush()
+
+    def read_cookies_from_file(self, file):
+        file.seek(0)
+        cookies = list(map(lambda x: json.loads(x.decode('utf-8')), file.readlines()))
+        cookies.sort(key=lambda x: x['id'])
+        return cookies
+
     def test_purge_on_startup(self):
 
-        original = b"""{"id":"thisIsAnID","created":"2016-03-02T20:23:00.000Z","max_age":604800,"authid":"example.authid","authrole":"example.authrole","authmethod":"example.authmethod"}
-{"id":"thisIsAnotherID","created":"2016-03-02T20:23:30.000Z","max_age":604800,"authid":"example.other.authid","authrole":"example.other.authrole","authmethod":"example.other.authmethod"}
-{"id":"thisIsAnID","modified":"2016-03-02T20:24:00.000Z","max_age":604800,"authid":"example.second.authid","authrole":"example.second.authrole","authmethod":"example.second.authmethod"}
-"""
+        created_time = util.utcnow()
+
+        original = [
+            {
+                "id": "thisIsAnID",
+                "created": created_time,
+                "max_age": 604800,
+                "authid": "example.authid",
+                "authrole": "example.authrole",
+                "authmethod": "example.authmethod"
+            },
+            {
+                "id": "thisIsAnotherID",
+                "created": created_time,
+                "max_age": 604800,
+                "authid": "example.other.authid",
+                "authrole": "example.other.authrole",
+                "authmethod": "example.other.authmethod"
+            },
+            {
+                "id": "thisIsAnID",
+                "modified": created_time,
+                "max_age": 604800,
+                "authid": "example.second.authid",
+                "authrole": "example.second.authrole",
+                "authmethod": "example.second.authmethod"
+            }
+        ]
+
         expected = [
             {
                 "id": "thisIsAnID",
+                "created": created_time,
+                "max_age": 604800,
+                "authid": "example.second.authid",
+                "authrole": "example.second.authrole",
+                "authmethod": "example.second.authmethod"
+            },
+            {
+                "id": "thisIsAnotherID",
+                "created": created_time,
+                "max_age": 604800,
+                "authid": "example.other.authid",
+                "authrole": "example.other.authrole",
+                "authmethod": "example.other.authmethod"
+            }
+        ]
+
+        with tempfile.NamedTemporaryFile() as fp:
+            self.write_cookies_to_file(original, fp)
+
+            config = {
+                'store': {
+                    'type': 'file',
+                    'filename': fp.name,
+                    'purge_on_startup': True
+                }
+            }
+
+            CookieStoreFileBacked(fp.name, config)
+
+            actual = self.read_cookies_from_file(fp)
+            self.assertEqual(actual, expected)
+
+    def test_purge_on_startup_default_is_false(self):
+
+        original = [
+            {
+                "id": "thisIsAnID",
                 "created": "2016-03-02T20:23:00.000Z",
+                "max_age": 604800,
+                "authid": "example.authid",
+                "authrole": "example.authrole",
+                "authmethod": "example.authmethod"
+            },
+            {
+                "id": "thisIsAnID",
+                "modified": "2016-03-02T20:24:00.000Z",
                 "max_age": 604800,
                 "authid": "example.second.authid",
                 "authrole": "example.second.authrole",
@@ -32,8 +116,67 @@ class TestCookieStore(unittest.TestCase):
         ]
 
         with tempfile.NamedTemporaryFile() as fp:
-            fp.write(original)
-            fp.flush()
+            self.write_cookies_to_file(original, fp)
+
+            config = {
+                'store': {
+                    'type': 'file',
+                    'filename': fp.name
+                }
+            }
+
+            CookieStoreFileBacked(fp.name, config)
+
+            actual = self.read_cookies_from_file(fp)
+
+            self.assertEqual(actual, original)
+
+    def test_purge_on_startup_delete_expired_cookies(self):
+        max_age = 300
+        now = time.time()
+        valid_time = util.utcstr(datetime.fromtimestamp(now))
+        expired_time = util.utcstr(datetime.fromtimestamp(now - max_age - 10))
+
+        original = [
+            {
+                "id": "thisIsAnID",
+                "created": expired_time,
+                "max_age": max_age,
+                "authid": "example.authid",
+                "authrole": "example.authrole",
+                "authmethod": "example.authmethod"
+            },
+            {
+                "id": "thisIsAnotherID",
+                "created": valid_time,
+                "max_age": max_age,
+                "authid": "example.other.authid",
+                "authrole": "example.other.authrole",
+                "authmethod": "example.other.authmethod"
+            },
+            {
+                "id": "thisIsAnID",
+                "modified": valid_time,
+                "max_age": max_age,
+                "authid": "example.second.authid",
+                "authrole": "example.second.authrole",
+                "authmethod": "example.second.authmethod"
+            }
+        ]
+
+        expected = [
+            {
+                "id": "thisIsAnotherID",
+                "created": valid_time,
+                "max_age": max_age,
+                "authid": "example.other.authid",
+                "authrole": "example.other.authrole",
+                "authmethod": "example.other.authmethod"
+            },
+        ]
+
+        with tempfile.NamedTemporaryFile() as fp:
+            self.write_cookies_to_file(original, fp)
 
             config = {
                 'store': {
@@ -45,34 +188,5 @@ class TestCookieStore(unittest.TestCase):
 
             CookieStoreFileBacked(fp.name, config)
 
-            fp.seek(0)
-            actual = list()
-            for line in fp.readlines():
-                cookie = json.loads(line.decode('utf-8'))
-                actual.append(cookie)
-
-            actual.sort(key=lambda x: x['id'])
+            actual = self.read_cookies_from_file(fp)
             self.assertEqual(actual, expected)
-
-    def test_purge_on_startup_default_is_false(self):
-
-        original = b"""{"id":"thisIsAnID","created":"2016-03-02T20:23:00.000Z","max_age":604800,"authid":"example.authid","authrole":"example.authrole","authmethod":"example.authmethod"}
-{"id":"thisIsAnotherID","created":"2016-03-02T20:23:30.000Z","max_age":604800,"authid":"example.other.authid","authrole":"example.other.authrole","authmethod":"example.other.authmethod"}
-{"id":"thisIsAnID","modified":"2016-03-02T20:24:00.000Z","max_age":604800,"authid":"example.second.authid","authrole":"example.second.authrole","authmethod":"example.second.authmethod"}
-"""
-
-        with tempfile.NamedTemporaryFile() as fp:
-            fp.write(original)
-            fp.flush()
-
-            config = {
-                'store': {
-                    'type': 'file',
-                    'filename': fp.name
-                }
-            }
-
-            CookieStoreFileBacked(fp.name, config)
-
-            fp.seek(0)
-            self.assertEqual(fp.read(), original)


### PR DESCRIPTION
Follow-up to PR https://github.com/crossbario/crossbar/pull/670.
Remove expired cookies from the storage.
