### PR TITLE
A way to configure a 'functional' component

### DIFF
--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -2019,7 +2019,7 @@ def check_router_component(component):
         raise InvalidConfigException("missing mandatory attribute 'type' in component")
 
     ctype = component['type']
-    if ctype not in ['wamplet', 'class']:
+    if ctype not in ['wamplet', 'class', 'function']:
         raise InvalidConfigException("invalid value '{}' for component type".format(ctype))
 
     if ctype == 'wamplet':
@@ -2047,6 +2047,24 @@ def check_router_component(component):
             'extra': (False, None),
         }, component, "invalid component configuration")
 
+    elif ctype == 'function':
+        check_dict_args({
+            'id': (False, [six.text_type]),
+            'type': (True, [six.text_type]),
+            'realm': (True, [six.text_type]),
+            'role': (False, [six.text_type]),
+
+            'callbacks': (False, [dict]),
+        }, component, "invalid component configuration")
+        if 'callbacks' in component:
+            valid_callbacks = ['join', 'leave', 'connect', 'disconnect']
+            for name in component['callbacks'].keys():
+                if name not in valid_callbacks:
+                    raise InvalidConfigException(
+                        "Invalid callback name '{}' (valid are: {})".format(
+                            name, valid_callbacks
+                        )
+                    )
     else:
         raise InvalidConfigException('logic error')
 


### PR DESCRIPTION
Here is a (working) sketch of how to take a "functional"-style component and configure it into crossbar.

Basically, it's just configuring methods to call for the 4 listeners: `connect, disconnect, join, leave`.

This sketch only allows for single callbacks -- it might be nicer to allow a list of callbacks, too. To use this, you'd add something like this to a ``components`` list in crossbar config:

```
                {
                    "type": "function",
                    "realm": "crossbardemo",
                    "role": "anonymous",
                    "callbacks": {
                        "join": "func_component.on_join",
                        "leave": "func_component.on_leave",
                        "connect": "func_component.on_connect",
                        "disconnect": "func_component.on_disconnect"
                    }
                }
```

(So it might make sense to allow, e.g., `"join": ["func_component.on_join", "some.other.module.joined_cb"]`)
