### PR TITLE
Fix log crashing on encoded str other than utf8

### DIFF
--- a/crossbar/controller/processtypes.py
+++ b/crossbar/controller/processtypes.py
@@ -145,7 +145,7 @@ class WorkerProcess(object):
             return
 
         if type(data) != six.text_type:
-            data = data.decode('utf8')
+            data = data.decode('utf8', errors="replace")
 
         if self._log_rich is None:
             # If it supports rich logging, it will print just the logger aware


### PR DESCRIPTION
Hi,

I recently used crossbar with [aioftp](https://pypi.python.org/pypi/aioftp/0.6.1). This lib logs by default everything sent from the ftp server, directly as bytes, and crashed my crossbar instance which assumes any byte strings is UTF8 encoded.

The workaround was for me to simply tune down aioftp verbose logging with something like:

```
import logging
logging.getLogger('aioftp.client').setLevel(logging.ERROR)
```
But it could have been useful information that I didn't want to loose in the log. Plus I doubt aioftp is the only lib that will do something like that, and we can't chase them all. What's more, it requires some skills to track down this problem, and the workaround won't seem obvious for most users, which will probably end up opening a ticket here.

It's a difficult problem because passing bytes to the logger are not only bad practice, but very hard to mitigate, as there is no way to pass get the bytes charset.

I'm offering this solution, which is the lesser of all evils : if some third party misbehave and log non ascii bytes, and since would be painful to do anything else than trying to decode as UTF8, I use errors="replace". This instruct the decoder to simply replace anything it can't decode by a "?".