### PR TITLE
fix unicode

### DIFF
--- a/crossbar/common/process.py
+++ b/crossbar/common/process.py
@@ -240,7 +240,7 @@ class NativeProcessSession(ApplicationSession):
 
         dl = []
         for proc in procs:
-            uri = '{}.{}'.format(self._uri_prefix, proc)
+            uri = u'{}.{}'.format(self._uri_prefix, proc)
             self.log.debug("Registering procedure '{uri}'", uri=uri)
             dl.append(self.register(getattr(self, proc), uri, options=RegisterOptions(details_arg='details')))
 

--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -600,17 +600,17 @@ class Node(object):
 
                 # setup native worker generic stuff
                 if 'pythonpath' in worker_options:
-                    added_paths = yield self._controller.call('crossbar.worker.{}.add_pythonpath'.format(worker_id), worker_options['pythonpath'], options=call_options)
+                    added_paths = yield self._controller.call(u'crossbar.worker.{}.add_pythonpath'.format(worker_id), worker_options['pythonpath'], options=call_options)
                     self.log.debug("{worker}: PYTHONPATH extended for {paths}",
                                    worker=worker_logname, paths=added_paths)
 
                 if 'cpu_affinity' in worker_options:
-                    new_affinity = yield self._controller.call('crossbar.worker.{}.set_cpu_affinity'.format(worker_id), worker_options['cpu_affinity'], options=call_options)
+                    new_affinity = yield self._controller.call(u'crossbar.worker.{}.set_cpu_affinity'.format(worker_id), worker_options['cpu_affinity'], options=call_options)
                     self.log.debug("{worker}: CPU affinity set to {affinity}",
                                    worker=worker_logname, affinity=new_affinity)
 
                 if 'manhole' in worker:
-                    yield self._controller.call('crossbar.worker.{}.start_manhole'.format(worker_id), worker['manhole'], options=call_options)
+                    yield self._controller.call(u'crossbar.worker.{}.start_manhole'.format(worker_id), worker['manhole'], options=call_options)
                     self.log.debug("{worker}: manhole started",
                                    worker=worker_logname)
 
@@ -627,7 +627,7 @@ class Node(object):
                             realm_id = 'realm-{:03d}'.format(self._realm_no)
                             self._realm_no += 1
 
-                        yield self._controller.call('crossbar.worker.{}.start_router_realm'.format(worker_id), realm_id, realm, options=call_options)
+                        yield self._controller.call(u'crossbar.worker.{}.start_router_realm'.format(worker_id), realm_id, realm, options=call_options)
                         self.log.info("{worker}: realm '{realm_id}' (named '{realm_name}') started",
                                       worker=worker_logname, realm_id=realm_id, realm_name=realm['name'])
 
@@ -639,7 +639,7 @@ class Node(object):
                                 role_id = 'role-{:03d}'.format(self._role_no)
                                 self._role_no += 1
 
