### PR TITLE
allow configuring via a Twisted endpoint-string

### DIFF
--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -924,6 +924,35 @@ def check_connecting_endpoint_unix(endpoint):
         check_endpoint_timeout(endpoint['timeout'])
 
 
+def check_connecting_endpoint_twisted(endpoint):
+    """
+    :param endpoint: The Twisted connecting endpoint to check.
+    :type endpoint: dict
+    """
+    for k in endpoint:
+        if k not in ['type', 'client_string', 'timeout']:
+            raise InvalidConfigException(
+                "encountered unknown attribute '{}' in connecting endpoint".format(k)
+            )
+
+    if 'client_string' not in endpoint:
+        raise InvalidConfigException(
+            "missing mandatory attribute 'client_string' in Twisted endpoint "
+            "item\n\n{}".format(pformat(endpoint))
+        )
+
+    client_string = endpoint['client_string']
+    if not isinstance(client_string, six.text_type):
+        raise InvalidConfigException(
+            "'client_string' attribute in Twisted endpoint must be "
+            "str ({} encountered)".format(type(path)))
+    # can we make Twisted tell us if client_string parses? or just
+    # save it until we actually run clientFromString()?
+
+    if 'timeout' in endpoint:
+        check_endpoint_timeout(endpoint['timeout'])
+
+
 def check_listening_endpoint(endpoint):
     """
     Check a listening endpoint configuration.
@@ -971,13 +1000,15 @@ def check_connecting_endpoint(endpoint):
         raise InvalidConfigException("missing mandatory attribute 'type' in endpoint item\n\n{}".format(pformat(endpoint)))
 
     etype = endpoint['type']
-    if etype not in ['tcp', 'unix']:
+    if etype not in ['tcp', 'unix', 'twisted']:
         raise InvalidConfigException("invalid attribute value '{}' for attribute 'type' in endpoint item\n\n{}".format(etype, pformat(endpoint)))
 
     if etype == 'tcp':
         check_connecting_endpoint_tcp(endpoint)
     elif etype == 'unix':
         check_connecting_endpoint_unix(endpoint)
+    elif etype == 'twisted':
+        check_connecting_endpoint_twisted(endpoint)
     else:
         raise InvalidConfigException('logic error')
 

--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -945,7 +945,7 @@ def check_connecting_endpoint_twisted(endpoint):
     if not isinstance(client_string, six.text_type):
         raise InvalidConfigException(
             "'client_string' attribute in Twisted endpoint must be "
-            "str ({} encountered)".format(type(path)))
+            "str ({} encountered)".format(type(client_string)))
     # can we make Twisted tell us if client_string parses? or just
     # save it until we actually run clientFromString()?
 

--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -841,6 +841,32 @@ def check_listening_endpoint_unix(endpoint):
         check_endpoint_backlog(endpoint['backlog'])
 
 
+def check_listening_endpoint_twisted(endpoint):
+    """
+    :param endpoint: The Twisted endpoint to check
+    :type endpoint: dict
+    """
+    for k in endpoint:
+        if k not in ['type', 'server_string']:
+            raise InvalidConfigException(
+                "encountered unknown attribute '{}' in listening endpoint".format(k)
+            )
+
+    if 'server_string' not in endpoint:
+        raise InvalidConfigException(
+            "missing mandatory attribute 'server_string' in Twisted"
+            " endpoint item\n\n{}".format(pformat(endpoint))
+        )
+
+    server = endpoint['server_string']
+    if not isinstance(server, six.text_type):
+        raise InvalidConfigException(
+            "'server_string' attribute in Twisted endpoint must be str"
+            " ({} encountered)".format(type(server))
+        )
+    # should/can we ask Twisted to parse it easily?
+
+
 def check_connecting_endpoint_tcp(endpoint):
     """
     Check a TCP connecting endpoint configuration.
@@ -915,13 +941,15 @@ def check_listening_endpoint(endpoint):
         raise InvalidConfigException("missing mandatory attribute 'type' in endpoint item\n\n{}".format(pformat(endpoint)))
 
     etype = endpoint['type']
-    if etype not in ['tcp', 'unix']:
+    if etype not in ['tcp', 'unix', 'twisted']:
         raise InvalidConfigException("invalid attribute value '{}' for attribute 'type' in endpoint item\n\n{}".format(etype, pformat(endpoint)))
 
     if etype == 'tcp':
         check_listening_endpoint_tcp(endpoint)
     elif etype == 'unix':
         check_listening_endpoint_unix(endpoint)
+    elif etype == 'twisted':
+        check_listening_endpoint_twisted(endpoint)
     else:
         raise InvalidConfigException('logic error')
 

--- a/crossbar/test/test_checkconfig.py
+++ b/crossbar/test/test_checkconfig.py
@@ -187,6 +187,59 @@ class CheckContainerTests(TestCase):
                       str(e.exception))
 
 
