### PR TITLE
don't show full server version in Server: header by default

### DIFF
--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -989,7 +989,8 @@ def check_websocket_options(options):
             'enable_flash_policy',
             'flash_policy',
             'compression',
-            'require_websocket_subprotocol'
+            'require_websocket_subprotocol',
+            'show_server_version',
         ]:
             raise InvalidConfigException("encountered unknown attribute '{}' in WebSocket options".format(k))
 

--- a/crossbar/router/protocol.py
+++ b/crossbar/router/protocol.py
@@ -297,6 +297,7 @@ class WampWebSocketServerFactory(websocket.WampWebSocketServerFactory):
     Crossbar.io WAMP-over-WebSocket server factory.
     """
 
+    showServerVersion = False
     protocol = WampWebSocketServerProtocol
     log = make_logger()
 
@@ -315,7 +316,11 @@ class WampWebSocketServerFactory(websocket.WampWebSocketServerFactory):
 
         options = config.get('options', {})
 
-        server = "Crossbar/{}".format(crossbar.__version__)
+        self.showServerVersion = options.get('show_server_version', self.showServerVersion)
+        if self.showServerVersion:
+            server = "Crossbar/{}".format(crossbar.__version__)
+        else:
+            server = "Crossbar"
         externalPort = options.get('external_port', None)
 
         # explicit list of WAMP serializers


### PR DESCRIPTION
This will by default cause crossbar to report ``Server: Crossbar`` which can be optionally made to show ``Server: Crossbar/0.13.2`` style by setting ``show_server_version: true`` in a transport configuration's options.

See #770 for context