### PR TITLE
"authextra" in dynamic authenticators

### DIFF
--- a/crossbar/newsfragments/853.bugfix
+++ b/crossbar/newsfragments/853.bugfix
@@ -1,0 +1,1 @@
+properly pass 'authextra' and 'authmethod' keys to all dynamic authenticators

--- a/crossbar/router/auth/anonymous.py
+++ b/crossbar/router/auth/anonymous.py
@@ -85,6 +85,8 @@ class PendingAuthAnonymous(PendingAuth):
             if error:
                 return error
 
+            self._session_details[u'authmethod'] = self._authmethod  # from AUTHMETHOD, via base
+            self._session_details[u'authextra'] = details.authextra
             d = self._authenticator_session.call(self._authenticator, self._realm, self._authid, self._session_details)
 
             def on_authenticate_ok(principal):

--- a/crossbar/router/auth/cryptosign.py
+++ b/crossbar/router/auth/cryptosign.py
@@ -166,7 +166,7 @@ class PendingAuthCryptosign(PendingAuth):
             if error:
                 return error
 
-            self._session_details[u'authmethod'] = u'cryptosign'
+            self._session_details[u'authmethod'] = self._authmethod  # from AUTHMETHOD, via base
             self._session_details[u'authextra'] = details.authextra
 
             d = self._authenticator_session.call(self._authenticator, realm, details.authid, self._session_details)

--- a/crossbar/router/auth/ticket.py
+++ b/crossbar/router/auth/ticket.py
@@ -94,6 +94,9 @@ class PendingAuthTicket(PendingAuth):
             if error:
                 return error
 
+            self._session_details[u'authmethod'] = self._authmethod  # from AUTHMETHOD, via base
+            self._session_details[u'authextra'] = details.authextra
+
             return types.Challenge(self._authmethod)
 
         else:

--- a/crossbar/router/auth/tls.py
+++ b/crossbar/router/auth/tls.py
@@ -102,6 +102,9 @@ class PendingAuthTLS(PendingAuth):
             if error:
                 return error
 
+            self._session_details[u'authmethod'] = self._authmethod  # from AUTHMETHOD, via base
+            self._session_details[u'authextra'] = details.authextra
+
             d = self._authenticator_session.call(self._authenticator, realm, details.authid, self._session_details)
 
             def on_authenticate_ok(principal):

--- a/crossbar/router/auth/wampcra.py
+++ b/crossbar/router/auth/wampcra.py
@@ -130,6 +130,9 @@ class PendingAuthWampCra(PendingAuth):
             if error:
                 return error
 
+            self._session_details[u'authmethod'] = self._authmethod  # from AUTHMETHOD, via base
+            self._session_details[u'authextra'] = details.authextra
+
             d = self._authenticator_session.call(self._authenticator, realm, details.authid, self._session_details)
 
             def on_authenticate_ok(principal):

--- a/crossbar/router/test/test_authorize.py
+++ b/crossbar/router/test/test_authorize.py
@@ -34,7 +34,7 @@ from twisted.trial import unittest
 from twisted.internet import defer
 
 from crossbar.router.role import RouterRoleStaticAuth
-from crossbar.router.auth import cryptosign, wampcra
+from crossbar.router.auth import cryptosign, wampcra, ticket
 
 from autobahn.wamp import types
 
@@ -132,6 +132,56 @@ class TestDynamicAuth(unittest.TestCase):
         self.assertTrue(isinstance(val, types.Challenge))
         self.assertEqual("wampcra", val.method)
         self.assertTrue("challenge" in val.extra)
+
+    def test_authextra_ticket(self):
+        """
+        We pass along the authextra to a dynamic authenticator
+        """
+        session = Mock()
+        session._transport._transport_info = {}
+
+        def fake_call(method, *args, **kw):
+            realm, authid, details = args
+            self.assertEqual("foo.auth_a_doodle", method)
+            self.assertEqual("realm", realm)
+            self.assertEqual(details["authmethod"], "ticket")
+            self.assertEqual(details["authextra"], {"foo": "bar"})
+            return defer.succeed({
+                "secret": u'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+                "role": u"some_role",
+                "extra": {
+                    "what": "authenticator-supplied authextra",
+                }
+            })
+        session.call = Mock(side_effect=fake_call)
+        realm = Mock()
+        realm._realm.session = session
+        session._pending_session_id = 'pending session id'
+        session._router_factory = {
+            "realm": realm,
+        }
+        config = {
+            "type": "dynamic",
+            "authenticator": "foo.auth_a_doodle",
+        }
+        extra = {
+            "foo": "bar",
+        }
+        details = Mock()
+        details.authid = u'alice'
+        details.authextra = extra
+
+        auth = ticket.PendingAuthTicket(session, config)
+        val = auth.hello(u"realm", details)
+        self.assertTrue(isinstance(val, types.Challenge))
+        self.assertEqual("ticket", val.method)
+        self.assertEqual({}, val.extra)
+
+        d = auth.authenticate("fake signature")
+        self.assertTrue(isinstance(d.result, types.Accept))
+        acc = d.result
+        self.assertEqual(acc.authextra, {"what": "authenticator-supplied authextra"})
+        self.assertEqual(acc.authid, u'alice')
 
 
 class TestRouterRoleStaticAuth(unittest.TestCase):


### PR DESCRIPTION
This should fix #853 for all `dynamic` authenticators by passing along `authmethod` and `authextra` in the `details=` kwarg to the dynamic authentication call (in the same way `cryptosign` already does).

Also adds unit-tests for all these.