### PR TITLE
When a dynamic authentication is used and the authenticator reassigns…

### DIFF
--- a/crossbar/router/cookiestore.py
+++ b/crossbar/router/cookiestore.py
@@ -118,6 +118,7 @@ class CookieStore(object):
             # auth info is store here
             'authid': None,
             'authrole': None,
+            'authrealm': None,
             'authmethod': None,
 
             # set of WAMP transports (WebSocket connections) this
@@ -144,19 +145,19 @@ class CookieStore(object):
 
     def getAuth(self, cbtid):
         """
-        Return `(authid, authrole, authmethod)` triple given cookie ID.
+        Return `(authid, authrole, authmethod, authrealm)` tuple given cookie ID.
         """
         if cbtid in self._cookies:
             c = self._cookies[cbtid]
-            cookie_auth_info = c['authid'], c['authrole'], c['authmethod']
+            cookie_auth_info = c['authid'], c['authrole'], c['authmethod'], c['authrealm']
         else:
-            cookie_auth_info = None, None, None
+            cookie_auth_info = None, None, None, None
 
         self.log.debug("Cookie auth info for {cbtid} retrieved: {cookie_auth_info}", cbtid=cbtid, cookie_auth_info=cookie_auth_info)
 
         return cookie_auth_info
 
-    def setAuth(self, cbtid, authid, authrole, authmethod):
+    def setAuth(self, cbtid, authid, authrole, authmethod, authrealm):
         """
         Set `(authid, authrole, authmethod)` triple for given cookie ID.
         """
@@ -164,6 +165,7 @@ class CookieStore(object):
             c = self._cookies[cbtid]
             c['authid'] = authid
             c['authrole'] = authrole
+            c['authrealm'] = authrealm
             c['authmethod'] = authmethod
 
     def addProto(self, cbtid, proto):
@@ -259,7 +261,8 @@ class CookieStoreFileBacked(CookieStore):
         self._cookie_file.write(json.dumps({
             'id': id, status: c['created'], 'max_age': c['max_age'],
             'authid': c['authid'], 'authrole': c['authrole'],
-            'authmethod': c['authmethod']
+            'authmethod': c['authmethod'],
+            'authrealm': c['authrealm']
         }) + '\n')
         self._cookie_file.flush()
         os.fsync(self._cookie_file.fileno())
@@ -293,8 +296,8 @@ class CookieStoreFileBacked(CookieStore):
             cookie = self._cookies[cbtid]
 
             # only set the changes and write them to the file if any of the values changed
-            if authid != cookie['authid'] or authrole != cookie['authrole'] or authmethod != cookie['authmethod']:
-                CookieStore.setAuth(self, cbtid, authid, authrole, authmethod)
+            if authid != cookie['authid'] or authrole != cookie['authrole'] or authmethod != cookie['authmethod'] or authrealm != cookie['authrealm']:
+                CookieStore.setAuth(self, cbtid, authid, authrole, authmethod, authrealm)
                 self._persist(cbtid, cookie, status='modified')
 
     def _clean_cookie_file(self):
@@ -312,7 +315,8 @@ class CookieStoreFileBacked(CookieStore):
                     'max_age': cookie['max_age'],
                     'authid': cookie['authid'],
                     'authrole': cookie['authrole'],
-                    'authmethod': cookie['authmethod']
+                    'authmethod': cookie['authmethod'],
+                    'authrealm': cookie['authrealm']
                 }) + '\n'
                 cookie_file.write(cookie_record)
 

--- a/crossbar/router/cookiestore.py
+++ b/crossbar/router/cookiestore.py
@@ -289,7 +289,7 @@ class CookieStoreFileBacked(CookieStore):
 
         return cbtid, header
 
-    def setAuth(self, cbtid, authid, authrole, authmethod):
+    def setAuth(self, cbtid, authid, authrole, authmethod, authrealm):
 
         if self.exists(cbtid):
 

--- a/crossbar/router/protocol.py
+++ b/crossbar/router/protocol.py
@@ -198,6 +198,7 @@ class WampWebSocketServerProtocol(websocket.WampWebSocketServerProtocol):
             #
             self._authid = None
             self._authrole = None
+            self._authrealm = None
             self._authmethod = None
             self._authprovider = None
 
@@ -230,14 +231,14 @@ class WampWebSocketServerProtocol(websocket.WampWebSocketServerProtocol):
                 #
                 if 'auth' in self.factory._config and 'cookie' in self.factory._config['auth']:
 
-                    self._authid, self._authrole, self._authmethod = self.factory._cookiestore.getAuth(self._cbtid)
+                    self._authid, self._authrole, self._authmethod, self._authrealm = self.factory._cookiestore.getAuth(self._cbtid)
 
                     if self._authid:
                         # there is a cookie set, and the cookie was previously successfully authenticated,
                         # so immediately authenticate the client using that information
                         self._authprovider = u'cookie'
