### PR TITLE
validate MQTT options, assign realm

### DIFF
--- a/crossbar/_log_categories.py
+++ b/crossbar/_log_categories.py
@@ -79,6 +79,7 @@ log_categories = {
     "MQ401": "Protocol violation from '{client_id}', terminating connection: {error}",
     "MQ402": "Got a packet ('{packet_id}') from '{client_id}' that is invalid for a server, terminating connection",
     "MQ403": "Got a Publish packet from '{client_id}' that has both QoS bits set, terminating connection",
+    "MQ404": "No transport to disconnect when timing out client",
     "MQ500": "Error handling a Connect, dropping connection",
     "MQ501": "Error handling a Subscribe from '{client_id}', dropping connection",
     "MQ502": "Error handling an Unsubscribe from '{client_id}', dropping connection",

--- a/crossbar/adapter/mqtt/tx.py
+++ b/crossbar/adapter/mqtt/tx.py
@@ -192,7 +192,10 @@ class MQTTServerTwistedProtocol(Protocol):
         self.log.debug(log_category="MQ400", client_id=self.session.client_id,
                        seconds=self._timeout_time,
                        conn_id=self._connection_id)
-        self.transport.loseConnection()
+        if self.transport:
+            self.transport.loseConnection()
+        else:
+            self.log.debug(log_category="MQ400")
 
     def _send_packet(self, packet):
         self.log.trace(log_category="MQ101", client_id=self.session.client_id,

--- a/crossbar/adapter/mqtt/wamp.py
+++ b/crossbar/adapter/mqtt/wamp.py
@@ -134,7 +134,7 @@ def wamp_payload_transform(payload_format, event):
             except Exception as e:
                 print(e)
                 return None
-        return payload
+    return payload
 
 
 class WampTransport(object):

--- a/crossbar/adapter/mqtt/wamp.py
+++ b/crossbar/adapter/mqtt/wamp.py
@@ -262,8 +262,7 @@ class WampMQTTServerProtocol(Protocol):
                 x_acknowledged_event_delivery=True)
         }
 
-        # Will be autoassigned
-        realm = None
+        realm = self.factory._config.get('realm', 'public')
         methods = []
 
         if ISSLTransport.providedBy(self.transport):

--- a/crossbar/adapter/mqtt/wamp.py
+++ b/crossbar/adapter/mqtt/wamp.py
@@ -265,7 +265,7 @@ class WampMQTTServerProtocol(Protocol):
                 x_acknowledged_event_delivery=True)
         }
 
-        realm = self.factory._config.get('realm', 'public')
+        realm = self.factory._config.get('realm', u'public')
         methods = []
 
         if ISSLTransport.providedBy(self.transport):

--- a/crossbar/adapter/mqtt/wamp.py
+++ b/crossbar/adapter/mqtt/wamp.py
@@ -119,13 +119,16 @@ def wamp_payload_transform(payload_format, event):
         if event.kwargs.get(u"mqtt_message"):
             try:
                 payload = b64decode(event.args[0].encode('utf8'))
-            except:
+            except Exception:
+                # I think this causes an error downstream as a None
+                # payload is illegal...maybe we can do better here (or
+                # at call-site for this)
                 return None
     else:
 
         # We dunno what to do with this.
         if event.payload:
-            return
+            return  # this will be None, see note above
 
         if payload_format == "json":
             try:

--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -1571,6 +1571,11 @@ def check_listening_transport_mqtt(transport, with_endpoint=True):
         check_listening_endpoint(transport['endpoint'])
 
     # Check options...
+    options = transport.get('options', {})
+    check_dict_args({
+        'realm': (True, [six.text_type]),
+        'role': (False, [six.text_type]),
+    }, options, "invalid mqtt options")
 
 
 def check_paths(paths, nested=False):

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ deps =
    coverage
    abtrunk: https://github.com/crossbario/autobahn-python/archive/master.zip
 commands =
+   sh -c "env"
    sh -c "which python"
    sh -c "which coverage"
    python -V


### PR DESCRIPTION
So I'm not actually sure if this is a real bug that should be fixed, or just my misunderstanding.

markos on #autobahn figured out that there wasn't a realm when using `mosquitto_pub` to publish to the MQTT listener. There is a comment that the realm will be automatically assigned, but I don't see where/how that happens.

I also don't know if the config *must* contain `realm` (as I made mandatory in this PR) or the `role` (which is not mandatory, but I think might be unused).
