### PR TITLE
Ticket944 meta events

### DIFF
--- a/crossbar/router/broker.py
+++ b/crossbar/router/broker.py
@@ -157,13 +157,15 @@ class Broker(object):
 
                 # publish WAMP meta events
                 #
-                if self._router._realm:
-                    service_session = self._router._realm.session
-                    if service_session and not subscription.uri.startswith(u'wamp.'):
+                if self._router._realm and self._router._realm.session:
+
+                    def _publish():
+                        service_session = self._router._realm.session
                         if was_subscribed:
                             service_session.publish(u'wamp.subscription.on_unsubscribe', session._session_id, subscription.id)
                         if was_deleted:
                             service_session.publish(u'wamp.subscription.on_delete', session._session_id, subscription.id)
+                    self._reactor.callLater(0, _publish)
 
             del self._session_to_subscriptions[session]
 
@@ -548,9 +550,10 @@ class Broker(object):
 
                 # publish WAMP meta events
                 #
-                if self._router._realm:
-                    service_session = self._router._realm.session
-                    if service_session and not subscription.uri.startswith(u'wamp.'):
+                if self._router._realm and self._router._realm.session:
+
+                    def _publish():
+                        service_session = self._router._realm.session
                         if is_first_subscriber:
                             subscription_details = {
                                 u'id': subscription.id,
@@ -561,6 +564,7 @@ class Broker(object):
                             service_session.publish(u'wamp.subscription.on_create', session._session_id, subscription_details)
                         if not was_already_subscribed:
                             service_session.publish(u'wamp.subscription.on_subscribe', session._session_id, subscription.id)
+                    self._reactor.callLater(0, _publish)
 
                 # check for retained events
                 #
@@ -678,13 +682,15 @@ class Broker(object):
 
         # publish WAMP meta events
         #
-        if self._router._realm:
-            service_session = self._router._realm.session
-            if service_session and not subscription.uri.startswith(u'wamp.'):
+        if self._router._realm and self._router._realm.session:
+
+            def _publish():
+                service_session = self._router._realm.session
                 if was_subscribed:
                     service_session.publish(u'wamp.subscription.on_unsubscribe', session._session_id, subscription.id)
                 if was_deleted:
                     service_session.publish(u'wamp.subscription.on_delete', session._session_id, subscription.id)
+            self._reactor.callLater(0, _publish)
 
         return was_subscribed, was_last_subscriber
 

--- a/crossbar/router/broker.py
+++ b/crossbar/router/broker.py
@@ -85,7 +85,7 @@ class Broker(object):
 
     log = make_logger()
 
-    def __init__(self, router, options=None):
+    def __init__(self, router, reactor, options=None):
         """
 
         :param router: The router this dealer is part of.
@@ -95,6 +95,7 @@ class Broker(object):
         """
         self._router = router
         self._options = options or RouterOptions()
+        self._reactor = reactor
 
         # subscription map managed by this broker
         self._subscription_map = UriObservationMap()

--- a/crossbar/router/broker.py
+++ b/crossbar/router/broker.py
@@ -34,7 +34,7 @@ import txaio
 
 from autobahn import util
 from autobahn.wamp import role
-from autobahn.wamp import message
+from autobahn.wamp import message, types
 from autobahn.wamp.exception import ApplicationError
 
 from autobahn.wamp.message import \
@@ -160,11 +160,27 @@ class Broker(object):
                 if self._router._realm and self._router._realm.session:
 
                     def _publish():
+                        if session._session_id is None:
+                            options = types.PublishOptions()
+                        else:
+                            options = types.PublishOptions(
+                                exclude=[session._session_id],
+                            )
                         service_session = self._router._realm.session
                         if was_subscribed:
-                            service_session.publish(u'wamp.subscription.on_unsubscribe', session._session_id, subscription.id)
+                            service_session.publish(
+                                u'wamp.subscription.on_unsubscribe',
+                                session._session_id,
+                                subscription.id,
+                                options=options,
+                            )
                         if was_deleted:
-                            service_session.publish(u'wamp.subscription.on_delete', session._session_id, subscription.id)
+                            service_session.publish(
+                                u'wamp.subscription.on_delete',
+                                session._session_id,
+                                subscription.id,
+                                options=options,
+                            )
                     self._reactor.callLater(0, _publish)
 
             del self._session_to_subscriptions[session]
@@ -554,6 +570,9 @@ class Broker(object):
 
                     def _publish():
                         service_session = self._router._realm.session
+                        options = types.PublishOptions(
+                            exclude=[session._session_id],
+                        )
                         if is_first_subscriber:
                             subscription_details = {
                                 u'id': subscription.id,
@@ -561,9 +580,19 @@ class Broker(object):
                                 u'uri': subscription.uri,
                                 u'match': subscription.match,
                             }
-                            service_session.publish(u'wamp.subscription.on_create', session._session_id, subscription_details)
+                            service_session.publish(
+                                u'wamp.subscription.on_create',
+                                session._session_id,
+                                subscription_details,
+                                options=options,
+                            )
                         if not was_already_subscribed:
-                            service_session.publish(u'wamp.subscription.on_subscribe', session._session_id, subscription.id)
+                            service_session.publish(
+                                u'wamp.subscription.on_subscribe',
+                                session._session_id,
+                                subscription.id,
+                                options=options,
+                            )
                     self._reactor.callLater(0, _publish)
 
                 # check for retained events
@@ -686,10 +715,26 @@ class Broker(object):
 
             def _publish():
                 service_session = self._router._realm.session
+                if session._session_id is None:
+                    options = types.PublishOptions()
+                else:
+                    options = types.PublishOptions(
+                        exclude=[session._session_id],
+                    )
                 if was_subscribed:
-                    service_session.publish(u'wamp.subscription.on_unsubscribe', session._session_id, subscription.id)
+                    service_session.publish(
+                        u'wamp.subscription.on_unsubscribe',
+                        session._session_id,
+                        subscription.id,
+                        options=options,
+                    )
                 if was_deleted:
-                    service_session.publish(u'wamp.subscription.on_delete', session._session_id, subscription.id)
+                    service_session.publish(
+                        u'wamp.subscription.on_delete',
+                        session._session_id,
+                        subscription.id,
+                        options=options,
+                    )
             self._reactor.callLater(0, _publish)
 
         return was_subscribed, was_last_subscriber

--- a/crossbar/router/router.py
+++ b/crossbar/router/router.py
@@ -103,7 +103,7 @@ class Router(object):
         # map: authrole -> set(session)
         self._authrole_to_sessions = {}
 
-        self._broker = self.broker(self, self._options)
+        self._broker = self.broker(self, factory._reactor, self._options)
         self._dealer = self.dealer(self, self._options)
         self._attached = 0
 
@@ -369,6 +369,9 @@ class RouterFactory(object):
         self._routers = {}
         self._options = options or RouterOptions(uri_check=RouterOptions.URI_CHECK_LOOSE)
         self._auto_create_realms = False
+        # XXX this should get passed in from .. somewhere
+        from twisted.internet import reactor
+        self._reactor = reactor
 
     def get(self, realm):
         """

--- a/crossbar/router/test/test_broker.py
+++ b/crossbar/router/test/test_broker.py
@@ -46,7 +46,7 @@ from crossbar.router.session import RouterSessionFactory, RouterSession
 from crossbar.router.broker import Broker
 from crossbar.router.role import RouterRoleStaticAuth
 
-from twisted.internet import defer
+from twisted.internet import defer, reactor
 
 
 class TestBrokerPublish(unittest.TestCase):
@@ -340,7 +340,7 @@ class TestBrokerPublish(unittest.TestCase):
         session0 = TestSession()
         session1 = TestSession()
         router = mock.MagicMock()
-        broker = Broker(router)
+        broker = Broker(router, reactor)
 
         # let's just "cheat" our way a little to the right state by
         # injecting our subscription "directly" (e.g. instead of


### PR DESCRIPTION
Addresses #944 

This works around the race-y "sending an Event before you've finished subscribing" by doing all the wamp meta-event publishes in "the next trip around the reactor loop" `callLater(0, ..)`. Thus, the ack for subscribing etc goes out before the meta-event.

Note that this also means you'll immediately get a meta-event for your own thing. That is, if you're subscribing to `wamp.subscription.on_subscribe` (whether exact-match, wildcard or prefix) you'll immediately get an "on_subscribe" (because your session just subscribed).

I made a short example in the Autobahn repo; should I push that, too?