### PR TITLE
convert all log calls using .format() to use kwargs

### DIFF
--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -2093,7 +2093,7 @@ def check_container_components(components):
         raise InvalidConfigException("'components' items must be lists ({} encountered)".format(type(components)))
 
     for i, component in enumerate(components):
-        log.debug("Checking container component item {} ..".format(i))
+        log.debug("Checking container component item {item} ..", item=i)
         check_container_component(component)
 
 
@@ -2192,7 +2192,7 @@ def check_router_components(components):
         raise InvalidConfigException("'components' items must be lists ({} encountered)".format(type(components)))
 
     for i, component in enumerate(components):
-        log.debug("Checking router component item {} ..".format(i))
+        log.debug("Checking router component item {item} ..", item=i)
         check_router_component(component)
 
 
@@ -2243,7 +2243,7 @@ def check_connections(connections):
         raise InvalidConfigException("'connections' items must be lists ({} encountered)".format(type(connections)))
 
     for i, connection in enumerate(connections):
-        log.debug("Checking connection item {} ..".format(i))
+        log.debug("Checking connection item {item} ..", item=i)
         check_connection(connection)
 
 
@@ -2282,7 +2282,7 @@ def check_router(router):
         raise InvalidConfigException("'realms' items must be lists ({} encountered)\n\n{}".format(type(realms), pformat(router)))
 
     for i, realm in enumerate(realms):
-        log.debug("Checking realm item {} ..".format(i))
+        log.debug("Checking realm item {item} ..", item=i)
         check_router_realm(realm)
 
     # transports
@@ -2292,7 +2292,7 @@ def check_router(router):
         raise InvalidConfigException("'transports' items must be lists ({} encountered)\n\n{}".format(type(transports), pformat(router)))
 
     for i, transport in enumerate(transports):
-        log.debug("Checking transport item {} ..".format(i))
+        log.debug("Checking transport item {item} ..", item=i)
         check_router_transport(transport)
 
     # connections
@@ -2748,7 +2748,7 @@ def check_config(config):
         raise InvalidConfigException("'workers' attribute in top-level configuration must be a list ({} encountered)".format(type(workers)))
 
     for i, worker in enumerate(workers):
-        log.debug("Checking worker item {} ..".format(i))
+        log.debug("Checking worker item {item} ..", item=i)
         check_worker(worker)
 
 
@@ -2797,7 +2797,7 @@ def convert_config_file(configfile):
 
     with open(configfile, 'r') as infile:
         if configext == '.yaml':
-            log.info("converting YAML configuration {} to JSON ...".format(configfile))
+            log.info("converting YAML configuration {cfg} to JSON ...", cfg=configfile)
             try:
                 config = yaml.safe_load(infile)
             except Exception as e:
@@ -2806,9 +2806,9 @@ def convert_config_file(configfile):
                 newconfig = os.path.abspath(configbase + '.json')
                 with open(newconfig, 'w') as outfile:
                     json.dump(config, outfile, ensure_ascii=False, separators=(',', ': '), indent=3, sort_keys=True)
-                    log.info("ok, JSON formatted configuration written to {}".format(newconfig))
+                    log.info("ok, JSON formatted configuration written to {cfg}", cfg=newconfig)
         elif configext == ".json":
-            log.info("converting JSON formatted configuration {} to YAML format ...".format(configfile))
+            log.info("converting JSON formatted configuration {cfg} to YAML format ...", cfg=configfile)
             try:
                 config = json.load(infile, object_pairs_hook=OrderedDict)
             except ValueError as e:
@@ -2817,7 +2817,7 @@ def convert_config_file(configfile):
                 newconfig = os.path.abspath(configbase + '.yaml')
                 with open(newconfig, 'w') as outfile:
                     yaml.safe_dump(config, outfile, default_flow_style=False)
-                    log.info("ok, YAML formatted configuration written to {}".format(newconfig))
+                    log.info("ok, YAML formatted configuration written to {cfg}", cfg=newconfig)
 
         else:
             raise InvalidConfigException("configuration file needs to be '.json' or '.yaml'.")

--- a/crossbar/common/process.py
+++ b/crossbar/common/process.py
@@ -282,7 +282,7 @@ class NativeProcessSession(ApplicationSession):
             self.log.warn(emsg)
             raise ApplicationError(u"crossbar.error.invalid_configuration", emsg)
         else:
-            self.log.info("Starting {} in process.".format(config['type']))
+            self.log.info("Starting {ptype} in process.", ptype=config['type'])
 
         if config['type'] == u'postgresql.connection':
             if _HAS_POSTGRESQL:

--- a/crossbar/common/profiler.py
+++ b/crossbar/common/profiler.py
@@ -128,7 +128,7 @@ if _HAS_VMPROF:
 
             # this will run on a background thread
             def convert_profile(profile_filename):
