### PR TITLE
Sketch out how towncrier might work with crossbar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ clean:
 	find . \( -name "*__pycache__" -type d \) -prune -exec rm -rf {} +
 
 docs:
+	towncrier --draft > docs/pages/ChangeLog.md
 	python docs/test_server.py
 
 # call this in a fresh virtualenv to update our frozen requirements.txt!

--- a/crossbar/newsfragments/.gitignore
+++ b/crossbar/newsfragments/.gitignore
@@ -1,0 +1,2 @@
+!.gitignore
+

--- a/crossbar/newsfragments/778.feature
+++ b/crossbar/newsfragments/778.feature
@@ -1,0 +1,1 @@
+removed exact version from ``Server:`` header and added ``show_server_version`` option

--- a/docs/templates/towncrier_changelog.md
+++ b/docs/templates/towncrier_changelog.md
@@ -1,0 +1,34 @@
+{% for section, _ in sections|dictsort(by='key') %}
+{% if section %}
+# {{section}}
+
+{% endif %}
+{% if sections[section] %}
+{% for category, val in definitions|dictsort if category in sections[section]%}
+
+## {{ definitions[category]['name'] }}
+
+{% if definitions[category]['showcontent'] %}
+{% for text, values in sections[section][category]|dictsort(by='value') %}
+* {% for value in values %}[{{value[1:]}}](https://github.com/crossbario/crossbar/issues/{{value[1:]}}){% endfor %}: {{ text }}
+{% endfor %}
+{% else %}
+* {{ sections[section][category]['']|sort|join(', ') }}
+
+
+{% endif %}
+{% if sections[section][category]|length == 0 %}
+
+*No significant changes.*
+
+
+{% else %}
+{% endif %}
+{% endfor %}
+{% else %}
+
+*No significant changes.*
+
+
+{% endif %}
+{% endfor %}

--- a/towncrier.ini
+++ b/towncrier.ini
@@ -1,0 +1,5 @@
+[towncrier]
+package = crossbar
+template = docs/templates/towncrier_changelog.md
+start_string = [//]: # "towncrier start"
+title_format = # {name} {version}


### PR DESCRIPTION
(Not for merge, yet).

This is an idea as to how ``towncrier`` might work to build crossbar's changelog. It needs a branch of towncrier: https://github.com/meejah/towncrier/tree/fix-35

What won't work yet is the "for-real" run of ``towncrier`` that burns in all the ``newsfragments`` to ChangeLog and then deletes them etc...