### PR TITLE
More towncrier changelog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,11 @@ clean:
 	find . \( -name "*__pycache__" -type d \) -prune -exec rm -rf {} +
 
 news: towncrier.ini crossbar/newsfragments/*.*
-	# this produces a NEWS.rst file, 'git rm's crossbar/newsfragmes/* and 'git add's NEWS.rst
+	# this produces a NEWS.md file, 'git rm's crossbar/newsfragmes/* and 'git add's NEWS.md
 	# ...which we then use to update docs/pages/ChangeLog.md
 	towncrier
 	cat docs/templates/changelog_preamble.md > docs/pages/ChangeLog.md
-	cat NEWS.rst >> docs/pages/ChangeLog.md
+	cat NEWS.md >> docs/pages/ChangeLog.md
 	git add docs/pages/ChangeLog.md
 	echo You should now 'git commit -m "update NEWS and ChangeLog"' the result, if happy.
 

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,15 @@ clean:
 	# Learn to love the shell! http://unix.stackexchange.com/a/115869/52500
 	find . \( -name "*__pycache__" -type d \) -prune -exec rm -rf {} +
 
+news: towncrier.ini crossbar/newsfragments/*.*
+	# this produces a NEWS.rst file, 'git rm's crossbar/newsfragmes/* and 'git add's NEWS.rst
+	# ...which we then use to update docs/pages/ChangeLog.md
+	towncrier
+	cat docs/templates/changelog_preamble.md > docs/pages/ChangeLog.md
+	cat NEWS.rst >> docs/pages/ChangeLog.md
+	git add docs/pages/ChangeLog.md
+	echo You should now 'git commit -m "update NEWS and ChangeLog"' the result, if happy.
+
 docs:
 	towncrier --draft > docs/pages/ChangeLog.md
 	python docs/test_server.py

--- a/crossbar/newsfragments/604.bugfix
+++ b/crossbar/newsfragments/604.bugfix
@@ -1,0 +1,1 @@
+Fix ReST caller error-logging

--- a/crossbar/newsfragments/638.bugfix
+++ b/crossbar/newsfragments/638.bugfix
@@ -1,0 +1,1 @@
+use -m when invoking subprocesses (so *.pyc files alone still work)

--- a/crossbar/newsfragments/702.bugfix
+++ b/crossbar/newsfragments/702.bugfix
@@ -1,0 +1,1 @@
+fix logging in WampLongPollResourceOpen

--- a/crossbar/newsfragments/710.bugfix
+++ b/crossbar/newsfragments/710.bugfix
@@ -1,0 +1,1 @@
+Kernel version detection for sharedport improved

--- a/crossbar/newsfragments/717.bugfix
+++ b/crossbar/newsfragments/717.bugfix
@@ -1,0 +1,1 @@
+if we have a PID file, but the PID is our own, don't exit

--- a/crossbar/newsfragments/719.bugfix
+++ b/crossbar/newsfragments/719.bugfix
@@ -1,0 +1,1 @@
+Remove platform conditional dependencies

--- a/crossbar/newsfragments/720.feature
+++ b/crossbar/newsfragments/720.feature
@@ -1,0 +1,1 @@
+add UBJSON support

--- a/crossbar/newsfragments/728.bugfix
+++ b/crossbar/newsfragments/728.bugfix
@@ -1,0 +1,1 @@
+announce ubjson "batched" mode + CLI support

--- a/crossbar/newsfragments/737.feature
+++ b/crossbar/newsfragments/737.feature
@@ -1,0 +1,1 @@
+add backwards-compatibility policy

--- a/crossbar/newsfragments/766.bugfix
+++ b/crossbar/newsfragments/766.bugfix
@@ -1,0 +1,1 @@
+replace ``msgpack-python`` with ``u-msgpack`` and upgrade several other dependencies

--- a/crossbar/newsfragments/772.feature
+++ b/crossbar/newsfragments/772.feature
@@ -1,0 +1,1 @@
+separate metadata from text in documentation

--- a/crossbar/newsfragments/780.feature
+++ b/crossbar/newsfragments/780.feature
@@ -1,0 +1,1 @@
+use ``towncrier`` to write changelog/NEWS file

--- a/crossbar/newsfragments/789.feature
+++ b/crossbar/newsfragments/789.feature
@@ -1,0 +1,1 @@
+Various documentation improvements

--- a/docs/templates/changelog_preamble.md
+++ b/docs/templates/changelog_preamble.md
@@ -1,0 +1,4 @@
+title: ChangeLog
+toc: [Documentation, Programming Guide, ChangeLog]
+
+

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,10 @@ with open('crossbar/__init__.py') as f:
 # read requirements from requirements.txt
 install_requires = []
 extras_require = {
-    'dev': []
+    'dev': [
+        'towncrier',
+        'tox',
+    ]
 }
 
 with open('requirements-in.txt') as f:

--- a/towncrier.ini
+++ b/towncrier.ini
@@ -1,5 +1,5 @@
 [towncrier]
 package = crossbar
 template = docs/templates/towncrier_changelog.md
-start_string = [//]: # "towncrier start"
+start_line = [//]: # "towncrier start"
 title_format = # {name} {version}

--- a/towncrier.ini
+++ b/towncrier.ini
@@ -3,3 +3,4 @@ package = crossbar
 template = docs/templates/towncrier_changelog.md
 start_line = [//]: # "towncrier start"
 title_format = # {name} {version}
+filename = NEWS.md


### PR DESCRIPTION
This adds a ``make news`` target that runs ``towncrier`` and cat's together the resulting `NEWS.md` file and a header into `docs/pages/ChangeLog.md`

I also inspected the logs from v0.13.2 until now and made up some newfragments for (I hope!) all the changes, so 0.14.0 can grow a changelog :)

So, @oberstet should just be able to run "make news" and "git commit" it right before tagging a new release...