### PR TITLE
Realm templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,6 @@ clean:
 	# Learn to love the shell! http://unix.stackexchange.com/a/115869/52500
 	find . \( -name "*__pycache__" -type d \) -prune -exec rm -rf {} +
 
-
 install:
 	pip install --upgrade -e .[all]
 
@@ -32,7 +31,11 @@ install3:
 
 publish: clean
 	python setup.py register
-	python setup.py sdist bdist_wheel upload
+	python setup.py sdist upload
+	# we can't ship wheels: while CB itself doesn't have binary extensions,
+	# we do dynamic deps ..
+	# see: https://github.com/crossbario/crossbar/issues/525
+	#python setup.py bdist_wheel upload
 
 test: flake8
 	trial crossbar

--- a/crossbar/adapter/rest/callee.py
+++ b/crossbar/adapter/rest/callee.py
@@ -59,7 +59,7 @@ class RESTCallee(ApplicationSession):
 
             newURL = urljoin(baseURL, url)
 
-            params = {x.encode('utf8'): y.encode('utf8') for x,y in params.items()}
+            params = {x.encode('utf8'): y.encode('utf8') for x, y in params.items()}
 
             res = yield self._webtransport.request(
                 method,
@@ -70,7 +70,7 @@ class RESTCallee(ApplicationSession):
             )
             content = yield self._webtransport.text_content(res)
 