-                self.log.info("Converting profile file {}".format(profile_filename))
+                self.log.info("Converting profile file {fname}", fname=profile_filename)
 
                 try:
                     stats = vmprof.read_profile(profile_filename, virtual_only=True, include_extra_info=True)

--- a/crossbar/common/reloader.py
+++ b/crossbar/common/reloader.py
@@ -126,22 +126,22 @@ class TrackingModuleReloader:
                     _, old_mtime = self._module_mtimes[mod_name]
 
                     if new_mtime == old_mtime:
-                        self.log.debug("Module {} unchanged".format(mod_name))
+                        self.log.debug("Module {mod_name} unchanged", mod_name=mod_name)
                     else:
                         self._module_mtimes[mod_name] = (f, new_mtime)
                         reload_modules.append(mod_name)
-                        self.log.debug("Change of module {} detected (file {}).".format(mod_name, f))
+                        self.log.debug("Change of module {mod_name} detected (file {f}).", mod_name=mod_name, f=f)
                 else:
                     self._module_mtimes[mod_name] = get_module_path_and_mtime(m)
                     reload_modules.append(mod_name)
-                    self.log.debug("Tracking new module {}".format(mod_name))
+                    self.log.debug("Tracking new module {mod_name}", mod_name=mod_name)
         else:
             reload_modules = maybe_dirty_modules
 
         if len(reload_modules):
-            self.log.debug("Reloading {} possibly changed modules".format(len(reload_modules)))
+            self.log.debug("Reloading {modules} possibly changed modules", modules=len(reload_modules))
             for module in reload_modules:
-                self.log.debug("Reloading module {}".format(module))
+                self.log.debug("Reloading module {module}", module=module)
 
                 # this is doing the actual work
                 #

--- a/crossbar/controller/cli.py
+++ b/crossbar/controller/cli.py
@@ -184,9 +184,9 @@ def check_is_running(cbdir):
                                 nicecmdline = ' '.join(cmdline)
                                 if len(nicecmdline) > 76:
                                     nicecmdline = nicecmdline[:38] + ' ... ' + nicecmdline[-38:]
-                                log.info('"{}" points to PID {} which is not a crossbar process:'.format(fp, pid))
-                                log.info('  ' + nicecmdline)
-                                log.info('Verify manually and either kill {} or delete {}'.format(pid, fp))
+                                log.info('"{fp}" points to PID {pid} which is not a crossbar process:', fp=fp, pid=pid)
+                                log.info('  {cmdline}', cmdline=nicecmdline)
+                                log.info('Verify manually and either kill {pid} or delete {fp}', pid=pid, fp=fp)
                                 return None
                         return pid_data
                     else:
@@ -392,7 +392,7 @@ def run_command_init(options, **kwargs):
     log.info("Application template initialized")
 
     if get_started_hint:
-        log.info("\n{}\n".format(get_started_hint))
+        log.info("\n{hint}\n", hint=get_started_hint)
     else:
         log.info("\nTo start your node, run 'crossbar start --cbdir {cbdir}'\n",
                  cbdir=os.path.abspath(os.path.join(options.appdir, '.crossbar')))
@@ -633,7 +633,7 @@ def run_command_start(options, reactor=None):
 
         def on_error(err):
             log.error("{e!s}", e=err.value)
-            log.error("Could not start node: {err}".format(err))
+            log.error("Could not start node: {err}", err=err)
             if reactor.running:
                 reactor.stop()
         d.addErrback(on_error)
@@ -1002,7 +1002,7 @@ def run(prog=None, args=None, reactor=None):
                 try:
                     os.mkdir(options.logdir)
                 except Exception as e:
-                    print("Could not create log directory: {}".format(e))
+                    print("Could not create log directory: {e}".format(e))
                     sys.exit(1)
 
     if not reactor:

--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -301,7 +301,11 @@ class Node(object):
                          " correspond to private-key-ed25519").format(pubkey_path)
                     )
             else:
