### PR TITLE
cryptosign fixups

### DIFF
--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -42,7 +42,7 @@ from pprint import pformat
 
 from pygments import highlight, lexers, formatters
 
-from autobahn.websocket.protocol import parseWsUrl
+from autobahn.websocket.util import parse_url
 
 from autobahn.wamp.message import _URI_PAT_STRICT_NON_EMPTY
 from autobahn.wamp.message import _URI_PAT_STRICT_LAST_EMPTY
@@ -979,7 +979,7 @@ def check_web_path_service_websocket(config):
         if not isinstance(url, six.text_type):
             raise InvalidConfigException("'url' in WebSocket configuration must be str ({} encountered)".format(type(url)))
         try:
-            parseWsUrl(url)
+            parse_url(url)
         except InvalidConfigException as e:
             raise InvalidConfigException("invalid 'url' in WebSocket configuration : {}".format(e))
 
@@ -1545,7 +1545,7 @@ def check_listening_transport_websocket(transport):
         if not isinstance(url, six.text_type):
             raise InvalidConfigException("'url' in WebSocket transport configuration must be str ({} encountered)".format(type(url)))
         try:
-            parseWsUrl(url)
+            parse_url(url)
         except InvalidConfigException as e:
             raise InvalidConfigException("invalid 'url' in WebSocket transport configuration : {}".format(e))
 
@@ -1597,7 +1597,7 @@ def check_listening_transport_websocket_testee(transport):
         if not isinstance(url, six.text_type):
             raise InvalidConfigException("'url' in WebSocket-Testee transport configuration must be str ({} encountered)".format(type(url)))
         try:
-            parseWsUrl(url)
+            parse_url(url)
         except InvalidConfigException as e:
             raise InvalidConfigException("invalid 'url' in WebSocket-Testee transport configuration : {}".format(e))
 
@@ -1760,7 +1760,7 @@ def check_connecting_transport_websocket(transport):
     if not isinstance(url, six.text_type):
         raise InvalidConfigException("'url' in WebSocket transport configuration must be str ({} encountered)".format(type(url)))
     try:
-        parseWsUrl(url)
+        parse_url(url)
     except InvalidConfigException as e:
         raise InvalidConfigException("invalid 'url' in WebSocket transport configuration : {}".format(e))
 

--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -260,7 +260,7 @@ class Node(object):
 
     def _prepare_node_keys(self):
         from nacl.signing import SigningKey
-        from nacl.encoding import HexEncoder
+        from nacl.encoding import HexEncoder, RawEncoder
 
         # make sure CBDIR/.cdc exists
         #
@@ -315,9 +315,7 @@ class Node(object):
             if skey_len in (32, 64):
                 with open(skey_file, 'r') as f:
                     skey_seed = f.read()
-                    encoder = None
-                    if skey_len == 64:
-                        encoder = HexEncoder
+                    encoder = HexEncoder if skey_len == 64 else RawEncoder
                     skey = SigningKey(skey_seed, encoder=encoder)
                 self.log.info("Existing CDC node key loaded from {skey_file}.", skey_file=skey_file)
             else:

--- a/crossbar/controller/process.py
+++ b/crossbar/controller/process.py
@@ -166,7 +166,7 @@ class NodeControllerSession(NativeProcessSession):
             'start_websocket_testee',
             'stop_websocket_testee',
 
-            'activate_realm'
+            'activate_realm',
         ]
 
         dl = []

--- a/crossbar/router/session.py
+++ b/crossbar/router/session.py
@@ -368,14 +368,15 @@ class RouterSession(BaseSession):
             if isinstance(msg, message.Hello):
 
                 self._session_roles = msg.roles
-
-                details = types.HelloDetails(realm=msg.realm,
-                                             authmethods=msg.authmethods,
-                                             authid=msg.authid,
-                                             authrole=msg.authrole,
-                                             authextra=msg.authextra,
-                                             session_roles=msg.roles,
-                                             pending_session=self._pending_session_id)
+                details = types.HelloDetails(
+                    realm=msg.realm,
+                    authmethods=msg.authmethods,
+                    authid=msg.authid,
+                    authrole=msg.authrole,
+                    authextra=msg.authextra,
+                    session_roles=msg.roles,
+                    pending_session=self._pending_session_id,
+                )
 
                 d = txaio.as_future(self.onHello, msg.realm, details)
 

--- a/crossbar/worker/router.py
+++ b/crossbar/worker/router.py
@@ -620,8 +620,12 @@ class RouterWorkerSession(NativeWorkerSession):
         :param config: The component configuration.
         :type config: obj
         """
-        self.log.debug("{}.start_router_component".format(self.__class__.__name__),
-                       id=id, config=config)
+        self.log.info(
+            "{cls}.start_router_component({id}, {config})",
+            cls=self.__class__.__name__,
+            id=id,
+            config=config,
+        )
 
         # prohibit starting a component twice
         #


### PR DESCRIPTION
Automagically decodes 64-length key strings as hex, fixes some whitespace, more error-checking, and eliminates a local function in an already-inlineCallbacks method