-            headers = {x.decode('utf8'):[z.decode('utf8') for z in y]
+            headers = {x.decode('utf8'): [z.decode('utf8') for z in y]
                        for x, y in dict(res.headers.getAllRawHeaders()).items()}
 
             resp = {

--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -2209,7 +2209,7 @@ def check_container(container):
     :type router: dict
     """
     for k in container:
-        if k not in ['id', 'type', 'options', 'manhole', 'components', 'connections']:
+        if k not in ['id', 'type', 'options', 'manhole', 'components', 'connections', 'template-realm']:
             raise InvalidConfigException("encountered unknown attribute '{}' in container configuration".format(k))
 
     # check stuff common to all native workers
@@ -2219,6 +2219,12 @@ def check_container(container):
 
     if 'options' in container:
         check_native_worker_options(container['options'])
+
+    # template-realm
+    #
+    if 'template-realm' in container:
+        # FIXME
+        pass
 
     # connections
     #

--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -2209,7 +2209,7 @@ def check_container(container):
     :type router: dict
     """
     for k in container:
-        if k not in ['id', 'type', 'options', 'manhole', 'components', 'connections', 'template-realm']:
+        if k not in ['id', 'type', 'options', 'manhole', 'components', 'connections', 'template', 'template-realm']:
             raise InvalidConfigException("encountered unknown attribute '{}' in container configuration".format(k))
 
     # check stuff common to all native workers
@@ -2222,7 +2222,7 @@ def check_container(container):
 
     # template-realm
     #
-    if 'template-realm' in container:
+    if container.get('template', False):
         # FIXME
         pass
 

--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -479,16 +479,19 @@ class Node(object):
             self.log.info("Using default node shutdown triggers {}".format(self._node_shutdown_triggers))
 
         # router and factory that creates router sessions
-        #
         self._router_factory = RouterFactory(self)
         self._router_session_factory = RouterSessionFactory(self._router_factory)
 
         rlm_config = {
+            # local node management realm (by default, "crossbar")
             'name': self._realm
         }
         rlm = RouterRealm(None, rlm_config)
 
-        # create a new router for the realm
+        # create a new router for the node management realm
+        #
+        # Note: the router factory by default only has a single role "trusted",
+        # stored in self._router_factory._routers[self._realm]._roles
         router = self._router_factory.start_realm(rlm)
 
         # add a router/realm service session

--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -40,7 +40,7 @@ from twisted.internet.defer import inlineCallbacks, Deferred
 from twisted.internet.ssl import optionsForClientTLS
 
 from autobahn.util import utcnow
-from autobahn.wamp.types import CallDetails, CallOptions, ComponentConfig
+from autobahn.wamp.types import CallDetails, ComponentConfig
 from autobahn.wamp.exception import ApplicationError
 from autobahn.twisted.wamp import ApplicationRunner
 
@@ -199,6 +199,9 @@ class Node(object):
 
         # map fro router worker IDs to
         self._realm_templates = {}
+
+        # fake call details we use to call into the local node management API
+        self._call_details = CallDetails(caller=0)
 
         # for node elements started under specific IDs, and where
         # the node configuration does not specify an ID, use a generic
@@ -571,206 +574,190 @@ class Node(object):
                           worker=worker_logname, uplink_id=uplink_id, realm_id=realm_id)
 
     @inlineCallbacks
+    def _run_worker_config(self, worker):
+        # worker ID
+        if 'id' in worker:
+            worker_id = worker.pop('id')
+        else:
+            worker_id = 'worker-{:03d}'.format(self._worker_no)
+            self._worker_no += 1
+
+        # worker type - a type of working process from the following fixed list
+        worker_type = worker['type']
+        assert(worker_type in ['router', 'container', 'websocket-testee', 'guest'])
+
+        # set logname depending on worker type
+        if worker_type == 'router':
+            worker_logname = "Router '{}'".format(worker_id)
+        elif worker_type == 'container':
+            worker_logname = "Container '{}'".format(worker_id)
+        elif worker_type == 'websocket-testee':
+            worker_logname = "WebSocketTestee '{}'".format(worker_id)
+        elif worker_type == 'guest':
+            worker_logname = "Guest '{}'".format(worker_id)
+        else:
+            raise Exception("logic error")
+
+        # any worker specific options
+        worker_options = worker.get('options', {})
+
+        # start native worker process (router, container, websocket-testee)
+        if worker_type in ['router', 'container', 'websocket-testee']:
+
+            # start a new native worker process ..
+            if worker_type == 'router':
+                yield self._controller.start_router(worker_id, worker_options, details=self._call_details)
+
+            elif worker_type == 'container':
+                yield self._controller.start_container(worker_id, worker_options, details=self._call_details)
+
+            elif worker_type == 'websocket-testee':
+                yield self._controller.start_websocket_testee(worker_id, worker_options, details=self._call_details)
+
+            # setup native worker generic stuff
+            if 'pythonpath' in worker_options:
+                added_paths = yield self._controller.call('crossbar.node.{}.worker.{}.add_pythonpath'.format(self._node_id, worker_id), worker_options['pythonpath'])
+                self.log.debug("{worker}: PYTHONPATH extended for {paths}",
+                               worker=worker_logname, paths=added_paths)
+
+            if 'cpu_affinity' in worker_options:
+                new_affinity = yield self._controller.call('crossbar.node.{}.worker.{}.set_cpu_affinity'.format(self._node_id, worker_id), worker_options['cpu_affinity'])
+                self.log.debug("{worker}: CPU affinity set to {affinity}",
+                               worker=worker_logname, affinity=new_affinity)
+
+            if 'manhole' in worker:
+                yield self._controller.call('crossbar.node.{}.worker.{}.start_manhole'.format(self._node_id, worker_id), worker['manhole'])
+                self.log.debug("{worker}: manhole started",
+                               worker=worker_logname)
+
+            # setup container worker
+            if worker_type == 'router':
+                yield self._run_router_config(worker, worker_id, worker_logname, worker_options)
+
+            # setup container worker
+            elif worker_type == 'container':
+                yield self._run_container_config(worker, worker_id, worker_logname, worker_options)
+
+            # setup websocket-testee worker
+            elif worker_type == 'websocket-testee':
+
+                # start transport on websocket-testee
+                transport = worker['transport']
+                transport_id = 'transport-{:03d}'.format(self._transport_no)
+                self._transport_no = 1
+
+                yield self._controller.call('crossbar.node.{}.worker.{}.start_websocket_testee_transport'.format(self._node_id, worker_id), transport_id, transport)
+                self.log.info("{}: transport '{}' started".format(worker_logname, transport_id))
+
+            else:
+                raise Exception("logic error")
+
+        # start guest (= non-native) worker process
+        elif worker_type == 'guest':
+            yield self._controller.start_guest(worker_id, worker, details=self._call_details)
+            self.log.info("{worker}: started", worker=worker_logname)
+
+        else:
+            raise Exception("logic error")
+
+    @inlineCallbacks
+    def _run_router_config(self, worker, worker_id, worker_logname, worker_options):
+        # start realms on router
+        for realm in worker.get('realms', []):
+            if realm.get('template', False):
+                # templated realm elements are stored for later instantiation
+                if worker_id not in self._realm_templates:
+                    self._realm_templates[worker_id] = []
+                self._realm_templates[worker_id].append(realm)
+            else:
+                # regular realm elements are started directly
+                yield self._run_realm_config(worker_id, worker_logname, realm)
+
+        # start connections (such as PostgreSQL database connection pools)
+        # to run embedded in the router
+        for connection in worker.get('connections', []):
+
+            if 'id' in connection:
+                connection_id = connection.pop('id')
+            else:
+                connection_id = 'connection-{:03d}'.format(self._connection_no)
+                self._connection_no += 1
+
+            yield self._controller.call('crossbar.node.{}.worker.{}.start_connection'.format(self._node_id, worker_id), connection_id, connection)
+            self.log.info("{}: connection '{}' started".format(worker_logname, connection_id))
+
+        # start components to run embedded in the router
+        for component in worker.get('components', []):
+
+            if 'id' in component:
+                component_id = component.pop('id')
+            else:
+                component_id = 'component-{:03d}'.format(self._component_no)
+                self._component_no += 1
+
+            yield self._controller.call('crossbar.node.{}.worker.{}.start_router_component'.format(self._node_id, worker_id), component_id, component)
+            self.log.info("{}: component '{}' started".format(worker_logname, component_id))
+
+        # start transports on router
+        for transport in worker['transports']:
+
+            if 'id' in transport:
+                transport_id = transport.pop('id')
+            else:
+                transport_id = 'transport-{:03d}'.format(self._transport_no)
+                self._transport_no += 1
+
+            yield self._controller.call('crossbar.node.{}.worker.{}.start_router_transport'.format(self._node_id, worker_id), transport_id, transport)
+            self.log.info("{}: transport '{}' started".format(worker_logname, transport_id))
+
+    @inlineCallbacks
+    def _run_container_config(self, worker, worker_id, worker_logname, worker_options):
+        # if components exit "very soon after" we try to
+        # start them, we consider that a failure and shut
+        # our node down. We remove this subscription 2
+        # seconds after we're done starting everything
+        # (see below). This is necessary as
+        # start_container_component returns as soon as
+        # we've established a connection to the component
+        def component_exited(info):
+            component_id = info.get("id")
+            self.log.critical("Component '{component_id}' failed to start; shutting down node.", component_id=component_id)
+            try:
+                self._reactor.stop()
+            except twisted.internet.error.ReactorNotRunning:
+                pass
+        topic = 'crossbar.node.{}.worker.{}.container.on_component_stop'.format(self._node_id, worker_id)
+        component_stop_sub = yield self._controller.subscribe(component_exited, topic)
+
+        # start components to run embedded in the container
+        #
+        for component in worker.get('components', []):
+
+            if 'id' in component:
+                component_id = component.pop('id')
+            else:
+                component_id = 'component-{:03d}'.format(self._component_no)
+                self._component_no += 1
+
+            yield self._controller.call('crossbar.node.{}.worker.{}.start_container_component'.format(self._node_id, worker_id), component_id, component)
+            self.log.info("{worker}: component '{component_id}' started",
+                          worker=worker_logname, component_id=component_id)
+
+        # after 2 seconds, consider all the application components running
+        self._reactor.callLater(2, component_stop_sub.unsubscribe)
+
+    @inlineCallbacks
     def _run_config(self, config):
         """
         Startup elements in the node as specified in the provided node configuration.
         """
-        # call options we use to call into the local node management API
-        call_options = CallOptions()
-
-        # fake call details we use to call into the local node management API
-        call_details = CallDetails(caller=0)
-
         # get contoller configuration subpart
         controller = config.get('controller', {})
 
         # start Manhole in node controller
         if 'manhole' in controller:
-            yield self._controller.start_manhole(controller['manhole'], details=call_details)
+            yield self._controller.start_manhole(controller['manhole'], details=self._call_details)
 
-        # startup all workers
+        # startup all workers ..
         for worker in config.get('workers', []):
-
-            # worker ID
-            if 'id' in worker:
-                worker_id = worker.pop('id')
-            else:
-                worker_id = 'worker-{:03d}'.format(self._worker_no)
-                self._worker_no += 1
-
-            # worker type - a type of working process from the following fixed list
-            worker_type = worker['type']
-            assert(worker_type in ['router', 'container', 'guest', 'websocket-testee'])
-
-            # set logname depending on worker type
-            if worker_type == 'router':
-                worker_logname = "Router '{}'".format(worker_id)
-            elif worker_type == 'container':
-                worker_logname = "Container '{}'".format(worker_id)
-            elif worker_type == 'websocket-testee':
-                worker_logname = "WebSocketTestee '{}'".format(worker_id)
-            elif worker_type == 'guest':
-                worker_logname = "Guest '{}'".format(worker_id)
-            else:
-                raise Exception("logic error")
-
-            # any worker specific options
-            worker_options = worker.get('options', {})
-
-            # native worker processes: router, container, websocket-testee
-            if worker_type in ['router', 'container', 'websocket-testee']:
-
-                # start a new native worker process ..
-                if worker_type == 'router':
-                    yield self._controller.start_router(worker_id, worker_options, details=call_details)
-
-                elif worker_type == 'container':
-                    yield self._controller.start_container(worker_id, worker_options, details=call_details)
-
-                elif worker_type == 'websocket-testee':
-                    yield self._controller.start_websocket_testee(worker_id, worker_options, details=call_details)
-
-                else:
-                    raise Exception("logic error")
-
-                # setup native worker generic stuff
-                if 'pythonpath' in worker_options:
-                    added_paths = yield self._controller.call('crossbar.node.{}.worker.{}.add_pythonpath'.format(self._node_id, worker_id), worker_options['pythonpath'], options=call_options)
-                    self.log.debug("{worker}: PYTHONPATH extended for {paths}",
-                                   worker=worker_logname, paths=added_paths)
-
-                if 'cpu_affinity' in worker_options:
-                    new_affinity = yield self._controller.call('crossbar.node.{}.worker.{}.set_cpu_affinity'.format(self._node_id, worker_id), worker_options['cpu_affinity'], options=call_options)
-                    self.log.debug("{worker}: CPU affinity set to {affinity}",
-                                   worker=worker_logname, affinity=new_affinity)
-
-                if 'manhole' in worker:
-                    yield self._controller.call('crossbar.node.{}.worker.{}.start_manhole'.format(self._node_id, worker_id), worker['manhole'], options=call_options)
-                    self.log.debug("{worker}: manhole started",
-                                   worker=worker_logname)
-
-                # setup router worker
-                if worker_type == 'router':
-
-                    # start realms on router
-                    for realm in worker.get('realms', []):
-                        if realm.get('template', False):
-                            # templated realm elements are stored for later instantiation
-                            if worker_id not in self._realm_templates:
-                                self._realm_templates[worker_id] = []
-                            self._realm_templates[worker_id].append(realm)
-                        else:
-                            # regular realm elements are started directly
-                            yield self._run_realm_config(worker_id, worker_logname, realm)
-
-                    # start connections (such as PostgreSQL database connection pools)
-                    # to run embedded in the router
-                    for connection in worker.get('connections', []):
-
-                        if 'id' in connection:
-                            connection_id = connection.pop('id')
-                        else:
-                            connection_id = 'connection-{:03d}'.format(self._connection_no)
-                            self._connection_no += 1
-
-                        yield self._controller.call('crossbar.node.{}.worker.{}.start_connection'.format(self._node_id, worker_id), connection_id, connection, options=call_options)
-                        self.log.info("{}: connection '{}' started".format(worker_logname, connection_id))
-
-                    # start components to run embedded in the router
-                    for component in worker.get('components', []):
-
-                        if 'id' in component:
-                            component_id = component.pop('id')
-                        else:
-                            component_id = 'component-{:03d}'.format(self._component_no)
-                            self._component_no += 1
-
-                        yield self._controller.call('crossbar.node.{}.worker.{}.start_router_component'.format(self._node_id, worker_id), component_id, component, options=call_options)
-                        self.log.info("{}: component '{}' started".format(worker_logname, component_id))
-
-                    # start transports on router
-                    for transport in worker['transports']:
-
-                        if 'id' in transport:
-                            transport_id = transport.pop('id')
-                        else:
-                            transport_id = 'transport-{:03d}'.format(self._transport_no)
-                            self._transport_no += 1
-
-                        yield self._controller.call('crossbar.node.{}.worker.{}.start_router_transport'.format(self._node_id, worker_id), transport_id, transport, options=call_options)
-                        self.log.info("{}: transport '{}' started".format(worker_logname, transport_id))
-
-                # setup container worker
-                elif worker_type == 'container':
-
-                    # if components exit "very soon after" we try to
-                    # start them, we consider that a failure and shut
-                    # our node down. We remove this subscription 2
-                    # seconds after we're done starting everything
-                    # (see below). This is necessary as
-                    # start_container_component returns as soon as
-                    # we've established a connection to the component
-                    def component_exited(info):
-                        component_id = info.get("id")
-                        self.log.critical("Component '{component_id}' failed to start; shutting down node.", component_id=component_id)
-                        try:
-                            self._reactor.stop()
-                        except twisted.internet.error.ReactorNotRunning:
-                            pass
-                    topic = 'crossbar.node.{}.worker.{}.container.on_component_stop'.format(self._node_id, worker_id)
-                    component_stop_sub = yield self._controller.subscribe(component_exited, topic)
-
-                    # start connections (such as PostgreSQL database connection pools)
-                    # to run embedded in the container
-                    #
-                    for connection in worker.get('connections', []):
-
-                        if 'id' in connection:
-                            connection_id = connection.pop('id')
-                        else:
-                            connection_id = 'connection-{:03d}'.format(self._connection_no)
-                            self._connection_no += 1
-
-                        yield self._controller.call('crossbar.node.{}.worker.{}.start_connection'.format(self._node_id, worker_id), connection_id, connection, options=call_options)
-                        self.log.info("{}: connection '{}' started".format(worker_logname, connection_id))
-
-                    # start components to run embedded in the container
-                    #
-                    for component in worker.get('components', []):
-
-                        if 'id' in component:
-                            component_id = component.pop('id')
-                        else:
-                            component_id = 'component-{:03d}'.format(self._component_no)
-                            self._component_no += 1
-
-                        yield self._controller.call('crossbar.node.{}.worker.{}.start_container_component'.format(self._node_id, worker_id), component_id, component, options=call_options)
-                        self.log.info("{worker}: component '{component_id}' started",
-                                      worker=worker_logname, component_id=component_id)
-
-                    # after 2 seconds, consider all the application components running
-                    self._reactor.callLater(2, component_stop_sub.unsubscribe)
-
-                # setup websocket-testee worker
-                elif worker_type == 'websocket-testee':
-
-                    # start transport on websocket-testee
-                    transport = worker['transport']
-                    transport_id = 'transport-{:03d}'.format(self._transport_no)
-                    self._transport_no = 1
-
-                    yield self._controller.call('crossbar.node.{}.worker.{}.start_websocket_testee_transport'.format(self._node_id, worker_id), transport_id, transport, options=call_options)
-                    self.log.info("{}: transport '{}' started".format(worker_logname, transport_id))
-
-                else:
-                    raise Exception("logic error")
-
-            elif worker_type == 'guest':
-
-                # start guest worker
-                #
-                yield self._controller.start_guest(worker_id, worker, details=call_details)
-                self.log.info("{worker}: started", worker=worker_logname)
-
-            else:
-                raise Exception("logic error")
+            yield self._run_worker_config(worker)

--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -358,9 +358,12 @@ class Node(object):
             if 'transport' in cdc_config:
                 transport = cdc_config['transport']
                 if 'tls' in transport['endpoint']:
-                    hostname = transport['endpoint']['tls']['hostname']
+                    if 'hostname' in transport['endpoint']:
+                        hostname = transport['endpoint']['tls']['hostname']
+                    else:
+                        raise Exception("TLS activated on CDC connection, but 'hostname' not provided")
                 else:
-                    raise Exception("TLS activated on CDC connection, but 'hostname' not provided")
+                    hostname = None
                 self.log.warn("CDC transport configuration overridden from node config!")
             else:
                 transport = {
@@ -413,7 +416,7 @@ class Node(object):
 
             runner = ApplicationRunner(
                 url=transport['url'], realm=realm, extra=extra,
-                ssl=optionsForClientTLS(hostname),
+                ssl=optionsForClientTLS(hostname) if hostname else None,
             )
 
             try:

--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -31,8 +31,6 @@
 from __future__ import absolute_import
 
 import os
-import re
-import json
 import traceback
 import socket
 import getpass
@@ -198,6 +196,19 @@ class Node(object):
 
         # node shutdown triggers, one or more of checkconfig.NODE_SHUTDOWN_MODES
         self._node_shutdown_triggers = [checkconfig.NODE_SHUTDOWN_ON_WORKER_EXIT]
+
+        # map fro router worker IDs to
+        self._realm_templates = {}
+
+        # for node elements started under specific IDs, and where
+        # the node configuration does not specify an ID, use a generic
+        # name numbered sequentially using the counters here
+        self._worker_no = 1
+        self._realm_no = 1
+        self._role_no = 1
+        self._connection_no = 1
+        self._transport_no = 1
+        self._component_no = 1
 
     def load(self, configfile=None):
         """
@@ -521,58 +532,55 @@ class Node(object):
 
     @inlineCallbacks
     def _startup(self, config):
-        # fake call details information when calling into
-        # remoted procedure locally
-        #
+        """
+        Startup elements in the node as specified in the provided node configuration.
+        """
+        # call options we use to call into the local node management API
+        call_options = CallOptions()
+
+        # fake call details we use to call into the local node management API
         call_details = CallDetails(caller=0)
 
+        # get contoller configuration subpart
         controller = config.get('controller', {})
 
         # start Manhole in node controller
-        #
         if 'manhole' in controller:
             yield self._controller.start_manhole(controller['manhole'], details=call_details)
 
         # startup all workers
-        #
-        worker_no = 1
-
-        # FIXME: setup things so we disclose our identity!
-        call_options = CallOptions()
-
         for worker in config.get('workers', []):
-            # worker ID, type and logname
-            #
+
+            # worker ID
             if 'id' in worker:
                 worker_id = worker.pop('id')
             else:
-                worker_id = 'worker{}'.format(worker_no)
-                worker_no += 1
+                worker_id = 'worker{}'.format(self._worker_no)
+                self._worker_no += 1
 
+            # worker type - a type of working process from the following fixed list
             worker_type = worker['type']
-            worker_options = worker.get('options', {})
+            assert(worker_type in ['router', 'container', 'guest', 'websocket-testee'])
 
+            # set logname depending on worker type
             if worker_type == 'router':
                 worker_logname = "Router '{}'".format(worker_id)
-
             elif worker_type == 'container':
                 worker_logname = "Container '{}'".format(worker_id)
-
             elif worker_type == 'websocket-testee':
                 worker_logname = "WebSocketTestee '{}'".format(worker_id)
-
             elif worker_type == 'guest':
                 worker_logname = "Guest '{}'".format(worker_id)
-
             else:
                 raise Exception("logic error")
 
-            # router/container
-            #
+            # any worker specific options
+            worker_options = worker.get('options', {})
+
+            # native worker processes: router, container, websocket-testee
             if worker_type in ['router', 'container', 'websocket-testee']:
 
                 # start a new native worker process ..
-                #
                 if worker_type == 'router':
                     yield self._controller.start_router(worker_id, worker_options, details=call_details)
 
@@ -586,7 +594,6 @@ class Node(object):
                     raise Exception("logic error")
 
                 # setup native worker generic stuff
-                #
                 if 'pythonpath' in worker_options:
                     added_paths = yield self._controller.call('crossbar.node.{}.worker.{}.add_pythonpath'.format(self._node_id, worker_id), worker_options['pythonpath'], options=call_options)
                     self.log.debug("{worker}: PYTHONPATH extended for {paths}",
@@ -603,132 +610,83 @@ class Node(object):
                                    worker=worker_logname)
 
                 # setup router worker
-                #
                 if worker_type == 'router':
 
                     # start realms on router
-                    #
-                    realm_no = 1
-
                     for realm in worker.get('realms', []):
 
+                        # start realm
                         if 'id' in realm:
                             realm_id = realm.pop('id')
                         else:
-                            realm_id = 'realm{}'.format(realm_no)
-                            realm_no += 1
+                            realm_id = 'realm{}'.format(self._realm_no)
+                            self._realm_no += 1
 
-                        # extract schema information from WAMP-flavored Markdown
-                        #
-                        schemas = None
-                        if 'schemas' in realm:
-                            schemas = {}
-                            schema_pat = re.compile(r"```javascript(.*?)```", re.DOTALL)
-                            cnt_files = 0
-                            cnt_decls = 0
-                            for schema_file in realm.pop('schemas'):
-                                schema_file = os.path.join(self._cbdir, schema_file)
-                                self.log.info("{worker}: processing WAMP-flavored Markdown file {schema_file} for WAMP schema declarations",
-                                              worker=worker_logname, schema_file=schema_file)
-                                with open(schema_file, 'r') as f:
-                                    cnt_files += 1
-                                    for d in schema_pat.findall(f.read()):
-                                        try:
-                                            o = json.loads(d)
-                                            if isinstance(o, dict) and '$schema' in o and o['$schema'] == u'http://wamp.ws/schema#':
-                                                uri = o['uri']
-                                                if uri not in schemas:
-                                                    schemas[uri] = {}
-                                                schemas[uri].update(o)
-                                                cnt_decls += 1
-                                        except Exception:
-                                            self.log.failure("{worker}: WARNING - failed to process declaration in {schema_file} - {log_failure.value}",
-                                                             worker=worker_logname, schema_file=schema_file)
-                            self.log.info("{worker}: processed {cnt_files} files extracting {cnt_decls} schema declarations and {len_schemas} URIs",
-                                          worker=worker_logname, cnt_files=cnt_files, cnt_decls=cnt_decls, len_schemas=len(schemas))
-
-                        enable_trace = realm.get('trace', False)
-                        yield self._controller.call('crossbar.node.{}.worker.{}.start_router_realm'.format(self._node_id, worker_id), realm_id, realm, schemas, enable_trace=enable_trace, options=call_options)
+                        yield self._controller.call('crossbar.node.{}.worker.{}.start_router_realm'.format(self._node_id, worker_id), realm_id, realm, options=call_options)
                         self.log.info("{worker}: realm '{realm_id}' (named '{realm_name}') started",
-                                      worker=worker_logname, realm_id=realm_id, realm_name=realm['name'], enable_trace=enable_trace)
+                                      worker=worker_logname, realm_id=realm_id, realm_name=realm['name'])
 
                         # add roles to realm
-                        #
-                        role_no = 1
                         for role in realm.get('roles', []):
                             if 'id' in role:
                                 role_id = role.pop('id')
                             else:
-                                role_id = 'role{}'.format(role_no)
-                                role_no += 1
+                                role_id = 'role{}'.format(self._role_no)
+                                self._role_no += 1
 
                             yield self._controller.call('crossbar.node.{}.worker.{}.start_router_realm_role'.format(self._node_id, worker_id), realm_id, role_id, role, options=call_options)
                             self.log.info("{}: role '{}' (named '{}') started on realm '{}'".format(worker_logname, role_id, role['name'], realm_id))
 
                         # start uplinks for realm
-                        #
-                        uplink_no = 1
                         for uplink in realm.get('uplinks', []):
                             if 'id' in uplink:
                                 uplink_id = uplink.pop('id')
                             else:
-                                uplink_id = 'uplink{}'.format(uplink_no)
-                                uplink_no += 1
+                                uplink_id = 'uplink{}'.format(self._uplink_no)
+                                self._uplink_no += 1
 
                             yield self._controller.call('crossbar.node.{}.worker.{}.start_router_realm_uplink'.format(self._node_id, worker_id), realm_id, uplink_id, uplink, options=call_options)
                             self.log.info("{}: uplink '{}' started on realm '{}'".format(worker_logname, uplink_id, realm_id))
 
                     # start connections (such as PostgreSQL database connection pools)
                     # to run embedded in the router
-                    #
-                    connection_no = 1
-
                     for connection in worker.get('connections', []):
 
                         if 'id' in connection:
                             connection_id = connection.pop('id')
                         else:
-                            connection_id = 'connection{}'.format(connection_no)
-                            connection_no += 1
+                            connection_id = 'connection{}'.format(self._connection_no)
+                            self._connection_no += 1
 
                         yield self._controller.call('crossbar.node.{}.worker.{}.start_connection'.format(self._node_id, worker_id), connection_id, connection, options=call_options)
                         self.log.info("{}: connection '{}' started".format(worker_logname, connection_id))
 
                     # start components to run embedded in the router
-                    #
-                    component_no = 1
-
                     for component in worker.get('components', []):
 
                         if 'id' in component:
                             component_id = component.pop('id')
                         else:
-                            component_id = 'component{}'.format(component_no)
-                            component_no += 1
+                            component_id = 'component{}'.format(self._component_no)
+                            self._component_no += 1
 
                         yield self._controller.call('crossbar.node.{}.worker.{}.start_router_component'.format(self._node_id, worker_id), component_id, component, options=call_options)
                         self.log.info("{}: component '{}' started".format(worker_logname, component_id))
 
                     # start transports on router
-                    #
-                    transport_no = 1
-
                     for transport in worker['transports']:
 
                         if 'id' in transport:
                             transport_id = transport.pop('id')
                         else:
-                            transport_id = 'transport{}'.format(transport_no)
-                            transport_no += 1
+                            transport_id = 'transport{}'.format(self._transport_no)
+                            self._transport_no += 1
 
                         yield self._controller.call('crossbar.node.{}.worker.{}.start_router_transport'.format(self._node_id, worker_id), transport_id, transport, options=call_options)
                         self.log.info("{}: transport '{}' started".format(worker_logname, transport_id))
 
                 # setup container worker
-                #
                 elif worker_type == 'container':
-
-                    component_no = 1
 
                     # if components exit "very soon after" we try to
                     # start them, we consider that a failure and shut
@@ -750,15 +708,13 @@ class Node(object):
                     # start connections (such as PostgreSQL database connection pools)
                     # to run embedded in the container
                     #
-                    connection_no = 1
-
                     for connection in worker.get('connections', []):
 
                         if 'id' in connection:
                             connection_id = connection.pop('id')
                         else:
-                            connection_id = 'connection{}'.format(connection_no)
-                            connection_no += 1
+                            connection_id = 'connection{}'.format(self._connection_no)
+                            self._connection_no += 1
 
                         yield self._controller.call('crossbar.node.{}.worker.{}.start_connection'.format(self._node_id, worker_id), connection_id, connection, options=call_options)
                         self.log.info("{}: connection '{}' started".format(worker_logname, connection_id))
@@ -770,8 +726,8 @@ class Node(object):
                         if 'id' in component:
                             component_id = component.pop('id')
                         else:
-                            component_id = 'component{}'.format(component_no)
-                            component_no += 1
+                            component_id = 'component{}'.format(self._component_no)
+                            self._component_no += 1
 
                         yield self._controller.call('crossbar.node.{}.worker.{}.start_container_component'.format(self._node_id, worker_id), component_id, component, options=call_options)
                         self.log.info("{worker}: component '{component_id}' started",
@@ -781,14 +737,12 @@ class Node(object):
                     self._reactor.callLater(2, component_stop_sub.unsubscribe)
 
                 # setup websocket-testee worker
-                #
                 elif worker_type == 'websocket-testee':
 
-                    # start transports on router
-                    #
+                    # start transport on websocket-testee
                     transport = worker['transport']
-                    transport_no = 1
-                    transport_id = 'transport{}'.format(transport_no)
+                    transport_id = 'transport{}'.format(self._transport_no)
+                    self._transport_no = 1
 
                     yield self._controller.call('crossbar.node.{}.worker.{}.start_websocket_testee_transport'.format(self._node_id, worker_id), transport_id, transport, options=call_options)
                     self.log.info("{}: transport '{}' started".format(worker_logname, transport_id))

--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -539,7 +539,8 @@ class Node(object):
             realm_id = 'realm-{:03d}'.format(self._realm_no)
             self._realm_no += 1
 
-        yield self._controller.call('crossbar.node.{}.worker.{}.start_router_realm'.format(self._node_id, worker_id), realm_id, realm)
+        yield self._controller.call('crossbar.node.{}.worker.{}.start_router_realm'.format(self._node_id, worker_id),
+                                    realm_id, realm)
         self.log.info("{worker}: realm '{realm_id}' (named '{realm_name}') started",
                       worker=worker_logname, realm_id=realm_id, realm_name=realm['name'])
 
@@ -551,8 +552,10 @@ class Node(object):
                 role_id = 'role-{:03d}'.format(self._role_no)
                 self._role_no += 1
 
-            yield self._controller.call('crossbar.node.{}.worker.{}.start_router_realm_role'.format(self._node_id, worker_id), realm_id, role_id, role)
-            self.log.info("{}: role '{}' (named '{}') started on realm '{}'".format(worker_logname, role_id, role['name'], realm_id))
+            yield self._controller.call('crossbar.node.{}.worker.{}.start_router_realm_role'.format(self._node_id, worker_id),
+                                        realm_id, role_id, role)
+            self.log.info("{worker}: role '{role_id}' (named '{role_name}') started on realm '{realm_id}'",
+                          worker=worker_logname, role_id=role_id, role_name=role['name'], realm_id=realm_id)
 
         # start uplinks for realm
         for uplink in realm.get('uplinks', []):
@@ -562,8 +565,10 @@ class Node(object):
                 uplink_id = 'uplink-{:03d}'.format(self._uplink_no)
                 self._uplink_no += 1
 
-            yield self._controller.call('crossbar.node.{}.worker.{}.start_router_realm_uplink'.format(self._node_id, worker_id), realm_id, uplink_id, uplink)
-            self.log.info("{}: uplink '{}' started on realm '{}'".format(worker_logname, uplink_id, realm_id))
+            yield self._controller.call('crossbar.node.{}.worker.{}.start_router_realm_uplink'.format(self._node_id, worker_id),
+                                        realm_id, uplink_id, uplink)
+            self.log.info("{worker}: uplink '{uplink_id}' started on realm '{realm_id}'",
+                          worker=worker_logname, uplink_id=uplink_id, realm_id=realm_id)
 
     @inlineCallbacks
     def _run_config(self, config):

--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -461,7 +461,7 @@ class Node(object):
 
         # router and factory that creates router sessions
         #
-        self._router_factory = RouterFactory(self._node_id)
+        self._router_factory = RouterFactory(self)
         self._router_session_factory = RouterSessionFactory(self._router_factory)
 
         rlm_config = {
@@ -507,7 +507,7 @@ class Node(object):
         panic = False
 
         try:
-            yield self._startup(self._config)
+            yield self._run_config(self._config)
 
             # Notify systemd that crossbar is fully up and running
             # This has no effect on non-systemd platforms
@@ -531,7 +531,42 @@ class Node(object):
                 pass
 
     @inlineCallbacks
-    def _startup(self, config):
+    def _run_realm_config(self, worker_id, worker_logname, realm):
+        # start realm
+        if 'id' in realm:
+            realm_id = realm.pop('id')
+        else:
+            realm_id = 'realm-{:03d}'.format(self._realm_no)
+            self._realm_no += 1
+
+        yield self._controller.call('crossbar.node.{}.worker.{}.start_router_realm'.format(self._node_id, worker_id), realm_id, realm)
+        self.log.info("{worker}: realm '{realm_id}' (named '{realm_name}') started",
+                      worker=worker_logname, realm_id=realm_id, realm_name=realm['name'])
+
+        # add roles to realm
+        for role in realm.get('roles', []):
+            if 'id' in role:
+                role_id = role.pop('id')
+            else:
+                role_id = 'role-{:03d}'.format(self._role_no)
+                self._role_no += 1
+
+            yield self._controller.call('crossbar.node.{}.worker.{}.start_router_realm_role'.format(self._node_id, worker_id), realm_id, role_id, role)
+            self.log.info("{}: role '{}' (named '{}') started on realm '{}'".format(worker_logname, role_id, role['name'], realm_id))
+
+        # start uplinks for realm
+        for uplink in realm.get('uplinks', []):
+            if 'id' in uplink:
+                uplink_id = uplink.pop('id')
+            else:
+                uplink_id = 'uplink-{:03d}'.format(self._uplink_no)
+                self._uplink_no += 1
+
+            yield self._controller.call('crossbar.node.{}.worker.{}.start_router_realm_uplink'.format(self._node_id, worker_id), realm_id, uplink_id, uplink)
+            self.log.info("{}: uplink '{}' started on realm '{}'".format(worker_logname, uplink_id, realm_id))
+
+    @inlineCallbacks
+    def _run_config(self, config):
         """
         Startup elements in the node as specified in the provided node configuration.
         """
@@ -614,39 +649,14 @@ class Node(object):
 
                     # start realms on router
                     for realm in worker.get('realms', []):
-
-                        # start realm
-                        if 'id' in realm:
-                            realm_id = realm.pop('id')
+                        if realm.get('template', False):
+                            # templated realm elements are stored for later instantiation
+                            if worker_id not in self._realm_templates:
+                                self._realm_templates[worker_id] = []
+                            self._realm_templates[worker_id].append(realm)
                         else:
-                            realm_id = 'realm-{:03d}'.format(self._realm_no)
-                            self._realm_no += 1
-
-                        yield self._controller.call('crossbar.node.{}.worker.{}.start_router_realm'.format(self._node_id, worker_id), realm_id, realm, options=call_options)
-                        self.log.info("{worker}: realm '{realm_id}' (named '{realm_name}') started",
-                                      worker=worker_logname, realm_id=realm_id, realm_name=realm['name'])
-
-                        # add roles to realm
-                        for role in realm.get('roles', []):
-                            if 'id' in role:
-                                role_id = role.pop('id')
-                            else:
-                                role_id = 'role-{:03d}'.format(self._role_no)
-                                self._role_no += 1
-
-                            yield self._controller.call('crossbar.node.{}.worker.{}.start_router_realm_role'.format(self._node_id, worker_id), realm_id, role_id, role, options=call_options)
-                            self.log.info("{}: role '{}' (named '{}') started on realm '{}'".format(worker_logname, role_id, role['name'], realm_id))
-
-                        # start uplinks for realm
-                        for uplink in realm.get('uplinks', []):
-                            if 'id' in uplink:
-                                uplink_id = uplink.pop('id')
-                            else:
-                                uplink_id = 'uplink-{:03d}'.format(self._uplink_no)
-                                self._uplink_no += 1
-
-                            yield self._controller.call('crossbar.node.{}.worker.{}.start_router_realm_uplink'.format(self._node_id, worker_id), realm_id, uplink_id, uplink, options=call_options)
-                            self.log.info("{}: uplink '{}' started on realm '{}'".format(worker_logname, uplink_id, realm_id))
+                            # regular realm elements are started directly
+                            yield self._run_realm_config(worker_id, worker_logname, realm)
 
                     # start connections (such as PostgreSQL database connection pools)
                     # to run embedded in the router

--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -555,7 +555,7 @@ class Node(object):
             if 'id' in worker:
                 worker_id = worker.pop('id')
             else:
-                worker_id = 'worker{}'.format(self._worker_no)
+                worker_id = 'worker-{:03d}'.format(self._worker_no)
                 self._worker_no += 1
 
             # worker type - a type of working process from the following fixed list
@@ -619,7 +619,7 @@ class Node(object):
                         if 'id' in realm:
                             realm_id = realm.pop('id')
                         else:
-                            realm_id = 'realm{}'.format(self._realm_no)
+                            realm_id = 'realm-{:03d}'.format(self._realm_no)
                             self._realm_no += 1
 
                         yield self._controller.call('crossbar.node.{}.worker.{}.start_router_realm'.format(self._node_id, worker_id), realm_id, realm, options=call_options)
@@ -631,7 +631,7 @@ class Node(object):
                             if 'id' in role:
                                 role_id = role.pop('id')
                             else:
-                                role_id = 'role{}'.format(self._role_no)
+                                role_id = 'role-{:03d}'.format(self._role_no)
                                 self._role_no += 1
 
                             yield self._controller.call('crossbar.node.{}.worker.{}.start_router_realm_role'.format(self._node_id, worker_id), realm_id, role_id, role, options=call_options)
@@ -642,7 +642,7 @@ class Node(object):
                             if 'id' in uplink:
                                 uplink_id = uplink.pop('id')
                             else:
-                                uplink_id = 'uplink{}'.format(self._uplink_no)
+                                uplink_id = 'uplink-{:03d}'.format(self._uplink_no)
                                 self._uplink_no += 1
 
                             yield self._controller.call('crossbar.node.{}.worker.{}.start_router_realm_uplink'.format(self._node_id, worker_id), realm_id, uplink_id, uplink, options=call_options)
@@ -655,7 +655,7 @@ class Node(object):
                         if 'id' in connection:
                             connection_id = connection.pop('id')
                         else:
-                            connection_id = 'connection{}'.format(self._connection_no)
+                            connection_id = 'connection-{:03d}'.format(self._connection_no)
                             self._connection_no += 1
 
                         yield self._controller.call('crossbar.node.{}.worker.{}.start_connection'.format(self._node_id, worker_id), connection_id, connection, options=call_options)
@@ -667,7 +667,7 @@ class Node(object):
                         if 'id' in component:
                             component_id = component.pop('id')
                         else:
-                            component_id = 'component{}'.format(self._component_no)
+                            component_id = 'component-{:03d}'.format(self._component_no)
                             self._component_no += 1
 
                         yield self._controller.call('crossbar.node.{}.worker.{}.start_router_component'.format(self._node_id, worker_id), component_id, component, options=call_options)
@@ -679,7 +679,7 @@ class Node(object):
                         if 'id' in transport:
                             transport_id = transport.pop('id')
                         else:
-                            transport_id = 'transport{}'.format(self._transport_no)
+                            transport_id = 'transport-{:03d}'.format(self._transport_no)
                             self._transport_no += 1
 
                         yield self._controller.call('crossbar.node.{}.worker.{}.start_router_transport'.format(self._node_id, worker_id), transport_id, transport, options=call_options)
@@ -713,7 +713,7 @@ class Node(object):
                         if 'id' in connection:
                             connection_id = connection.pop('id')
                         else:
-                            connection_id = 'connection{}'.format(self._connection_no)
+                            connection_id = 'connection-{:03d}'.format(self._connection_no)
                             self._connection_no += 1
 
                         yield self._controller.call('crossbar.node.{}.worker.{}.start_connection'.format(self._node_id, worker_id), connection_id, connection, options=call_options)
@@ -726,7 +726,7 @@ class Node(object):
                         if 'id' in component:
                             component_id = component.pop('id')
                         else:
-                            component_id = 'component{}'.format(self._component_no)
+                            component_id = 'component-{:03d}'.format(self._component_no)
                             self._component_no += 1
 
                         yield self._controller.call('crossbar.node.{}.worker.{}.start_container_component'.format(self._node_id, worker_id), component_id, component, options=call_options)
@@ -741,7 +741,7 @@ class Node(object):
 
                     # start transport on websocket-testee
                     transport = worker['transport']
-                    transport_id = 'transport{}'.format(self._transport_no)
+                    transport_id = 'transport-{:03d}'.format(self._transport_no)
                     self._transport_no = 1
 
                     yield self._controller.call('crossbar.node.{}.worker.{}.start_websocket_testee_transport'.format(self._node_id, worker_id), transport_id, transport, options=call_options)

--- a/crossbar/controller/process.py
+++ b/crossbar/controller/process.py
@@ -171,7 +171,7 @@ class NodeControllerSession(NativeProcessSession):
         dl = []
         for proc in procs:
             uri = '{}.{}'.format(self._uri_prefix, proc)
-            self.log.info("Registering management API procedure {proc}", proc=uri)
+            self.log.debug("Registering management API procedure {proc}", proc=uri)
             dl.append(self.register(getattr(self, proc), uri, options=RegisterOptions(details_arg='details')))
 
         regs = yield DeferredList(dl)
@@ -196,7 +196,7 @@ class NodeControllerSession(NativeProcessSession):
                     self.log.info("Match: realm {realm} from template {pattern}", realm=realm, pattern=pat_str)
                     tmpl[u'name'] = realm
                     try:
-                        yield self._node._run_realm_config(worker_id, 'Worker [TMPL] '.format(worker_id), tmpl)
+                        yield self._node._run_realm_config(worker_id, "Router '{}'".format(worker_id), tmpl)
                     except Exception as e:
                         self.log.error(e)
                     finally:

--- a/crossbar/router/auth/cryptosign.py
+++ b/crossbar/router/auth/cryptosign.py
@@ -39,6 +39,8 @@ import nacl
 from nacl.signing import VerifyKey
 from nacl.exceptions import BadSignatureError
 
+from twisted.internet.defer import inlineCallbacks, returnValue
+
 from autobahn import util
 from autobahn.wamp import types
 
@@ -91,11 +93,12 @@ class PendingAuthCryptosign(PendingAuth):
         }
         return extra
 
+    @inlineCallbacks
     def hello(self, realm, details):
         # the channel binding requested by the client authenticating
         channel_binding = details.authextra.get(u'channel_binding', None)
         if channel_binding is not None and channel_binding not in [u'tls-unique']:
-            return types.Deny(message=u'invalid channel binding type "{}" requested'.format(channel_binding))
+            returnValue(types.Deny(message=u'invalid channel binding type "{}" requested'.format(channel_binding)))
         else:
             self.log.info("WAMP-cryptosign CHANNEL BINDING requested: {}".format(channel_binding))
 
@@ -129,29 +132,29 @@ class PendingAuthCryptosign(PendingAuth):
                             if self._authid is None:
                                 self._authid = _authid
                             else:
-                                return types.Deny(message=u'cannot infer client identity from pubkey: multiple authids in principal database have this pubkey')
+                                returnValue(types.Deny(message=u'cannot infer client identity from pubkey: multiple authids in principal database have this pubkey'))
                     if self._authid is None:
-                        return types.Deny(message=u'cannot identify client: no authid requested and no principal found for provided extra.pubkey')
+                        returnValue(types.Deny(message=u'cannot identify client: no authid requested and no principal found for provided extra.pubkey'))
                 else:
-                    return types.Deny(message=u'cannot identify client: no authid requested and no extra.pubkey provided')
+                    returnValue(types.Deny(message=u'cannot identify client: no authid requested and no extra.pubkey provided'))
 
             if self._authid in self._config.get(u'principals', {}):
 
                 principal = self._config[u'principals'][self._authid]
 
                 if pubkey and (pubkey not in principal[u'authorized_keys']):
-                    return types.Deny(message=u'extra.pubkey provided does not match any one of authorized_keys for the principal')
+                    returnValue(types.Deny(message=u'extra.pubkey provided does not match any one of authorized_keys for the principal'))
 
-                error = self._assign_principal(principal)
+                error = yield self._assign_principal(principal)
                 if error:
-                    return error
+                    returnValue(error)
 
                 self._verify_key = VerifyKey(pubkey, encoder=nacl.encoding.HexEncoder)
 
                 extra = self._compute_challenge(channel_binding)
-                return types.Challenge(self._authmethod, extra)
+                returnValue(types.Challenge(self._authmethod, extra))
             else:
-                return types.Deny(message=u'no principal with authid "{}" exists'.format(details.authid))
+                returnValue(types.Deny(message=u'no principal with authid "{}" exists'.format(details.authid)))
 
         elif self._config[u'type'] == u'dynamic':
 
@@ -159,32 +162,33 @@ class PendingAuthCryptosign(PendingAuth):
 
             error = self._init_dynamic_authenticator()
             if error:
-                return error
+                returnValue(error)
 
             self._session_details[u'authmethod'] = u'cryptosign'
             self._session_details[u'authextra'] = details.authextra
 
             d = self._authenticator_session.call(self._authenticator, realm, details.authid, self._session_details)
 
+            @inlineCallbacks
             def on_authenticate_ok(principal):
-                error = self._assign_principal(principal)
+                error = yield self._assign_principal(principal)
                 if error:
-                    return error
+                    returnValue(error)
 
                 self._verify_key = VerifyKey(principal[u'pubkey'], encoder=nacl.encoding.HexEncoder)
 
                 extra = self._compute_challenge(channel_binding)
-                return types.Challenge(self._authmethod, extra)
+                returnValue(types.Challenge(self._authmethod, extra))
 
             def on_authenticate_error(err):
                 return self._marshal_dynamic_authenticator_error(err)
 
             d.addCallbacks(on_authenticate_ok, on_authenticate_error)
-            return d
+            returnValue(d)
 
         else:
             # should not arrive here, as config errors should be caught earlier
-            return types.Deny(message=u'invalid authentication configuration (authentication type "{}" is unknown)'.format(self._config['type']))
+            returnValue(types.Deny(message=u'invalid authentication configuration (authentication type "{}" is unknown)'.format(self._config['type'])))
 
     def authenticate(self, signed_message):
         """

--- a/crossbar/router/auth/cryptosign.py
+++ b/crossbar/router/auth/cryptosign.py
@@ -161,6 +161,9 @@ class PendingAuthCryptosign(PendingAuth):
             if error:
                 return error
 
+            self._session_details[u'authmethod'] = u'cryptosign'
+            self._session_details[u'authextra'] = details.authextra
+
             d = self._authenticator_session.call(self._authenticator, realm, details.authid, self._session_details)
 
             def on_authenticate_ok(principal):
@@ -170,7 +173,7 @@ class PendingAuthCryptosign(PendingAuth):
 
                 self._verify_key = VerifyKey(principal[u'pubkey'], encoder=nacl.encoding.HexEncoder)
 
-                extra = self._compute_challenge()
+                extra = self._compute_challenge(channel_binding)
                 return types.Challenge(self._authmethod, extra)
 
             def on_authenticate_error(err):

--- a/crossbar/router/auth/pending.py
+++ b/crossbar/router/auth/pending.py
@@ -64,6 +64,8 @@ class PendingAuth:
         self._session_details = {
             u'transport': session._transport._transport_info,
             u'session': session._pending_session_id,
+            u'authmethod': None,
+            u'authextra': None
         }
 
         # The router factory we are working for

--- a/crossbar/router/auth/pending.py
+++ b/crossbar/router/auth/pending.py
@@ -67,7 +67,11 @@ class PendingAuth:
             u'transport': session._transport._transport_info,
             u'session': session._pending_session_id,
             u'authmethod': None,
-            u'authextra': None
+            u'authextra': None,
+
+            # The URI prefix under which the locally running router worker registers,
+            # eg "crossbar.node.corei7ub1310.worker.worker-001"
+            u'worker': session._router_factory._node._uri_prefix
         }
 
         # The router factory we are working for

--- a/crossbar/router/auth/pending.py
+++ b/crossbar/router/auth/pending.py
@@ -150,13 +150,20 @@ class PendingAuth:
 
         # realm auto-activation: if realm is not started on router, maybe start it ..
         if self._realm not in self._router_factory:
+            self.log.info("Auto starting realm '{realm}' ..", realm=self._realm)
+
             # this actually might start the realm asyncronously .. wait until the creation is finished
             # or fails finally
             yield self._router_factory.auto_start_realm(self._realm)
 
-        # if realm is not started on router, bail out now!
-        if self._realm not in self._router_factory:
-            returnValue(types.Deny(ApplicationError.NO_SUCH_REALM, message=u'no realm "{}" exists on this router'.format(self._realm)))
+            # if realm is not started on router, bail out now!
+            if self._realm not in self._router_factory:
+                self.log.debug("Realm '{realm}' could not be auto started, and thus simply does not exist", realm=self._realm)
+                returnValue(types.Deny(ApplicationError.NO_SUCH_REALM, message=u'no realm "{}" exists on this router'.format(self._realm)))
+            else:
+                self.log.info("Realm '{realm}' auto started succeesfully", realm=self._realm)
+        else:
+            self.log.debug("Realm '{realm}' already started", realm=self._realm)
 
         # role auto-activation: if role is not running on realm, maybe start it ..
         if not self._router_factory[self._realm].has_role(self._authrole):

--- a/crossbar/router/auth/pending.py
+++ b/crossbar/router/auth/pending.py
@@ -192,7 +192,10 @@ class PendingAuth:
                 return types.Deny(ApplicationError.NO_SUCH_REALM, message=u"client did not specify a realm to join (and no explicit realm was configured for dynamic authenticator)")
             authenticator_realm = self._realm
 
-        self._authenticator_session = self._router_factory.get(authenticator_realm)._realm.session
+        if authenticator_realm not in self._router_factory:
+            return types.Deny(ApplicationError.NO_SUCH_REALM, message=u"realm <{}> to run dynamic authenticator on does not exist".format(authenticator_realm))
+
+        self._authenticator_session = self._router_factory[authenticator_realm]._realm.session
 
     def _marshal_dynamic_authenticator_error(self, err):
         error = ApplicationError.AUTHENTICATION_FAILED

--- a/crossbar/router/protocol.py
+++ b/crossbar/router/protocol.py
@@ -36,7 +36,7 @@ import crossbar
 
 from autobahn.twisted import websocket
 from autobahn.twisted import rawsocket
-from autobahn.websocket.compress import *  # noqa
+from autobahn.websocket.compress import PerMessageDeflateOffer, PerMessageDeflateOfferAccept
 
 from txaio import make_logger
 

--- a/crossbar/router/router.py
+++ b/crossbar/router/router.py
@@ -426,11 +426,13 @@ class RouterFactory(object):
 
     @inlineCallbacks
     def auto_start_realm(self, realm):
-        self.log.info("Auto-starting realm {realm} ..", realm=realm)
-        prefix = '.'.join(self._node._uri_prefix.split('.')[:-2])
-        proc = u'{}.activate_realm'.format(prefix)
-
-        self.log.info("Calling into node controller procedure {proc}", proc=proc)
+        """
+        This is called from a finished, pending authentication when
+        the realm assigned by the authenticator is currently not running.
+        """
+        uri_prefix = '.'.join(self._node._uri_prefix.split('.')[:-2])
+        proc = u'{}.activate_realm'.format(uri_prefix)
+        self.log.debug("Calling into node controller procedure '{proc}' with realm='{realm}'", proc=proc, realm=realm)
         yield self._node.call(proc, realm)
 
     def auto_add_role(self, realm, role):

--- a/crossbar/router/router.py
+++ b/crossbar/router/router.py
@@ -439,6 +439,7 @@ class RouterFactory(object):
             self.log.info("Calling into node controller procedure '{proc}' with realm='{realm}'", proc=proc, realm=realm)
             d = self._auto_starting[realm] = self._node.call(proc, realm)
             self.log.info("Auto-starting realm {realm} ...", realm=realm)
+
             def done(arg):
                 self.log.debug("Auto-started realm '{realm}'", realm=realm)
                 del self._auto_starting[realm]
@@ -471,4 +472,3 @@ class RouterFactory(object):
                 role_id,
                 self._get_auto_role_config(role),
             )
