### PR TITLE
#610 long poll python3

### DIFF
--- a/crossbar/router/longpoll.py
+++ b/crossbar/router/longpoll.py
@@ -43,7 +43,7 @@ from twisted.web.resource import Resource, NoResource
 from twisted.web import http
 from twisted.web.server import NOT_DONE_YET
 
-from autobahn.util import generate_token
+from autobahn.util import generate_token, _LazyHexFormatter
 
 from autobahn.wamp.websocket import parseSubprotocolIdentifier
 
@@ -51,6 +51,8 @@ from autobahn.wamp.exception import SerializationError, \
     TransportLost
 
 from txaio import make_logger
+from txaio import failure_format_traceback, failure_message, create_failure
+
 
 __all__ = (
     'WampLongPollResource',
@@ -82,7 +84,11 @@ class WampLongPollResourceSessionSend(Resource):
         messages in the batch.
         """
         payload = request.content.read()
-        self.log.debug("WampLongPoll: receiving data for transport '{0}'\n{1}".format(self._parent._transport_id, binascii.hexlify(payload)))
+        self.log.debug(
+            "WampLongPoll: receiving data for transport '{tid}'\n{octets}",
+            tid=self._parent._transport_id,
+            octets=_LazyHexFormatter(payload),
+        )
 
         try:
             # process (batch of) WAMP message(s)
@@ -123,7 +129,13 @@ class WampLongPollResourceSessionReceive(Resource):
         if False:
             def logqueue():
                 if not self._killed:
-                    self.log.debug("WampLongPoll: transport '{0}' - currently polled {1}, pending messages {2}".format(self._parent._transport_id, self._request is not None, len(self._queue)))
+                    self.log.debug(
+                        "WampLongPoll: transport '{tid}' - currently polled"
+                        " {is_polled}, pending messages {pending}",
+                        tid=self._parent._transport_id,
+                        is_polled=self._request is not None,
+                        pending=len(self._queue),
+                    )
                     self.reactor.callLater(1, logqueue)
             logqueue()
 
@@ -190,7 +202,10 @@ class WampLongPollResourceSessionReceive(Resource):
         request.setHeader(b'content-type', mime_type)
 
         def cancel(_):
-            self.log.debug("WampLongPoll: poll request for transport '{0}' has gone away".format(self._parent._transport_id))
+            self.log.debug(
+                "WampLongPoll: poll request for transport '{tid}' has gone away",
+                tid=self._parent._transport_id,
+            )
             self._request = None
 
         request.notifyFinish().addErrback(cancel)
@@ -206,6 +221,8 @@ class WampLongPollResourceSessionClose(Resource):
     A Web resource for closing the Long-poll session WampLongPollResourceSession.
     """
 
+    log = make_logger()
+
     def __init__(self, parent):
         """
 
@@ -220,12 +237,18 @@ class WampLongPollResourceSessionClose(Resource):
         A client may actively close a session (and the underlying long-poll transport)
         by issuing a HTTP/POST with empty body to this resource.
         """
-        self.log.debug("WampLongPoll: closing transport '{0}'".format(self._parent._transport_id))
+        self.log.debug(
+            "WampLongPoll: closing transport '{tid}'",
+            tid=self._parent._transport_id,
+        )
 
         # now actually close the session
         self._parent.close()
 
-        self.log.debug("WampLongPoll: session ended and transport {0} closed".format(self._parent._transport_id))
+        self.log.debug(
+            "WampLongPoll: session ended and transport {tid} closed",
+            tid=self._parent._transport_id,
+        )
 
         request.setResponseCode(http.NO_CONTENT)
         self._parent._parent._set_standard_headers(request)
@@ -281,23 +304,35 @@ class WampLongPollResourceSession(Resource):
         if killAfter > 0:
             def killIfDead():
                 if not self._isalive:
-                    self.log.debug("WampLongPoll: killing inactive WAMP session with transport '{0}'".format(self._transport_id))
+                    self.log.debug(
+                        "WampLongPoll: killing inactive WAMP session with transport '{tid}'",
+                        tid=self._transport_id,
+                    )
 
                     self.onClose(False, 5000, "session inactive")
                     self._receive._kill()
                     if self._transport_id in self._parent._transports:
                         del self._parent._transports[self._transport_id]
                 else:
-                    self.log.debug("WampLongPoll: transport '{0}' is still alive".format(self._transport_id))
+                    self.log.debug(
+                        "WampLongPoll: transport '{tid}' is still alive",
+                        tid=self._transport_id,
+                    )
 
                     self._isalive = False
                     self.reactor.callLater(killAfter, killIfDead)
 
             self.reactor.callLater(killAfter, killIfDead)
         else:
-            self.log.debug("WampLongPoll: transport '{0}' automatic killing of inactive session disabled".format(self._transport_id))
+            self.log.debug(
+                "WampLongPoll: transport '{tid}' automatic killing of inactive session disabled",
+                tid=self._transport_id,
+            )
 
-        self.log.debug("WampLongPoll: session resource for transport '{0}' initialized)".format(self._transport_id))
+        self.log.debug(
+            "WampLongPoll: session resource for transport '{tid}' initialized)",
+            tid=self._transport_id,
+        )
 
         self.onOpen()
 
@@ -362,7 +397,10 @@ class WampLongPollResourceSession(Resource):
         Callback from :func:`autobahn.websocket.interfaces.IWebSocketChannel.onMessage`
         """
         for msg in self._serializer.unserialize(payload, isBinary):
-            self.log.debug("WampLongPoll: RX {0}".format(msg))
+            self.log.debug(
+                "WampLongPoll: RX {octets}",
+                octets=_LazyHexFormatter(msg),
+            )
             self._session.onMessage(msg)
 
     def send(self, msg):
@@ -371,10 +409,19 @@ class WampLongPollResourceSession(Resource):
         """
         if self.isOpen():
             try:
-                self.log.debug("WampLongPoll: TX {0}".format(msg))
+                self.log.debug(
+                    "WampLongPoll: TX {octets}",
+                    octets=_LazyHexFormatter(msg),
+                )
                 payload, isBinary = self._serializer.serialize(msg)
             except Exception as e:
                 # all exceptions raised from above should be serialization errors ..
+                f = create_failure()
+                self.log.error(
+                    "Unable to serialize WAMP application payload: {msg}",
+                    msg=failure_message(f),
+                )
+                self.log.debug("{tb}", tb=failure_format_traceback(f))
                 raise SerializationError("unable to serialize WAMP application payload ({0})".format(e))
             else:
                 self._receive.queue(payload)
@@ -413,11 +460,17 @@ class WampLongPollResourceOpen(Resource):
         payload = request.content.read()
         try:
             options = json.loads(payload)
-        except Exception as e:
-            return self._parent._fail_request(request, "could not parse WAMP session open request body: {0}".format(e))
+        except Exception:
+            f = create_failure()
+            self.log.error(
+                "Couldn't parse WAMP request body: {msg}",
+                msg=failure_message(f),
+            )
+            self.log.debug("{msg}", msg=failure_format_traceback(f))
+            return self._parent._fail_request(request, b"could not parse WAMP session open request body")
 
         if type(options) != dict:
-            return self._parent._fail_request(request, "invalid type for WAMP session open request [was {0}, expected dictionary]".format(type(options)))
+            return self._parent._fail_request(request, b"invalid type for WAMP session open request")
 
         if u'protocols' not in options:
             return self._parent._fail_request(request, "missing attribute 'protocols' in WAMP session open request")
@@ -622,6 +675,7 @@ class WampLongPollResource(Resource):
             if name == b'':
                 return self
             else:
+                self.log.error("No WAMP transport '{name}'", name=name)
                 return NoResource("no WAMP transport '{0}'".format(name))
 
         if len(request.postpath) == 0 or (len(request.postpath) == 1 and request.postpath[0] in [b'send', b'receive', b'close']):

--- a/crossbar/router/session.py
+++ b/crossbar/router/session.py
@@ -265,7 +265,6 @@ class RouterApplicationSession(object):
                     self._log_error(Failure(), "While notifying 'disconnect'")
 
                 if self._router._realm.session:
-                    print("XXX", session._session_id)
                     yield self._router._realm.session.publish(
                         u'wamp.session.on_leave',
                         session._session_id,


### PR DESCRIPTION
There's two pieces here: one fixes a bunch of logging things, and the other fixes some incorrect `bytes` vs `str` handling. See #610 

For logging:

 - use late string-interpolation always
 - debug-log tracebacks for errors
 - use the autobahn trick to lazily-hexlify debug octet logging

For longpoll specifically:

 - always return bytes for responses etc
 - simplify some of the failure messages (e.g. remove exception messages; they're in debug/info logs now so there's no good reason to return them to the client)

I tested against the longpoll example on both Python 3.5 and 2.7 (under Debian).