### PR TITLE
Ticket1000 h2 support

### DIFF
--- a/crossbar/twisted/endpoint.py
+++ b/crossbar/twisted/endpoint.py
@@ -213,6 +213,12 @@ def _create_tls_server_context(config, cbdir, log):
 
     # create a TLS context factory
     # see: https://twistedmatrix.com/documents/current/api/twisted.internet.ssl.CertificateOptions.html
+    # XXX can we get CertificateOptions to do this for us?
+    from twisted.web import http
+    protocols = [b'http/1.1']
+    if http.H2_ENABLED:
+        protocols = [b'h2', b'http/1.1']
+
     ctx = CertificateOptions(
         privateKey=key,
         certificate=cert,
@@ -221,6 +227,7 @@ def _create_tls_server_context(config, cbdir, log):
         caCerts=ca_certs,
         dhParameters=dh_params,
         acceptableCiphers=crossbar_ciphers,
+        acceptableProtocols=protocols,
 
         # TLS hardening
         enableSingleUseKeys=True,

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -2,6 +2,8 @@ click>=6.6
 setuptools>=28.3.0
 zope.interface>=4.3.2
 Twisted>=17.1.0
+h2<3.0.0
+priority>=1.3.0
 txaio>=2.7.0
 autobahn>=0.18.2
 netaddr>=0.7.18


### PR DESCRIPTION
Using this, I am able to get Firefox to do http2 connections to a crossbar instances Web pages. You have to use HTTPS. See #1000

It seems .. odd that we have to pass "h2" explicitly to `CertificateOptions`. Also, the latest h2 (3.0.1) doesn't work -- I *think* it's just "too new for Twisted" but I didn't look very deeply.