-

--- a/crossbar/router/router.py
+++ b/crossbar/router/router.py
@@ -343,7 +343,7 @@ class RouterFactory(object):
 
     def __contains__(self, realm):
         result = realm in self._routers
-        self.log.info("RouterFactory.__contains__({realm}) -> {result}", realm=realm, result=result)
+        self.log.debug("RouterFactory.__contains__({realm}) -> {result}", realm=realm, result=result)
         return result
 
     def onLastDetach(self, router):

--- a/crossbar/router/router.py
+++ b/crossbar/router/router.py
@@ -433,7 +433,10 @@ class RouterFactory(object):
         uri_prefix = '.'.join(self._node._uri_prefix.split('.')[:-2])
         proc = u'{}.activate_realm'.format(uri_prefix)
         self.log.debug("Calling into node controller procedure '{proc}' with realm='{realm}'", proc=proc, realm=realm)
+
+        self.log.info("Auto-starting realm {realm} ...", realm=realm)
         yield self._node.call(proc, realm)
+        self.log.info("Auto-started realm {realm}.", realm=realm)
 
     def auto_add_role(self, realm, role):
         raise Exception("role auto-activation not yet implemented")

--- a/crossbar/router/service.py
+++ b/crossbar/router/service.py
@@ -48,6 +48,36 @@ def _is_restricted_session(session):
     return session._authrole is None or session._authrole == u'trusted'
 
 
