### PR TITLE
Skip test if running as root

### DIFF
--- a/crossbar/twisted/test/test_endpoint.py
+++ b/crossbar/twisted/test/test_endpoint.py
@@ -142,3 +142,7 @@ class ListeningEndpointTests(TestCase):
         test_unix_already_listening.skip = _
         test_unix_already_listening_cant_delete.skip = _
         del _
+    elif os.getuid() == 0:
+        _ = "Cannot run as root"
+        test_unix_already_listening_cant_delete.skip = _
+        del _


### PR DESCRIPTION
I usually execute Crossbar.io tests via Docker. Since Crossbar.io runs as root the `test_unix_already_listening_cant_delete` test always fail.
I propose to skip it if running as root.