-                        self.log.debug("Authenticated client via cookie cbtid={cbtid} as authid={authid}, authrole={authrole}, authmethod={authmethod}",
-                                       cbtid=self._cbtid, authid=self._authid, authrole=self._authrole, authmethod=self._authmethod)
+                        self.log.debug("Authenticated client via cookie cbtid={cbtid} as authid={authid}, authrole={authrole}, authmethod={authmethod}, authrealm={authrealm}",
+                                       cbtid=self._cbtid, authid=self._authid, authrole=self._authrole, authmethod=self._authmethod, authrealm=self._authrealm)
                     else:
                         # there is a cookie set, but the cookie wasn't authenticated yet using a different auth method
                         self.log.debug("Cookie-based authentication enabled, but cookie isn't authenticated yet")
@@ -437,6 +438,7 @@ class WampRawSocketServerProtocol(rawsocket.WampRawSocketServerProtocol):
         #
         self._authid = None
         self._authrole = None
+        self._authrealm = None
         self._authmethod = None
         self._authprovider = None
 

--- a/crossbar/router/test/test_cookiestore.py
+++ b/crossbar/router/test/test_cookiestore.py
@@ -31,6 +31,7 @@ class TestCookieStore(unittest.TestCase):
                 "max_age": 604800,
                 "authid": "example.authid",
                 "authrole": "example.authrole",
+                "authrealm": "example.authrealm",
                 "authmethod": "example.authmethod"
             },
             {
@@ -39,6 +40,7 @@ class TestCookieStore(unittest.TestCase):
                 "max_age": 604800,
                 "authid": "example.other.authid",
                 "authrole": "example.other.authrole",
+                "authrealm": "example.other.authrealm",
                 "authmethod": "example.other.authmethod"
             },
             {
@@ -47,6 +49,7 @@ class TestCookieStore(unittest.TestCase):
                 "max_age": 604800,
                 "authid": "example.second.authid",
                 "authrole": "example.second.authrole",
+                "authrealm": "example.second.authrealm",
                 "authmethod": "example.second.authmethod"
             }
         ]
@@ -58,6 +61,7 @@ class TestCookieStore(unittest.TestCase):
                 "max_age": 604800,
                 "authid": "example.second.authid",
                 "authrole": "example.second.authrole",
+                "authrealm": "example.second.authrealm",
                 "authmethod": "example.second.authmethod"
             },
             {
@@ -66,6 +70,7 @@ class TestCookieStore(unittest.TestCase):
                 "max_age": 604800,
                 "authid": "example.other.authid",
                 "authrole": "example.other.authrole",
+                "authrealm": "example.other.authrealm",
                 "authmethod": "example.other.authmethod"
             }
         ]
@@ -95,6 +100,7 @@ class TestCookieStore(unittest.TestCase):
                 "max_age": 604800,
                 "authid": "example.authid",
                 "authrole": "example.authrole",
+                "authrealm": "example.authrealm",
                 "authmethod": "example.authmethod"
             },
             {
@@ -103,6 +109,7 @@ class TestCookieStore(unittest.TestCase):
                 "max_age": 604800,
                 "authid": "example.second.authid",
                 "authrole": "example.second.authrole",
+                "authrealm": "example.second.authrealm",
                 "authmethod": "example.second.authmethod"
             },
             {
@@ -111,6 +118,7 @@ class TestCookieStore(unittest.TestCase):
                 "max_age": 604800,
                 "authid": "example.other.authid",
                 "authrole": "example.other.authrole",
+                "authrealm": "example.other.authrealm",
                 "authmethod": "example.other.authmethod"
             }
         ]
@@ -144,6 +152,7 @@ class TestCookieStore(unittest.TestCase):
                 "max_age": max_age,
                 "authid": "example.authid",
                 "authrole": "example.authrole",
+                "authrealm": "example.authrealm",
                 "authmethod": "example.authmethod"
             },
             {
@@ -152,6 +161,7 @@ class TestCookieStore(unittest.TestCase):
                 "max_age": max_age,
                 "authid": "example.other.authid",
                 "authrole": "example.other.authrole",
+                "authrealm": "example.other.authrealm",
                 "authmethod": "example.other.authmethod"
             },
             {
@@ -160,6 +170,7 @@ class TestCookieStore(unittest.TestCase):
                 "max_age": max_age,
                 "authid": "example.second.authid",
                 "authrole": "example.second.authrole",
+                "authrealm": "example.second.authrealm",
                 "authmethod": "example.second.authmethod"
             }
         ]
@@ -171,6 +182,7 @@ class TestCookieStore(unittest.TestCase):
                 "max_age": max_age,
                 "authid": "example.other.authid",
                 "authrole": "example.other.authrole",
+                "authrealm": "example.other.authrealm",
                 "authmethod": "example.other.authmethod"
             },
         ]


### PR DESCRIPTION
… the client realm, and the client reconnects - the reassigned realm is now recovered from the cookie storage. This PR is for issue #825 