+# # extract schema information from WAMP-flavored Markdown
+# #
+# schemas = None
+# if 'schemas' in realm:
+#     schemas = {}
+#     schema_pat = re.compile(r"```javascript(.*?)```", re.DOTALL)
+#     cnt_files = 0
+#     cnt_decls = 0
+#     for schema_file in realm.pop('schemas'):
+#         schema_file = os.path.join(self._cbdir, schema_file)
+#         self.log.info("{worker}: processing WAMP-flavored Markdown file {schema_file} for WAMP schema declarations",
+#                       worker=worker_logname, schema_file=schema_file)
+#         with open(schema_file, 'r') as f:
+#             cnt_files += 1
+#             for d in schema_pat.findall(f.read()):
+#                 try:
+#                     o = json.loads(d)
+#                     if isinstance(o, dict) and '$schema' in o and o['$schema'] == u'http://wamp.ws/schema#':
+#                         uri = o['uri']
+#                         if uri not in schemas:
+#                             schemas[uri] = {}
+#                         schemas[uri].update(o)
+#                         cnt_decls += 1
+#                 except Exception:
+#                     self.log.failure("{worker}: WARNING - failed to process declaration in {schema_file} - {log_failure.value}",
+#                                      worker=worker_logname, schema_file=schema_file)
+#     self.log.info("{worker}: processed {cnt_files} files extracting {cnt_decls} schema declarations and {len_schemas} URIs",
+#                   worker=worker_logname, cnt_files=cnt_files, cnt_decls=cnt_decls, len_schemas=len(schemas))
+
+
 class RouterServiceSession(ApplicationSession):
 
     """

--- a/crossbar/router/session.py
+++ b/crossbar/router/session.py
@@ -540,7 +540,7 @@ class RouterSession(BaseSession):
 
         DO NOT attach to Deferreds that are returned to calling code.
         """
