### PR TITLE
cryptosign: encode challenge as a hex string to support json serializer

### DIFF
--- a/crossbar/router/auth/cryptosign.py
+++ b/crossbar/router/auth/cryptosign.py
@@ -91,7 +91,7 @@ class PendingAuthCryptosign(PendingAuth):
             self._expected_signed_message = self._challenge
 
         extra = {
-            u'challenge': binascii.b2a_hex(self._challenge)
+            u'challenge': binascii.b2a_hex(self._challenge).decode('ascii')
         }
         return extra
 


### PR DESCRIPTION
Crossbar currently bails when performing a crytosign challenge when the json protocol is used. The log states:

> WAMP message serialization error: Object of type 'bytes' is not JSON serializable

This change encodes the hex challenge as an ascii string rather than a byte array and I don't believe it should have any affect on the python client.  I know cryptosign is still very experimental but I've written a new Go client which includes support for it and other than this minor issue, it works wonderfully.  The Go client has been taught how to use either a byte array or hex string, but keeping the JSON protocol available along with cryptosign would be nice.