+class CheckEndpointTests(TestCase):
+    """
+    check_listening_endpoint and check_connecting_endpoint
+    """
+
+    def test_twisted_client_error(self):
+        config = {
+            "type": "twisted",
+            "client_string": 1000,
+        }
+
+        with self.assertRaises(checkconfig.InvalidConfigException) as ctx:
+            checkconfig.check_connecting_endpoint(config)
+        self.assertTrue(
+            "in Twisted endpoint must be str" in str(ctx.exception)
+        )
+
+    def test_twisted_server_error(self):
+        config = {
+            "type": "twisted",
+            "server_string": 1000,
+        }
+
+        with self.assertRaises(checkconfig.InvalidConfigException) as ctx:
+            checkconfig.check_listening_endpoint(config)
+        self.assertTrue(
+            "in Twisted endpoint must be str" in str(ctx.exception)
+        )
+
+    def test_twisted_server_missing_arg(self):
+        config = {
+            "type": "twisted"
+        }
+
+        with self.assertRaises(checkconfig.InvalidConfigException) as ctx:
+            checkconfig.check_listening_endpoint(config)
+        self.assertTrue(
+            "mandatory attribute 'server_string'" in str(ctx.exception)
+        )
+
+    def test_twisted_client_missing_arg(self):
+        config = {
+            "type": "twisted"
+        }
+
+        with self.assertRaises(checkconfig.InvalidConfigException) as ctx:
+            checkconfig.check_connecting_endpoint(config)
+        self.assertTrue(
+            "mandatory attribute 'client_string'" in str(ctx.exception)
+        )
+
+
+
 class CheckRealmTests(TestCase):
     """
     Tests for check_router_realm, check_router_realm_role

--- a/crossbar/test/test_checkconfig.py
+++ b/crossbar/test/test_checkconfig.py
@@ -239,7 +239,6 @@ class CheckEndpointTests(TestCase):
         )
 
 
-
 class CheckRealmTests(TestCase):
     """
     Tests for check_router_realm, check_router_realm_role

--- a/crossbar/twisted/endpoint.py
+++ b/crossbar/twisted/endpoint.py
@@ -46,7 +46,8 @@ from twisted.internet.endpoints import TCP4ServerEndpoint, \
     TCP6ClientEndpoint, \
     UNIXServerEndpoint, \
     UNIXClientEndpoint, \
-    serverFromString
+    serverFromString,   \
+    clientFromString
 from twisted.python.filepath import FilePath
 
 from crossbar.twisted.sharedport import SharedPort, SharedTLSPort
@@ -590,6 +591,9 @@ def create_connecting_endpoint_from_config(config, cbdir, reactor, log):
         # create the endpoint
         #
         endpoint = UNIXClientEndpoint(reactor, path, timeout=timeout)
+
+    elif config['type'] == 'twisted':
+        endpoint = clientFromString(reactor, config['client_string'])
 
     else:
         raise Exception("invalid endpoint type '{}'".format(config['type']))

--- a/crossbar/twisted/endpoint.py
+++ b/crossbar/twisted/endpoint.py
@@ -45,7 +45,8 @@ from twisted.internet.endpoints import TCP4ServerEndpoint, \
     TCP4ClientEndpoint, \
     TCP6ClientEndpoint, \
     UNIXServerEndpoint, \
-    UNIXClientEndpoint
+    UNIXClientEndpoint, \
+    serverFromString
 from twisted.python.filepath import FilePath
 
 from crossbar.twisted.sharedport import SharedPort, SharedTLSPort
@@ -416,6 +417,10 @@ def create_listening_endpoint_from_config(config, cbdir, reactor, log):
         # create the endpoint
         #
         endpoint = UNIXServerEndpoint(reactor, path.path, backlog=backlog)
+
+    # twisted endpoint-string
+    elif config['type'] == 'twisted':
+        endpoint = serverFromString(reactor, config['server_string'])
 
     else:
         raise Exception("invalid endpoint type '{}'".format(config['type']))

--- a/crossbar/twisted/test/test_endpoint.py
+++ b/crossbar/twisted/test/test_endpoint.py
@@ -35,7 +35,8 @@ import shutil
 
 from uuid import uuid4
 
-from twisted.internet.endpoints import UNIXServerEndpoint
+from twisted.internet.endpoints import UNIXServerEndpoint, TCP4ServerEndpoint
+from twisted.internet.endpoints import TCP4ClientEndpoint
 from twisted.internet.selectreactor import SelectReactor
 from twisted.internet.protocol import Factory
 from twisted.protocols.wire import Echo
@@ -43,6 +44,7 @@ from twisted.python.runtime import platform
 
 from crossbar.test import TestCase
 from crossbar.twisted.endpoint import create_listening_endpoint_from_config
+from crossbar.twisted.endpoint import create_connecting_endpoint_from_config
 
 from txaio import make_logger
 
@@ -147,3 +149,23 @@ class ListeningEndpointTests(TestCase):
         _ = "Cannot run as root"
         test_unix_already_listening_cant_delete.skip = _
         del _
+
+    def test_twisted_client(self):
+        reactor = SelectReactor()
+        config = {
+            "type": "twisted",
+            "client_string": "tcp:host=127.0.0.1:port=9876",
+        }
+
+        endpoint = create_connecting_endpoint_from_config(config, self.cbdir, reactor, self.log)
+        self.assertTrue(isinstance(endpoint, TCP4ClientEndpoint))
+
+    def test_twisted_server(self):
+        reactor = SelectReactor()
+        config = {
+            "type": "twisted",
+            "server_string": "tcp:9876:interface=127.0.0.1",
+        }
+
+        endpoint = create_listening_endpoint_from_config(config, self.cbdir, reactor, self.log)
+        self.assertTrue(isinstance(endpoint, TCP4ServerEndpoint))


### PR DESCRIPTION
This adds a third way to configure endpoints (on top of "tcp" and "unix") which is to directly pass any valid Twisted endpoint-string (i.e. anything `serverFromString` would accept).

The use-case here would be to take advantage of any extra endpoints types that got added via the plugin API (or maybe you find it easier to specify tcp/unix endpoints via the Twisted endpoint string).

For example, you could use the `onion:` endpoint type available if you've installed `txtorcon`or the `i2p:` endpoint if you've installed `txi2p` to provide WAMP/Crossbar services via two different anonymity networks. You could use the `le:` or `lets:` endpoints provided by `txacme`. Presumably there are other examples.