### PR TITLE
Make `python{2,3} -m crossbar` work

### DIFF
--- a/crossbar/__main__.py
+++ b/crossbar/__main__.py
@@ -1,9 +1,9 @@
 #####################################################################################
 #
-#  Copyright (C) Tavendo GmbH
+#  Copyright (c) Crossbar.io Technologies GmbH
 #
-#  Unless a separate license agreement exists between you and Tavendo GmbH (e.g. you
-#  have purchased a commercial license), the license terms below apply.
+#  Unless a separate license agreement exists between you and Crossbar.io GmbH (e.g.
+#  you have purchased a commercial license), the license terms below apply.
 #
 #  Should you enter into a separate license agreement after having received a copy of
 #  this software, then the terms of such license agreement replace the terms below at

--- a/crossbar/__main__.py
+++ b/crossbar/__main__.py
@@ -1,0 +1,37 @@
+#####################################################################################
+#
+#  Copyright (C) Tavendo GmbH
+#
+#  Unless a separate license agreement exists between you and Tavendo GmbH (e.g. you
+#  have purchased a commercial license), the license terms below apply.
+#
+#  Should you enter into a separate license agreement after having received a copy of
+#  this software, then the terms of such license agreement replace the terms below at
+#  the time at which such license agreement becomes effective.
+#
+#  In case a separate license agreement ends, and such agreement ends without being
+#  replaced by another separate license agreement, the license terms below apply
+#  from the time at which said agreement ends.
+#
+#  LICENSE TERMS
+#
+#  This program is free software: you can redistribute it and/or modify it under the
+#  terms of the GNU Affero General Public License, version 3, as published by the
+#  Free Software Foundation. This program is distributed in the hope that it will be
+#  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+#  See the GNU Affero General Public License Version 3 for more details.
+#
+#  You should have received a copy of the GNU Affero General Public license along
+#  with this program. If not, see <http://www.gnu.org/licenses/agpl-3.0.en.html>.
+#
+#####################################################################################
+
+if __name__ == '__main__':
+    from pkg_resources import load_entry_point
+    import sys
+
+    sys.exit(
+        load_entry_point('crossbar', 'console_scripts', 'crossbar')()
+    )


### PR DESCRIPTION
It uses the same setuptools plugin as Crossbar, so we don't need to test it extensively. This change will:

a) make it easier to pass `-u` for unbuffered, as well as any other Python environments
b) make it easier to use python2 or python3 crossbar, in case you have multiple Crossbars installed (mainly developers here)
c) bring Crossbar in line with other Python utilities that are moving to `-m` as an option (and probably later the default) -- e.g. pip, Twisted, pytest, et al

Maybe references or helps fix https://github.com/crossbario/crossbar/issues/506 ?