### PR TITLE
Prevent automatic Twisted reactor loading

### DIFF
--- a/crossbar/adapter/rest/callee.py
+++ b/crossbar/adapter/rest/callee.py
@@ -30,8 +30,6 @@
 
 from __future__ import absolute_import
 
-import treq
-
 from six.moves.urllib.parse import urljoin
 
 from twisted.internet.defer import inlineCallbacks, returnValue
@@ -43,7 +41,12 @@ from autobahn.twisted.wamp import ApplicationSession
 class RESTCallee(ApplicationSession):
 
     def __init__(self, *args, **kwargs):
-        self._webtransport = kwargs.pop("webTransport", treq)
+        self._webtransport = kwargs.pop("webTransport")
+
+        if not self._webtransport:
+            import treq
+            self._webtransport = treq
+
         super(RESTCallee, self).__init__(*args, **kwargs)
 
     @inlineCallbacks

--- a/crossbar/adapter/rest/subscriber.py
+++ b/crossbar/adapter/rest/subscriber.py
@@ -30,7 +30,6 @@
 
 from __future__ import absolute_import
 
-import treq
 import json
 
 from functools import partial
@@ -50,7 +49,12 @@ class MessageForwarder(ApplicationSession):
     log = make_logger()
 
     def __init__(self, *args, **kwargs):
-        self._webtransport = kwargs.pop("webTransport", treq)
+        self._webtransport = kwargs.pop("webTransport")
+
+        if not self._webtransport:
+            import treq
+            self._webtransport = treq
+
         super(MessageForwarder, self).__init__(*args, **kwargs)
 
     @inlineCallbacks

--- a/crossbar/common/fswatcher.py
+++ b/crossbar/common/fswatcher.py
@@ -33,8 +33,6 @@ from __future__ import absolute_import
 import os
 from txaio import make_logger
 
-from twisted.internet import reactor
-
 try:
     from watchdog.observers import Observer
     from watchdog.events import FileSystemEventHandler
@@ -83,6 +81,8 @@ if HAS_FS_WATCHER:
                         u'rel_path': os.path.relpath(evt.src_path, self._working_dir),
                         u'is_directory': evt.is_directory,
                     }
+
+                    from twisted.internet import reactor
                     reactor.callFromThread(callback, event)
 
                 self._handler.on_any_event = on_any_event

--- a/crossbar/common/process.py
+++ b/crossbar/common/process.py
@@ -44,11 +44,7 @@ try:
     #
     # twisted.conch.manhole_ssh will import even without, but we _need_ SSH
     import pyasn1  # noqa
-    from twisted.cred import checkers, portal
-    from twisted.conch.manhole import ColoredManhole
-    from twisted.conch.manhole_ssh import ConchFactory, \
-        TerminalRealm, \
-        TerminalSession
+    import cryptography  # noqa
 except ImportError as e:
     _HAS_MANHOLE = False
     _MANHOLE_MISSING_REASON = str(e)
@@ -63,6 +59,8 @@ from autobahn.wamp.exception import ApplicationError
 from autobahn.wamp.types import PublishOptions, RegisterOptions
 
 from txaio import make_logger
+
+from twisted.cred import checkers, portal
 
 from crossbar.common import checkconfig
 from crossbar.common.checkconfig import get_config_value
@@ -575,6 +573,10 @@ class NativeProcessSession(ApplicationSession):
 
             def windowChanged(self, winSize):
                 pass
+
+        from twisted.conch.manhole_ssh import (
+            ConchFactory, TerminalRealm, TerminalSession)
+        from twisted.conch.manhole import ColoredManhole
 
         rlm = TerminalRealm()
         rlm.sessionFactory = PatchedTerminalSession  # monkey patch

--- a/crossbar/common/profiler.py
+++ b/crossbar/common/profiler.py
@@ -35,7 +35,6 @@ import tempfile
 
 import six
 
-from twisted.internet import reactor
 from twisted.internet.defer import Deferred
 from twisted.internet.threads import deferToThread
 
@@ -221,6 +220,7 @@ if _HAS_VMPROF:
 
             self.log.info("Starting profiling using {profiler} for {runtime} seconds.", profiler=self._id, runtime=runtime)
 
+            from twisted.internet import reactor
             reactor.callLater(runtime, finish_profile)
 
             return self._profile_id, self._finished

--- a/crossbar/twisted/resource.py
+++ b/crossbar/twisted/resource.py
@@ -37,7 +37,6 @@ from twisted.web import http, server
 from twisted.web.http import NOT_FOUND
 from twisted.web.resource import Resource, NoResource
 from twisted.web.static import File
-from twisted.web.proxy import ReverseProxyResource  # noqa (Republish resource)
 from twisted.python.filepath import FilePath
 
 from txaio import make_logger

--- a/crossbar/worker/router.py
+++ b/crossbar/worker/router.py
@@ -90,8 +90,7 @@ from crossbar.twisted.site import createHSTSRequestFactory
 
 from crossbar.twisted.resource import JsonResource, \
     Resource404, \
-    RedirectResource, \
-    ReverseProxyResource
+    RedirectResource
 
 from crossbar.adapter.mqtt.wamp import WampMQTTServerFactory
 
@@ -1062,6 +1061,10 @@ class RouterWorkerSession(NativeWorkerSession):
         # Reverse proxy resource
         #
         elif path_config['type'] == 'reverseproxy':
+
+            # Import late because t.w.proxy imports the reactor
+            from twisted.web.proxy import ReverseProxyResource
+
             host = path_config['host']
             port = int(path_config.get('port', 80))
             path = path_config.get('path', '').encode('ascii', 'ignore')


### PR DESCRIPTION
Makes KQueue on OSX/BSD and IOCP on Windows work now, fixes #920