-        self.log.failure("Internal error (2): {log_failure.value}", failure=fail)
+        self.log.failure("Internal error (3): {log_failure.value}", failure=fail)
 
         # tell other side we're done
         reply = message.Abort(u"wamp.error.authorization_failed", u"Internal server error")
@@ -650,8 +650,9 @@ class RouterSession(BaseSession):
                     return types.Deny(ApplicationError.NO_AUTH_METHOD, message=u'cannot authenticate using any of the offered authmethods {}'.format(authmethods))
 
         except Exception as e:
-            self.log.critical("Internal error")
-            return types.Deny(message=u'internal error: {}'.format(e))
+            raise
+            self.log.critical("Internal error (1)")
+            return types.Deny(message=u'internal error (1): {}'.format(e))
 
     def onAuthenticate(self, signature, extra):
         """
@@ -672,7 +673,7 @@ class RouterSession(BaseSession):
             # should not arrive here: logic error
             else:
                 self.log.warn('unexpected pending authentication {pending_auth}', pending_auth=self._pending_auth)
-                return types.Deny(message=u'internal error: unexpected pending authentication')
+                return types.Deny(message=u'internal error (2): unexpected pending authentication')
 
         # should not arrive here: client misbehaving!
         else:

--- a/crossbar/router/test/test_broker.py
+++ b/crossbar/router/test/test_broker.py
@@ -56,9 +56,14 @@ class TestBrokerPublish(unittest.TestCase):
         """
         Setup router and router session factories.
         """
+        class Node:
+            def __init__(self, node_id):
+                self._node_id = node_id
+
+        node = Node(u'mynode')
 
         # create a router factory
-        self.router_factory = RouterFactory(u'mynode')
+        self.router_factory = RouterFactory(node)
 
         # start a realm
         self.realm = RouterRealm(None, {u'name': u'realm1'})

--- a/crossbar/router/test/test_router.py
+++ b/crossbar/router/test/test_router.py
@@ -55,9 +55,14 @@ class TestEmbeddedSessions(unittest.TestCase):
         """
         Setup router and router session factories.
         """
+        class Node:
+            def __init__(self, node_id):
+                self._node_id = node_id
+
+        node = Node(u'mynode')
 
         # create a router factory
-        self.router_factory = RouterFactory(u'mynode')
+        self.router_factory = RouterFactory(node)
 
         # start a realm
         self.router_factory.start_realm(RouterRealm(None, {u'name': u'realm1'}))

--- a/crossbar/worker/container.py
+++ b/crossbar/worker/container.py
@@ -186,7 +186,7 @@ class ContainerWorkerSession(NativeWorkerSession):
         #
         realm = config['realm']
         extra = config.get('extra', None)
-        component_config = ComponentConfig(realm=realm, extra=extra)
+        component_config = ComponentConfig(realm=realm, extra=extra, controller=self)
 
         try:
             create_component = _appsession_loader(config)

--- a/crossbar/worker/router.py
+++ b/crossbar/worker/router.py
@@ -334,7 +334,7 @@ class RouterWorkerSession(NativeWorkerSession):
         raise Exception("not implemented")
 
     @inlineCallbacks
-    def start_router_realm(self, id, config, schemas=None, enable_trace=False, details=None):
+    def start_router_realm(self, id, config, enable_trace=False, details=None):
         """
         Starts a realm on this router worker.
 