-                            yield self._controller.call('crossbar.worker.{}.start_router_realm_role'.format(worker_id), realm_id, role_id, role, options=call_options)
+                            yield self._controller.call(u'crossbar.worker.{}.start_router_realm_role'.format(worker_id), realm_id, role_id, role, options=call_options)
                             self.log.info(
                                 "{logname}: role '{role}' (named '{role_name}') started on realm '{realm}'",
                                 logname=worker_logname,
@@ -656,7 +656,7 @@ class Node(object):
                                 uplink_id = 'uplink-{:03d}'.format(self._uplink_no)
                                 self._uplink_no += 1
 
-                            yield self._controller.call('crossbar.worker.{}.start_router_realm_uplink'.format(worker_id), realm_id, uplink_id, uplink, options=call_options)
+                            yield self._controller.call(u'crossbar.worker.{}.start_router_realm_uplink'.format(worker_id), realm_id, uplink_id, uplink, options=call_options)
                             self.log.info(
                                 "{logname}: uplink '{uplink}' started on realm '{realm}'",
                                 logname=worker_logname,
@@ -674,7 +674,7 @@ class Node(object):
                             connection_id = 'connection-{:03d}'.format(self._connection_no)
                             self._connection_no += 1
 
-                        yield self._controller.call('crossbar.worker.{}.start_connection'.format(worker_id), connection_id, connection, options=call_options)
+                        yield self._controller.call(u'crossbar.worker.{}.start_connection'.format(worker_id), connection_id, connection, options=call_options)
                         self.log.info(
                             "{logname}: connection '{connection}' started",
                             logname=worker_logname,
@@ -690,7 +690,7 @@ class Node(object):
                             component_id = 'component-{:03d}'.format(self._component_no)
                             self._component_no += 1
 
-                        yield self._controller.call('crossbar.worker.{}.start_router_component'.format(worker_id), component_id, component, options=call_options)
+                        yield self._controller.call(u'crossbar.worker.{}.start_router_component'.format(worker_id), component_id, component, options=call_options)
                         self.log.info(
                             "{logname}: component '{component}' started",
                             logname=worker_logname,
@@ -706,7 +706,7 @@ class Node(object):
                             transport_id = 'transport-{:03d}'.format(self._transport_no)
                             self._transport_no += 1
 
-                        yield self._controller.call('crossbar.worker.{}.start_router_transport'.format(worker_id), transport_id, transport, options=call_options)
+                        yield self._controller.call(u'crossbar.worker.{}.start_router_transport'.format(worker_id), transport_id, transport, options=call_options)
                         self.log.info(
                             "{logname}: transport '{tid}' started",
                             logname=worker_logname,
@@ -744,7 +744,7 @@ class Node(object):
                             connection_id = 'connection-{:03d}'.format(self._connection_no)
                             self._connection_no += 1
 
-                        yield self._controller.call('crossbar.worker.{}.start_connection'.format(worker_id), connection_id, connection, options=call_options)
+                        yield self._controller.call(u'crossbar.worker.{}.start_connection'.format(worker_id), connection_id, connection, options=call_options)
                         self.log.info(
                             "{logname}: connection '{connection}' started",
                             logname=worker_logname,
@@ -761,7 +761,7 @@ class Node(object):
                             component_id = 'component-{:03d}'.format(self._component_no)
                             self._component_no += 1
 
-                        yield self._controller.call('crossbar.worker.{}.start_container_component'.format(worker_id), component_id, component, options=call_options)
+                        yield self._controller.call(u'crossbar.worker.{}.start_container_component'.format(worker_id), component_id, component, options=call_options)
                         self.log.info("{worker}: component '{component_id}' started",
                                       worker=worker_logname, component_id=component_id)
 
@@ -776,7 +776,7 @@ class Node(object):
                     transport_id = 'transport-{:03d}'.format(self._transport_no)
                     self._transport_no = 1
 
-                    yield self._controller.call('crossbar.worker.{}.start_websocket_testee_transport'.format(worker_id), transport_id, transport, options=call_options)
+                    yield self._controller.call(u'crossbar.worker.{}.start_websocket_testee_transport'.format(worker_id), transport_id, transport, options=call_options)
                     self.log.info(
                         "{logname}: transport '{tid}' started",
                         logname=worker_logname,

--- a/crossbar/controller/process.py
+++ b/crossbar/controller/process.py
@@ -101,8 +101,8 @@ class NodeControllerSession(NativeProcessSession):
             'checkconfig': checkconfig.check_router_options,
             'logname': 'Router',
             'topics': {
-                'starting': 'crossbar.node.on_router_starting',
-                'started': 'crossbar.node.on_router_started',
+                'starting': u'crossbar.node.on_router_starting',
+                'started': u'crossbar.node.on_router_started',
             }
         },
         'container': {
@@ -110,8 +110,8 @@ class NodeControllerSession(NativeProcessSession):
             'checkconfig': checkconfig.check_container_options,
             'logname': 'Container',
             'topics': {
-                'starting': 'crossbar.node.on_container_starting',
-                'started': 'crossbar.node.on_container_started',
+                'starting': u'crossbar.node.on_container_starting',
+                'started': u'crossbar.node.on_container_started',
             }
         },
         'websocket-testee': {
@@ -119,8 +119,8 @@ class NodeControllerSession(NativeProcessSession):
             'checkconfig': checkconfig.check_websocket_testee_options,
             'logname': 'WebSocketTestee',
             'topics': {
-                'starting': 'crossbar.node.on_websocket_testee_starting',
-                'started': 'crossbar.node.on_websocket_testee_started',
+                'starting': u'crossbar.node.on_websocket_testee_starting',
+                'started': u'crossbar.node.on_websocket_testee_started',
             }
         },
     }
@@ -191,7 +191,7 @@ class NodeControllerSession(NativeProcessSession):
         #
         dl = []
         for proc in self.PROCS:
-            uri = '{}.{}'.format(self._uri_prefix, proc)
+            uri = u'{}.{}'.format(self._uri_prefix, proc)
             self.log.info('Registering management API procedure "{proc}"', proc=uri)
             dl.append(self.register(getattr(self, proc), uri, options=RegisterOptions(details_arg='details')))
 

--- a/crossbar/worker/router.py
+++ b/crossbar/worker/router.py
@@ -323,7 +323,7 @@ class RouterWorkerSession(NativeWorkerSession):
 
             dl = []
             for proc in procs:
-                uri = '{}.{}'.format(self._uri_prefix, proc)
+                uri = u'{}.{}'.format(self._uri_prefix, proc)
                 self.log.debug("Registering management API procedure {proc}", proc=uri)
                 dl.append(self.register(getattr(self, proc), uri, options=RegisterOptions(details_arg='details')))
 

--- a/crossbar/worker/worker.py
+++ b/crossbar/worker/worker.py
@@ -73,7 +73,7 @@ class NativeWorkerSession(NativeProcessSession):
         Called when the worker has connected to the node's management router.
         """
         self._worker_id = self.config.extra.worker
-        self._uri_prefix = 'crossbar.worker.{}'.format(self._worker_id)
+        self._uri_prefix = u'crossbar.worker.{}'.format(self._worker_id)
 
         NativeProcessSession.onConnect(self, False)
 
@@ -121,7 +121,7 @@ class NativeWorkerSession(NativeProcessSession):
 
         dl = []
         for proc in procs:
-            uri = '{}.{}'.format(self._uri_prefix, proc)
+            uri = u'{}.{}'.format(self._uri_prefix, proc)
             self.log.debug("Registering management API procedure {proc}", proc=uri)
             dl.append(self.register(getattr(self, proc), uri, options=RegisterOptions(details_arg='details')))
 
@@ -506,7 +506,7 @@ class NativeWorkerSession(NativeProcessSession):
 
         # publish event "on_pythonpath_add" to all but the caller
         #
-        topic = '{}.on_pythonpath_add'.format(self._uri_prefix)
+        topic = u'{}.on_pythonpath_add'.format(self._uri_prefix)
         res = {
             u'paths': sys.path,
             u'paths_added': paths_added,


### PR DESCRIPTION
Latest autobahn got rid of a "if py2" check that turned str into unicode, which breaks a bunch of crossbar calls when it's running in python2.