### PR TITLE
Add Deploying section and Puppet recipe #742

### DIFF
--- a/docs/pages/installation/Deploying-Crossbar.io-with-Puppet.md
+++ b/docs/pages/installation/Deploying-Crossbar.io-with-Puppet.md
@@ -1,0 +1,38 @@
+[Documentation](.) > [Installation](Installation) > [Deploying Crossbar.io](Deploying Crossbar.io) > Deploying Crossbar.io with Puppet
+
+# Install Crossbar.io from Puppetforge 
+
+With Puppet you can provision Crossbar.io WAMP Router on your systems with standalone agent, Puppet Server or Puppet Enteprise.
+
+We provide a module on [Puppetforge](https://forge.puppet.com/bluesman/crossbar).
+
+For an overview of all feature supported and more technical details, see the [GitHub repository](https://github.com/blues-man/crossbar-puppet).
+
+
+## Usage
+
+Installation:
+
+```console
+puppet module install bluesman-crossbar
+```
+
+To run:
+
+```console
+puppet apply -e 'include crossbar'
+```
+
+This will start and init a Crossbar.io server with default configuration. To check things are running, point your browser to http://machine-ip:8080. This should show a custom 404 page.
+
+
+## OS Support
+
+Currently, only these Operating System are supported
+
+* CentOS 7
+
+
+## Next
+
+Ready to go? Then [choose your language or device of choice](Choose your Weapon).

--- a/docs/pages/installation/Deploying-Crossbar.io.md
+++ b/docs/pages/installation/Deploying-Crossbar.io.md
@@ -1,0 +1,12 @@
+[Documentation](.) > [Installation](Installation) > Deploying Crossbar.io
+
+# Configuration management software
+
+We provide installation instructions for setting up Crossbar.io on your own systems with most used configuration management tools for DevOps
+
+We provide modules for
+
+# Puppet
+
+* [Deploying Crossbar.io with Puppet](Deploying Crossbar.io with Puppet)
+

--- a/docs/pages/installation/Installation.md
+++ b/docs/pages/installation/Installation.md
@@ -10,6 +10,10 @@ Setting up Crossbar.io on cloud platforms:
 
 * [Setup in the Cloud](Setup in the Cloud)
 
+Deploying Crossbar.io with Configuration management tools:
+
+* [Deploying Crossbar.io](Deploying Crossbar.io)
+
 Using our public demo instance:
 
 * [Demo Instance](Demo Instance)


### PR DESCRIPTION
We would add a specific section for Deploying Crossbar with most
used configuration management tools as Puppet, Ansible, Salt etc
filling it with a Puppet recipe