@@ -342,11 +342,9 @@ class RouterWorkerSession(NativeWorkerSession):
         :type id: str
         :param config: The realm configuration.
         :type config: dict
-        :param schemas: An (optional) initial schema dictionary to load.
-        :type schemas: dict
         """
         self.log.debug("{}.start_router_realm".format(self.__class__.__name__),
-                       id=id, config=config, schemas=schemas)
+                       id=id, config=config)
 
         # prohibit starting a realm twice
         #
@@ -385,7 +383,7 @@ class RouterWorkerSession(NativeWorkerSession):
             'onready': Deferred()
         }
         cfg = ComponentConfig(realm, extra)
-        rlm.session = RouterServiceSession(cfg, router, schemas=schemas)
+        rlm.session = RouterServiceSession(cfg, router)
         self._router_session_factory.add(rlm.session, authrole=u'trusted')
 
         yield extra['onready']

--- a/crossbar/worker/router.py
+++ b/crossbar/worker/router.py
@@ -213,6 +213,20 @@ class RouterRealm(object):
         self.roles = {}
         self.uplinks = {}
 
+    def marshal(self):
+        """
+        Marshal object information for use with WAMP calls/events.
+        """
+        now = datetime.utcnow()
+        return {
+            u'id': self.id,
+            # 'started' is used by container-components; keeping it
+            # for consistency in the public API
+            u'started': utcstr(self.created),
+            u'uptime': (now - self.created).total_seconds(),
+            u'config': self.config
+        }
+
 
 class RouterRealmRole(object):
 
@@ -288,6 +302,7 @@ class RouterWorkerSession(NativeWorkerSession):
 
         # the procedures registered
         procs = [
+            'is_router_realm_running',
             'get_router_realms',
             'start_router_realm',
             'stop_router_realm',
@@ -322,7 +337,10 @@ class RouterWorkerSession(NativeWorkerSession):
         # NativeWorkerSession.publish_ready()
         yield self.publish_ready()
 
-    def get_router_realms(self, details=None):
+    def is_router_realm_running(self, id, details=None):
+        return id in self.realms
+
+    def get_router_realms(self, id=None, details=None):
         """
         Get realms currently running on this router worker.
 
