### PR TITLE
Dynamic auth improvements

### DIFF
--- a/crossbar/router/dealer.py
+++ b/crossbar/router/dealer.py
@@ -317,7 +317,7 @@ class Dealer(object):
             different from the call to authorize succeed, but the
             authorization being denied)
             """
-            self.log.failure("Authorization failed", failure=err)
+            self.log.failure("Authorization of 'register' for '{uri}' failed", uri=register.procedure, failure=err)
             reply = message.Error(
                 message.Register.MESSAGE_TYPE,
                 register.request,
@@ -429,7 +429,6 @@ class Dealer(object):
             d = self._router.authorize(session, call.procedure, u'call')
 
             def on_authorize_success(authorization):
-
                 # the call to authorize the action _itself_ succeeded. now go on depending on whether
                 # the action was actually authorized or not ..
                 #
@@ -446,7 +445,7 @@ class Dealer(object):
                 different from the call to authorize succeed, but the
                 authorization being denied)
                 """
-                self.log.failure("Authorization failed", failure=err)
+                self.log.failure("Authorization of 'call' for '{uri}' failed", uri=call.procedure, failure=err)
                 reply = message.Error(
                     message.Call.MESSAGE_TYPE,
                     call.request,

--- a/crossbar/router/role.py
+++ b/crossbar/router/role.py
@@ -420,12 +420,13 @@ class RouterRoleDynamicAuth(RouterRole):
             return Failure(
                 ValueError(
                     "Authorizer returned unknown type '{name}'".format(
-                    name=type(authorization).__name__,
+                        name=type(authorization).__name__,
                     )
                 )
             )
         d.addCallback(sanity_check)
         return d
+
 
 class RouterRoleLMDBAuth(RouterRole):
     """

--- a/crossbar/router/router.py
+++ b/crossbar/router/router.py
@@ -271,7 +271,7 @@ class Router(object):
 
         def got_authorization(authorization):
             # backward compatibility
-            if type(authorization) == bool:
+            if isinstance(authorization, bool):
                 authorization = {
                     u'allow': authorization,
                     u'cache': False

--- a/docs/pages/administration/auth/Authorization.md
+++ b/docs/pages/administration/auth/Authorization.md
@@ -129,7 +129,7 @@ As a shortcut and for backwards compatibility you can instead return a single `b
 
 The arguments to the call are:
 
- - `session`: `None` for embedded componets or a `dict` containing session details (as sent to `onJoin`)
+ - `session`: a `dict` containing session details
  - `uri`: A string, the WAMP URI of the action being authorized
  - `action`: A string, one of `publish`, `subscribe`, `register`, or `call` indicating what is being authorized
 

--- a/docs/pages/administration/auth/Authorization.md
+++ b/docs/pages/administration/auth/Authorization.md
@@ -119,6 +119,22 @@ Besides *Static Authorization* using the URI-pattern based authorization scheme 
 
 With *Dynamic Authorization* your application will provide a WAMP procedure (with a defined signature) that Crossbar.io will then call to determine the permissions of other clients.
 
+The method must accept three arguments: `(session, uri, action)` and must return a `dict` with the following keys:
+
+ - `allow` (required) a bool indicating if the action is allowed
+ - `disclose` (optional, default `False`) a bool indicating if callee's session-id should be disclosed to callers
+ - `cache` (optional, default `False`) a bool indicating if the router can cache this answer
+
+As a shortcut and for backwards compatibility you can instead return a single `bool` which is the same as just specifying `allow` (that is, returning True is the same as returning `dict(allow=True)`.
+
+The arguments to the call are:
+
+ - `session`: `None` for embedded componets or a `dict` containing session details (as sent to `onJoin`)
+ - `uri`: A string, the WAMP URI of the action being authorized
+ - `action`: A string, one of `publish`, `subscribe`, `register`, or `call` indicating what is being authorized
+
+For fully-worked examples, see [crossbarexample/authorization](https://github.com/crossbario/crossbarexamples/tree/master/authorization/dynamic>).
+
 E.g. consider the following Python function
 
 ```python


### PR DESCRIPTION
While looking at #817 and documenting dynamic authorization, I made some improvements. The last commits completely fails authorization if the authorizor returns incorrect information, while with just the second-last commit the call will still go through but with default authorization (I think it's safest to do the behavior with all commits in this branch).

Note this is on top of the documentation PR (#866) so you could *just* merge this one and close that one ...