### PR TITLE
Issue693 node config

### DIFF
--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -358,8 +358,17 @@ def check_dict_args(spec, config, msg):
             valid_type = False
             for t in spec[k][1]:
                 if isinstance(config[k], t):
-                    valid_type = True
-                    break
+                    # We're special-casing Sequence here, because in
+                    # general if we say a Sequence is okay, we do NOT
+                    # want strings to be allowed but Python says that
+                    # "isinstance('foo', Sequence) == True"
+                    if t is Sequence:
+                        if not isinstance(config[k], (six.text_type, str)):
+                            valid_type = True
+                            break
+                    else:
+                        valid_type = True
+                        break
             if not valid_type:
                 raise InvalidConfigException("{} - invalid type {} encountered for attribute '{}', must be one of ({})".format(msg, type(config[k]).__name__, k, ', '.join([x.__name__ for x in spec[k][1]])))
 

--- a/crossbar/test/test_checkconfig.py
+++ b/crossbar/test/test_checkconfig.py
@@ -34,12 +34,32 @@ from crossbar.test import TestCase
 from crossbar.common import checkconfig
 
 import json
+import six
+if six.PY3:
+    from collections.abc import Sequence
+else:
+    from collections import Sequence
 
 
 class CheckDictArgsTests(TestCase):
     """
     Tests for L{crossbar.common.checkconfig.check_dict_args}.
     """
+    def test_sequence_string(self):
+        """
+        A Sequence should not imply we accept strings
+        """
+        with self.assertRaises(checkconfig.InvalidConfigException) as e:
+            checkconfig.check_dict_args(
+                {"foo": (True, [Sequence])},
+                {"foo": "not really a Sequence"},
+                "Nice message for the user"
+            )
+        self.assertEqual(
+            "Nice message for the user - invalid type for configuration item - expected Sequence, got str",
+            str(e.exception),
+        )
+
     def test_notDict(self):
         """
         A non-dict passed in as the config will raise a

--- a/crossbar/test/test_checkconfig.py
+++ b/crossbar/test/test_checkconfig.py
@@ -61,6 +61,17 @@ class CheckDictArgsTests(TestCase):
             str(e.exception),
         )
 
+    def test_sequence_list(self):
+        """
+        A Sequence should accept list
+        """
+        checkconfig.check_dict_args(
+            {"foo": (True, [Sequence])},
+            {"foo": ["a", "real", "sequence"]},
+            "Nice message for the user"
+        )
+        # should work, with no exceptions
+
     def test_notDict(self):
         """
         A non-dict passed in as the config will raise a

--- a/crossbar/test/test_checkconfig.py
+++ b/crossbar/test/test_checkconfig.py
@@ -56,7 +56,8 @@ class CheckDictArgsTests(TestCase):
                 "Nice message for the user"
             )
         self.assertEqual(
-            "Nice message for the user - invalid type for configuration item - expected Sequence, got str",
+            "Nice message for the user - invalid type str encountered for "
+            "attribute 'foo', must be one of (Sequence)",
             str(e.exception),
         )
 


### PR DESCRIPTION
This should fix #693 by disallowing string/text where we intended sequence (e.g. list, set etc). (Strings are considered sequences in Python).