@@ -331,7 +349,13 @@ class RouterWorkerSession(NativeWorkerSession):
         """
         self.log.debug("{}.get_router_realms".format(self.__class__.__name__))
 
-        raise Exception("not implemented")
+        if id is not None:
+            if id not in self.realms:
+                raise ApplicationError(u"crossbar.error.no_such_object", "No realm with ID '{}'".format(id))
+            else:
+                return self.realms[id].marshal()
+        else:
+            return [realm.marshal() for realm in self.realms.values()]
 
     @inlineCallbacks
     def start_router_realm(self, id, config, enable_trace=False, details=None):
@@ -639,7 +663,7 @@ class RouterWorkerSession(NativeWorkerSession):
         #
         realm = config['realm']
         extra = config.get('extra', None)
-        component_config = ComponentConfig(realm=realm, extra=extra)
+        component_config = ComponentConfig(realm=realm, extra=extra, controller=self)
         create_component = _appsession_loader(config)
 
         # .. and create and add an WAMP application session to

--- a/crossbar/worker/router.py
+++ b/crossbar/worker/router.py
@@ -269,7 +269,7 @@ class RouterWorkerSession(NativeWorkerSession):
         yield NativeWorkerSession.onJoin(self, details, publish_ready=False)
 
         # factory for producing (per-realm) routers
-        self._router_factory = RouterFactory(self._node_id)
+        self._router_factory = RouterFactory(self)
 
         # factory for producing router sessions
         self._router_session_factory = RouterSessionFactory(self._router_factory)

--- a/setup.py
+++ b/setup.py
@@ -122,6 +122,7 @@ extras_require_dev = [
     'flake8>=2.5.1',                # MIT license
     'colorama>=0.3.3',              # BSD license
     'mock>=1.3.0',                  # BSD license
+    'wheel>=0.26.0',                # MIT license
 ]
 if sys.platform != 'win32':
     # Twisted manhole support


### PR DESCRIPTION
This implements realm templates. Realm templates have their name in the node configuration be a regular expression. When the authentication has assigned a realm and that realm is not running, the automatic realm activation will match the realm against all patterns, and upon a match, start the realm from the configuration template under the actual name.

Works with the example here https://github.com/crossbario/crossbarexamples/blob/master/realmtemplates/.crossbar/config.json#L34