### PR TITLE
Remove incorrect cert path checking

### DIFF
--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -746,19 +746,9 @@ def check_connecting_endpoint_tls(tls):
         if k not in ['ca_certificates', 'hostname', 'certificate', 'key']:
             raise InvalidConfigException("encountered unknown attribute '{}' in connecting endpoint TLS configuration".format(k))
 
-    for k in ['certificate', 'key']:
-        if k in tls and not os.path.exists(tls[k]):
-            raise InvalidConfigException(
-                "File '{}' for '{}' in TLS configuration "
-                "not found".format(tls[k], k)
-            )
-
     if 'ca_certificates' in tls:
         if not isinstance(tls['ca_certificates'], Sequence):
             raise InvalidConfigException("'ca_certificates' must be a list")
-        for fname in tls['ca_certificates']:
-            if not os.path.exists(fname):
-                raise InvalidConfigException("'ca_certificates' contains non-existant path '{}'".format(fname))
 
     for req_k in ['hostname']:
         if req_k not in tls:


### PR DESCRIPTION
If we want to check the cert path, we have to check os.path.join(cbdir, cert).

Please see crossbartwisted/endpoint.py:

    cert_fname = os.path.abspath(os.path.join(cbdir, config['certificate']))

I cannot find a clean way to get it done correctly yet. So propose to remove the check for now.
I think checking cert file exist is optional, and currently the wrong checking is a bug.