-                self.log.info("Node public key file {} not found - re-creating from node private key file {}".format(pubkey_path, privkey_path))
+                self.log.info(
+                    "Node public key file {pub_path} not found - re-creating from node private key file {priv_path}",
+                    pub_path=pubkey_path,
+                    priv_path=privkey_path,
+                )
                 pub_tags = OrderedDict([
                     (u'creator', priv_tags[u'creator']),
                     (u'created-at', priv_tags[u'created-at']),
@@ -311,7 +315,7 @@ class Node(object):
                 msg = u'Crossbar.io node public key\n\n'
                 _write_node_key(pubkey_path, pub_tags, msg)
 
-            self.log.debug("Node key already exists (public key: {})".format(pubkey_hex))
+            self.log.debug("Node key already exists (public key: {hex})", hex=pubkey_hex)
 
         else:
             # node private key does not yet exist: generate one
@@ -444,10 +448,10 @@ class Node(object):
         # allow to override node shutdown triggers
         #
         if 'shutdown' in controller_options:
-            self.log.info("Overriding default node shutdown triggers with {} from node config".format(controller_options['shutdown']))
+            self.log.info("Overriding default node shutdown triggers with {triggers} from node config", triggers=controller_options['shutdown'])
             self._node_shutdown_triggers = controller_options['shutdown']
         else:
-            self.log.info("Using default node shutdown triggers {}".format(self._node_shutdown_triggers))
+            self.log.info("Using default node shutdown triggers {triggers}", triggers=self._node_shutdown_triggers)
 
         # add the node controller singleton session
         #
@@ -683,7 +687,13 @@ class Node(object):
                                 self._role_no += 1
 
                             yield self._controller.call('crossbar.worker.{}.start_router_realm_role'.format(worker_id), realm_id, role_id, role, options=call_options)
-                            self.log.info("{}: role '{}' (named '{}') started on realm '{}'".format(worker_logname, role_id, role['name'], realm_id))
+                            self.log.info(
+                                "{logname}: role '{role}' (named '{role_name}') started on realm '{realm}'",
+                                logname=worker_logname,
+                                role=role_id,
+                                role_name=role['name'],
+                                realm=realm_id,
+                            )
 
                         # start uplinks for realm
                         for uplink in realm.get('uplinks', []):
@@ -694,7 +704,12 @@ class Node(object):
                                 self._uplink_no += 1
 
                             yield self._controller.call('crossbar.worker.{}.start_router_realm_uplink'.format(worker_id), realm_id, uplink_id, uplink, options=call_options)
-                            self.log.info("{}: uplink '{}' started on realm '{}'".format(worker_logname, uplink_id, realm_id))
+                            self.log.info(
+                                "{logname}: uplink '{uplink}' started on realm '{realm}'",
+                                logname=worker_logname,
+                                uplink=uplink_id,
+                                realm=realm_id,
+                            )
 
                     # start connections (such as PostgreSQL database connection pools)
                     # to run embedded in the router
@@ -707,7 +722,11 @@ class Node(object):
                             self._connection_no += 1
 
                         yield self._controller.call('crossbar.worker.{}.start_connection'.format(worker_id), connection_id, connection, options=call_options)
-                        self.log.info("{}: connection '{}' started".format(worker_logname, connection_id))
+                        self.log.info(
+                            "{logname}: connection '{connection}' started",
+                            logname=worker_logname,
+                            connection=connection_id,
+                        )
 
                     # start components to run embedded in the router
                     for component in worker.get('components', []):
@@ -719,7 +738,11 @@ class Node(object):
                             self._component_no += 1
 
                         yield self._controller.call('crossbar.worker.{}.start_router_component'.format(worker_id), component_id, component, options=call_options)
-                        self.log.info("{}: component '{}' started".format(worker_logname, component_id))
+                        self.log.info(
+                            "{logname}: component '{component}' started",
+                            logname=worker_logname,
+                            component=component_id,
+                        )
 
                     # start transports on router
                     for transport in worker['transports']:
@@ -731,7 +754,11 @@ class Node(object):
                             self._transport_no += 1
 
                         yield self._controller.call('crossbar.worker.{}.start_router_transport'.format(worker_id), transport_id, transport, options=call_options)
-                        self.log.info("{}: transport '{}' started".format(worker_logname, transport_id))
+                        self.log.info(
+                            "{logname}: transport '{tid}' started",
+                            logname=worker_logname,
+                            tid=transport_id,
+                        )
 
                 # setup container worker
                 elif worker_type == 'container':
@@ -765,7 +792,11 @@ class Node(object):
                             self._connection_no += 1
 
                         yield self._controller.call('crossbar.worker.{}.start_connection'.format(worker_id), connection_id, connection, options=call_options)
-                        self.log.info("{}: connection '{}' started".format(worker_logname, connection_id))
+                        self.log.info(
+                            "{logname}: connection '{connection}' started",
+                            logname=worker_logname,
+                            connection=connection_id,
+                        )
 
                     # start components to run embedded in the container
                     #
@@ -793,7 +824,11 @@ class Node(object):
                     self._transport_no = 1
 
                     yield self._controller.call('crossbar.worker.{}.start_websocket_testee_transport'.format(worker_id), transport_id, transport, options=call_options)
-                    self.log.info("{}: transport '{}' started".format(worker_logname, transport_id))
+                    self.log.info(
+                        "{logname}: transport '{tid}' started",
+                        logname=worker_logname,
+                        tid=transport_id,
+                    )
 
                 else:
                     raise Exception("logic error")

--- a/crossbar/controller/process.py
+++ b/crossbar/controller/process.py
@@ -549,13 +549,13 @@ class NodeControllerSession(NativeProcessSession):
         worker.ready.addCallbacks(on_ready_success, on_ready_error)
 
         def on_exit_success(_):
-            self.log.info("Node worker {} ended successfully".format(worker.id))
+            self.log.info("Node worker {worker.id} ended successfully", worker=worker)
             worker.log_stats(0)
             del self._workers[worker.id]
             return True
 
         def on_exit_error(err):
-            self.log.info("Node worker {} ended with error ({})".format(worker.id, err))
+            self.log.info("Node worker {worker.id} ended with error ({err})", worker=worker, err=err)
             worker.log_stats(0)
             del self._workers[worker.id]
             return False
@@ -566,19 +566,19 @@ class NodeControllerSession(NativeProcessSession):
             # automatically shutdown node whenever a worker ended (successfully, or with error)
             #
             if checkconfig.NODE_SHUTDOWN_ON_WORKER_EXIT in self._node._node_shutdown_triggers:
-                self.log.info("Node worker ended, and trigger '{}' active".format(checkconfig.NODE_SHUTDOWN_ON_WORKER_EXIT))
+                self.log.info("Node worker ended, and trigger '{trigger}' active", trigger=checkconfig.NODE_SHUTDOWN_ON_WORKER_EXIT)
                 shutdown = True
 
             # automatically shutdown node when worker ended with error
             #
             if not was_successful and checkconfig.NODE_SHUTDOWN_ON_WORKER_EXIT_WITH_ERROR in self._node._node_shutdown_triggers:
-                self.log.info("Node worker ended with error, and trigger '{}' active".format(checkconfig.NODE_SHUTDOWN_ON_WORKER_EXIT_WITH_ERROR))
+                self.log.info("Node worker ended with error, and trigger '{trigger}' active", trigger=checkconfig.NODE_SHUTDOWN_ON_WORKER_EXIT_WITH_ERROR)
                 shutdown = True
 
             # automatically shutdown node when no more workers are left
             #
             if len(self._workers) == 0 and checkconfig.NODE_SHUTDOWN_ON_LAST_WORKER_EXIT in self._node._node_shutdown_triggers:
-                self.log.info("No more node workers running, and trigger '{}' active".format(checkconfig.NODE_SHUTDOWN_ON_LAST_WORKER_EXIT))
+                self.log.info("No more node workers running, and trigger '{trigger}' active", trigger=checkconfig.NODE_SHUTDOWN_ON_LAST_WORKER_EXIT)
                 shutdown = True
 
             # initiate shutdown (but only if we are not already shutting down)
@@ -591,7 +591,10 @@ class NodeControllerSession(NativeProcessSession):
                     # ignore: shutdown already initiated ..
                     self.log.info("Node is already shutting down.")
             else:
-                self.log.info("Node will continue to run (node shutdown triggers active: {})".format(self._node._node_shutdown_triggers))
+                self.log.info(
+                    "Node will continue to run (node shutdown triggers active: {triggers})",
+                    triggers=self._node._node_shutdown_triggers,
+                )
 
         d_on_exit = worker.exit.addCallbacks(on_exit_success, on_exit_error)
         d_on_exit.addBoth(check_for_shutdown)

--- a/crossbar/controller/template.py
+++ b/crossbar/controller/template.py
@@ -218,7 +218,7 @@ class Templates:
         basedir = pkg_resources.resource_filename("crossbar", template['basedir'])
         if IS_WIN:
             basedir = basedir.replace('\\', '/')  # Jinja need forward slashes even on Windows
-        self.log.info("Using template from '{}'".format(basedir))
+        self.log.info("Using template from '{dir}'", dir=basedir)
 
         appdir = os.path.abspath(appdir)
 
@@ -249,9 +249,9 @@ class Templates:
                             self.log.info(msg)
                             raise Exception(msg)
                         else:
-                            self.log.warn("{} - SKIPPING".format(msg))
+                            self.log.warn("{msg} - SKIPPING", msg=msg)
                     else:
-                        self.log.info("Creating directory {}".format(create_dir_path))
+                        self.log.info("Creating directory {dir}", dir=create_dir_path)
                         if not dryrun:
                             os.mkdir(create_dir_path)
                         created.append(('dir', create_dir_path))
@@ -275,9 +275,9 @@ class Templates:
                                 self.log.info(msg)
                                 raise Exception(msg)
                             else:
-                                self.log.warn("{} - SKIPPING".format(msg))
+                                self.log.warn("{msg} - SKIPPING", msg=msg)
                         else:
-                            self.log.info("Creating file {}".format(dst_file))
+                            self.log.info("Creating file {name}", name=dst_file)
                             if not dryrun:
                                 if f in template.get('skip_jinja', []):
                                     shutil.copy(src_file, dst_file)
@@ -302,18 +302,18 @@ class Templates:
             for ptype, path in reversed(created):
                 if ptype == 'file':
                     try:
-                        self.log.info("Removing file {}".format(path))
+                        self.log.info("Removing file {path}", path=path)
                         if not dryrun:
                             os.remove(path)
                     except:
-                        self.log.warn("Warning: could not remove file {}".format(path))
+                        self.log.warn("Warning: could not remove file {path}", path=path)
                 elif ptype == 'dir':
                     try:
-                        self.log.info("Removing directory {}".format(path))
+                        self.log.info("Removing directory {path}", path=path)
                         if not dryrun:
                             os.rmdir(path)
                     except:
-                        self.log.warn("Warning: could not remove directory {}".format(path))
+                        self.log.warn("Warning: could not remove directory {path}", path=path)
                 else:
                     raise Exception("logic error")
             raise

--- a/crossbar/router/auth/cryptosign.py
+++ b/crossbar/router/auth/cryptosign.py
@@ -101,7 +101,10 @@ class PendingAuthCryptosign(PendingAuth):
         if channel_binding is not None and channel_binding not in [u'tls-unique']:
             return types.Deny(message=u'invalid channel binding type "{}" requested'.format(channel_binding))
         else:
-            self.log.info("WAMP-cryptosign CHANNEL BINDING requested: {}".format(channel_binding))
+            self.log.info(
+                "WAMP-cryptosign CHANNEL BINDING requested: {binding}",
+                binding=channel_binding,
+            )
 
         # remember the realm the client requested to join (if any)
         self._realm = realm

--- a/crossbar/router/auth/ticket.py
+++ b/crossbar/router/auth/ticket.py
@@ -113,7 +113,13 @@ class PendingAuthTicket(PendingAuth):
                 return self._accept()
             else:
                 # ticket was invalid: deny client
-                self.log.debug('WAMP-Ticket (static): expected ticket "{}"" ({}), but got "{}" ({})'.format(self._signature, type(self._signature), signature, type(signature)))
+                self.log.debug(
+                    'WAMP-Ticket (static): expected ticket "{expected}"" ({expected_type}), but got "{sig}" ({sig_type})',
+                    expected=self._signature,
+                    expected_type=type(self._signature),
+                    sig=signature,
+                    sig_type=type(signature),
+                )
                 return types.Deny(message=u"ticket in static WAMP-Ticket authentication is invalid")
 
         # WAMP-Ticket "dynamic"

--- a/crossbar/router/protocol.py
+++ b/crossbar/router/protocol.py
@@ -176,11 +176,14 @@ class WampWebSocketServerProtocol(websocket.WampWebSocketServerProtocol):
             from twisted.internet import reactor
 
             def print_traffic():
-                self.log.info("Traffic {}: {} / {} in / out bytes - {} / {} in / out msgs".format(self.peer,
-                                                                                                  self.trafficStats.incomingOctetsWireLevel,
-                                                                                                  self.trafficStats.outgoingOctetsWireLevel,
-                                                                                                  self.trafficStats.incomingWebSocketMessages,
-                                                                                                  self.trafficStats.outgoingWebSocketMessages))
+                self.log.info(
+                    "Traffic {peer}: {wire_in} / {wire_out} in / out bytes - {ws_in} / {ws_out} in / out msgs",
+                    peer=self.peer,
+                    wire_in=self.trafficStats.incomingOctetsWireLevel,
+                    wire_out=self.trafficStats.outgoingOctetsWireLevel,
+                    ws_in=self.trafficStats.incomingWebSocketMessages,
+                    ws_out=self.trafficStats.outgoingWebSocketMessages,
+                )
                 reactor.callLater(1, print_traffic)
 
             print_traffic()
@@ -228,7 +231,7 @@ class WampWebSocketServerProtocol(websocket.WampWebSocketServerProtocol):
                 # associated with the same cookie
                 self.factory._cookiestore.addProto(self._cbtid, self)
 
-                self.log.debug("Cookie tracking enabled on WebSocket connection {}".format(self))
+                self.log.debug("Cookie tracking enabled on WebSocket connection {ws}", ws=self)
 
                 # if cookie-based authentication is enabled, set auth info from cookie store
                 #
@@ -248,7 +251,7 @@ class WampWebSocketServerProtocol(websocket.WampWebSocketServerProtocol):
                 else:
                     self.log.debug("Cookie-based authentication disabled")
             else:
-                self.log.debug("Cookie tracking disabled on WebSocket connection {}".format(self))
+                self.log.debug("Cookie tracking disabled on WebSocket connection {ws}", ws=self)
 
             # remember transport level info for later forwarding in
             # WAMP meta event "wamp.session.on_join"

--- a/crossbar/router/service.py
+++ b/crossbar/router/service.py
@@ -74,11 +74,17 @@ class RouterServiceSession(ApplicationSession):
         self._schemas = {}
         if schemas:
             self._schemas.update(schemas)
-            self.log.info('initialized schemas cache with {} entries'.format(len(self._schemas)))
+            self.log.info(
+                'initialized schemas cache with {entries} entries',
+                entries=len(self._schemas),
+            )
 
     @inlineCallbacks
     def onJoin(self, details):
-        self.log.debug('Router service session attached: {}'.format(details))
+        self.log.debug(
+            'Router service session attached: {details}',
+            details=details,
+        )
 
         if True:
             procs = [
@@ -109,7 +115,7 @@ class RouterServiceSession(ApplicationSession):
         else:
             regs = yield self.register(self)
 
-        self.log.debug('Registered {} procedures'.format(len(regs)))
+        self.log.debug('Registered {regs} procedures', regs=regs)
 
         if self.config.extra and 'onready' in self.config.extra:
             self.config.extra['onready'].callback(self)

--- a/crossbar/router/session.py
+++ b/crossbar/router/session.py
@@ -704,7 +704,7 @@ class RouterSession(BaseSession):
                     return types.Deny(ApplicationError.NO_AUTH_METHOD, message=u'cannot authenticate using any of the offered authmethods {}'.format(authmethods))
 
         except Exception as e:
-            self.log.critical("Internal error: {}".format(e))
+            self.log.critical("Internal error: {msg}", msg=str(e))
             return types.Deny(message=u'internal error: {}'.format(e))
 
     def onAuthenticate(self, signature, extra):

--- a/crossbar/twisted/endpoint.py
+++ b/crossbar/twisted/endpoint.py
@@ -343,7 +343,7 @@ def create_listening_endpoint_from_config(config, cbdir, reactor, log):
             try:
                 port = int(environ[config['port'][1:]])
             except Exception as e:
-                log.warn("Could not read listening port from env var: {}".format(e))
+                log.warn("Could not read listening port from env var: {e}", e=e)
                 raise
         else:
             port = config['port']

--- a/crossbar/worker/__init__.py
+++ b/crossbar/worker/__init__.py
@@ -80,7 +80,7 @@ def _appsession_loader(config):
             dist = config['package']
             name = config['entrypoint']
 
-            log.debug("Starting WAMPlet '{}/{}'".format(dist, name))
+            log.debug("Starting WAMPlet '{dist}/{name}'", dist=dist, name=name)
 
             # component is supposed to make instances of ApplicationSession
             component = pkg_resources.load_entry_point(

--- a/crossbar/worker/process.py
+++ b/crossbar/worker/process.py
@@ -256,7 +256,7 @@ def run():
             reactor.run()
 
     except Exception as e:
-        log.info("Unhandled exception: {}".format(e))
+        log.info("Unhandled exception: {e}", e=e)
         if reactor.running:
             reactor.addSystemEventTrigger('after', 'shutdown', os._exit, 1)
             reactor.stop()

--- a/crossbar/worker/router.py
+++ b/crossbar/worker/router.py
@@ -331,7 +331,7 @@ class RouterWorkerSession(NativeWorkerSession):
         :returns: List of realms currently running.
         :rtype: list of str
         """
-        self.log.debug("{}.get_router_realms".format(self.__class__.__name__))
+        self.log.debug("{name}.get_router_realms", name=self.__class__.__name__)
 
         return sorted(self.realms.keys())
 
@@ -345,8 +345,7 @@ class RouterWorkerSession(NativeWorkerSession):
         :param config: The realm configuration.
         :type config: dict
         """
-        self.log.debug("{}.start_router_realm".format(self.__class__.__name__),
-                       realm_id=realm_id, config=config)
+        self.log.debug("{name}.start_router_realm", name=self.__class__.__name__)
 
         # prohibit starting a realm twice
         #
@@ -406,8 +405,7 @@ class RouterWorkerSession(NativeWorkerSession):
         :param close_sessions: If `True`, close all session currently attached.
         :type close_sessions: bool
         """
-        self.log.debug("{}.stop_router_realm".format(self.__class__.__name__),
-                       realm_id=realm_id, close_sessions=close_sessions)
+        self.log.debug("{name}.stop_router_realm", name=self.__class__.__name__)
 
         # FIXME
         raise NotImplementedError()
@@ -422,7 +420,7 @@ class RouterWorkerSession(NativeWorkerSession):
         :returns: A list of roles.
         :rtype: list of dicts
         """
-        self.log.debug("{}.get_router_realm_roles".format(self.__class__.__name__), id=id)
+        self.log.debug("{name}.get_router_realm_roles({id})", name=self.__class__.__name__, id=id)
 
         if id not in self.realms:
             raise ApplicationError(u"crossbar.error.no_such_object", "No realm with ID '{}'".format(id))
@@ -440,8 +438,7 @@ class RouterWorkerSession(NativeWorkerSession):
         :param config: The role configuration.
         :type config: dict
         """
-        self.log.debug("{}.start_router_realm_role".format(self.__class__.__name__),
-                       id=id, role_id=role_id, config=config)
+        self.log.debug("{name}.start_router_realm_role", name=self.__class__.__name__)
 
         if id not in self.realms:
             raise ApplicationError(u"crossbar.error.no_such_object", "No realm with ID '{}'".format(id))
@@ -468,8 +465,7 @@ class RouterWorkerSession(NativeWorkerSession):
         :param role_id: The ID of the role to be stopped.
         :type role_id: str
         """
-        self.log.debug("{}.stop_router_realm_role".format(self.__class__.__name__),
-                       id=id, role_id=role_id)
+        self.log.debug("{name}.stop_router_realm_role", name=self.__class__.__name__)
 
         if id not in self.realms:
             raise ApplicationError(u"crossbar.error.no_such_object", "No realm with ID '{}'".format(id))
@@ -489,7 +485,7 @@ class RouterWorkerSession(NativeWorkerSession):
         :returns: A list of uplinks.
         :rtype: list of dicts
         """
-        self.log.debug("{}.get_router_realm_uplinks".format(self.__class__.__name__))
+        self.log.debug("{name}.get_router_realm_uplinks", name=self.__class__.__name__)
 
         if id not in self.realms:
             raise ApplicationError(u"crossbar.error.no_such_object", "No realm with ID '{}'".format(id))
@@ -508,8 +504,7 @@ class RouterWorkerSession(NativeWorkerSession):
         :param uplink_config: The uplink configuration.
         :type uplink_config: dict
         """
-        self.log.debug("{}.start_router_realm_uplink".format(self.__class__.__name__),
-                       realm_id=realm_id, uplink_id=uplink_id, uplink_config=uplink_config)
+        self.log.debug("{name}.start_router_realm_uplink", name=self.__class__.__name__)
 
         # check arguments
         if realm_id not in self.realms:
@@ -550,8 +545,7 @@ class RouterWorkerSession(NativeWorkerSession):
         :param uplink_id: The ID of the uplink within the realm to stop.
         :type uplink_id: str
         """
-        self.log.debug("{}.stop_router_realm_uplink".format(self.__class__.__name__),
-                       id=id, uplink_id=uplink_id)
+        self.log.debug("{name}.stop_router_realm_uplink", name=self.__class__.__name__)
 
         raise NotImplementedError()
 
@@ -562,7 +556,7 @@ class RouterWorkerSession(NativeWorkerSession):
         :returns: List of app components currently running.
         :rtype: list of dict
         """
-        self.log.debug("{}.get_router_components".format(self.__class__.__name__))
+        self.log.debug("{name}.get_router_components", name=self.__class__.__name__)
 
         res = []
         for component in sorted(self.components.values(), key=lambda c: c.created):
@@ -605,8 +599,7 @@ class RouterWorkerSession(NativeWorkerSession):
         :param config: The component configuration.
         :type config: obj
         """
-        self.log.debug("{}.start_router_component".format(self.__class__.__name__),
-                       id=id, config=config)
+        self.log.debug("{name}.start_router_component", name=self.__class__.__name__)
 
         # prohibit starting a component twice
         #
@@ -717,10 +710,10 @@ class RouterWorkerSession(NativeWorkerSession):
         :param id: The ID of the component to stop.
         :type id: str
         """
-        self.log.debug("{}.stop_router_component".format(self.__class__.__name__), id=id)
+        self.log.debug("{name}.stop_router_component({id})", name=self.__class__.__name__, id=id)
 
         if id in self.components:
-            self.log.debug("Worker {}: stopping component {}".format(self.config.extra.worker, id))
+            self.log.debug("Worker {worker}: stopping component {id}", worker=self.config.extra.worker, id=id)
 
             try:
                 # self._components[id].disconnect()
@@ -738,7 +731,7 @@ class RouterWorkerSession(NativeWorkerSession):
         :returns: List of transports currently running.
         :rtype: list of dict
         """
-        self.log.debug("{}.get_router_transports".format(self.__class__.__name__))
+        self.log.debug("{name}.get_router_transports", name=self.__class__.__name__)
 
         res = []
         for transport in sorted(self.transports.values(), key=lambda c: c.created):
@@ -758,8 +751,7 @@ class RouterWorkerSession(NativeWorkerSession):
         :param config: The transport configuration.
         :type config: dict
         """
-        self.log.debug("{}.start_router_transport".format(self.__class__.__name__),
-                       id=id, config=config)
+        self.log.debug("{name}.start_router_transport", name=self.__class__.__name__)
 
         # prohibit starting a transport twice
         #
@@ -777,7 +769,7 @@ class RouterWorkerSession(NativeWorkerSession):
             self.log.error(emsg)
             raise ApplicationError(u"crossbar.error.invalid_configuration", emsg)
         else:
-            self.log.debug("Starting {}-transport on router.".format(config['type']))
+            self.log.debug("Starting {ttype}-transport on router.", ttype=config['type'])
 
         # standalone WAMP-RawSocket transport
         #
@@ -859,7 +851,7 @@ class RouterWorkerSession(NativeWorkerSession):
 
         def ok(port):
             self.transports[id] = RouterTransport(id, config, transport_factory, port)
-            self.log.debug("Router transport '{}'' started and listening".format(id))
+            self.log.debug("Router transport '{id}'' started and listening", id)
             return
 
         def fail(err):
@@ -1189,7 +1181,7 @@ class RouterWorkerSession(NativeWorkerSession):
             try:
                 klassname = path_config['classname']
 
-                self.log.debug("Starting class '{}'".format(klassname))
+                self.log.debug("Starting class '{name}'", name=klassname)
 
                 c = klassname.split('.')
                 module_name, klass_name = '.'.join(c[:-1]), c[-1]
@@ -1248,7 +1240,7 @@ class RouterWorkerSession(NativeWorkerSession):
         :param id: The ID of the transport to stop.
         :type id: str
         """
-        self.log.debug("{}.stop_router_transport".format(self.__class__.__name__), id=id)
+        self.log.debug("{name}.stop_router_transport", name=self.__class__.__name__)
 
         # FIXME
         if id not in self.transports:
@@ -1257,7 +1249,7 @@ class RouterWorkerSession(NativeWorkerSession):
             self.log.error(emsg)
             raise ApplicationError(u'crossbar.error.not_running', emsg)
 
-        self.log.debug("Stopping transport with ID '{}'".format(id))
+        self.log.debug("Stopping transport with ID '{id}'", id=id)
 
         d = self.transports[id].port.stopListening()
 

--- a/crossbar/worker/testee.py
+++ b/crossbar/worker/testee.py
@@ -82,7 +82,7 @@ class WebSocketTesteeServerProtocol(WebSocketServerProtocol):
                                       cbVersion=crossbar.__version__,
                                       wsUri=self.factory.url))
         except Exception as e:
-            self.log.warn("Error rendering WebSocket status page template: {}".format(e))
+            self.log.warn("Error rendering WebSocket status page template: {e}", e=e)
 
 
 class StreamingWebSocketTesteeServerProtocol(WebSocketServerProtocol):
@@ -174,13 +174,12 @@ class WebSocketTesteeWorkerSession(NativeWorkerSession):
     def get_websocket_testee_transport(self, details=None):
         """
         """
-        self.log.debug("{}.get_websocket_testee_transport".format(self.__class__.__name__))
+        self.log.debug("{name}.get_websocket_testee_transport", name=self.__class__.__name__)
 
     def start_websocket_testee_transport(self, id, config, details=None):
         """
         """
-        self.log.debug("{}.start_websocket_testee_transport".format(self.__class__.__name__),
-                       id=id, config=config)
+        self.log.debug("{name}.start_websocket_testee_transport", name=self.__class__.__name__)
 
         # prohibit starting a transport twice
         #
@@ -199,7 +198,7 @@ class WebSocketTesteeWorkerSession(NativeWorkerSession):
             self.log.error(emsg)
             raise ApplicationError(u"crossbar.error.invalid_configuration", emsg)
         else:
-            self.log.debug("Starting {}-transport on websocket-testee.".format(config['type']))
+            self.log.debug("Starting {ttype}-transport on websocket-testee.", ttype=config['type'])
 
         # WebSocket testee pseudo transport
         #
@@ -224,7 +223,7 @@ class WebSocketTesteeWorkerSession(NativeWorkerSession):
         def ok(port):
             # FIXME
             # self.transports[id] = RouterTransport(id, config, transport_factory, port)
-            self.log.debug("Router transport '{}'' started and listening".format(id))
+            self.log.debug("Router transport '{tid}'' started and listening", tid=id)
             return
 
         def fail(err):
@@ -238,5 +237,5 @@ class WebSocketTesteeWorkerSession(NativeWorkerSession):
     def stop_websocket_testee_transport(self, id, details=None):
         """
         """
-        self.log.debug("{}.stop_websocket_testee_transport".format(self.__class__.__name__), id=id)
+        self.log.debug("{name}.stop_websocket_testee_transport", name=self.__class__.__name__)
         raise NotImplementedError()


### PR DESCRIPTION
After looking at #864 I ran a search for all uses of `.format` with a `.log.*` call and re-worked them all to not use `.format`.

There's a really nasty failure-case if you *just* pass a string-to-log to the logging calls: if that string happens to have `{}`'s in it, then the logger will try to interpolate it and most likely fail. I find this happens "somewhat often" when printing exceptions. The safest way to log a straight string is like:

```
self.log.debug("{msg}", msg="a string that can contain { and } safely")
```