### PR TITLE
Issue695 onleave

### DIFF
--- a/crossbar/router/session.py
+++ b/crossbar/router/session.py
@@ -54,6 +54,7 @@ from crossbar.router.auth import PendingAuthWampCra, PendingAuthTicket
 from crossbar.router.auth import AUTHMETHODS, AUTHMETHOD_MAP
 
 from twisted.internet.defer import inlineCallbacks
+from twisted.python.failure import Failure
 
 try:
     from crossbar.router.auth import PendingAuthCryptosign
@@ -251,6 +252,11 @@ class RouterApplicationSession(object):
 
                 if session._transport:
                     session._transport.close()
+
+                try:
+                    yield session.fire('leave', session, details)
+                except Exception:
+                    self._log_error(Failure(), "While notifying 'leave'")
 
                 try:
                     yield session.fire('disconnect', session)

--- a/crossbar/router/session.py
+++ b/crossbar/router/session.py
@@ -107,6 +107,7 @@ class RouterApplicationSession(object):
         #
         self._session._transport = self
 
+        self._session.fire('connect', self._session, self)
         self._session.onConnect()
 
     def _swallow_error(self, fail, msg):

--- a/crossbar/router/session.py
+++ b/crossbar/router/session.py
@@ -141,7 +141,13 @@ class RouterApplicationSession(object):
             # immediate disconnect which winds up right here...so we
             # take at trip through the reactor loop.
             from twisted.internet import reactor
-            reactor.callLater(0, self._router.detach, self._session)
+
+            def detach(sess):
+                try:
+                    self._router.detach(sess)
+                except Exception:
+                    pass
+            reactor.callLater(0, detach, self._session)
 
     def abort(self):
         """
@@ -474,7 +480,10 @@ class RouterSession(BaseSession):
 
                 # We need to first detach the session from the router before
                 # erasing the session ID below ..
-                self._router.detach(self)
+                try:
+                    self._router.detach(self)
+                except Exception:
+                    pass
 
                 # In order to send wamp.session.on_leave properly
                 # (i.e. *with* the proper session_id) we save it
@@ -526,7 +535,10 @@ class RouterSession(BaseSession):
             except Exception:
                 self.log.failure("Exception raised in onLeave callback")
 
-            self._router.detach(self)
+            try:
+                self._router.detach(self)
+            except Exception:
+                pass
 
             self._session_id = None
 
@@ -568,7 +580,10 @@ class RouterSession(BaseSession):
 
         # cleanup
         if self._router:
-            self._router.detach(self)
+            try:
+                self._router.detach(self)
+            except Exception:
+                pass
         self._session_id = None
         self._pending_session_id = None
         return None  # we've handled the error; don't propagate


### PR DESCRIPTION
Some fixes and cleanups to deal with https://github.com/crossbario/autobahn-python/issues/695 

This properly propagates the message + reason to the "client" session when these are specified to `leave()` -- for example, a simple case is if the client session does `yield self.leave(u"wamp.close.logout", u"some reason")` in `onJoin`.

It also seems that `wamp.session.on_leave` wasn't getting published in this case either, and `.detach()` can potentially fail so we guard that too ...