### PR TITLE
Ticket1030 event retention

### DIFF
--- a/crossbar/router/broker.py
+++ b/crossbar/router/broker.py
@@ -315,6 +315,17 @@ class Broker(object):
                         if not observation:
                             # No observation, lets make a new one
                             observation = self._subscription_map.create_observation(publish.topic, extra=SubscriptionExtra())
+                        else:
+                            # this can happen if event-history is
+                            # enabled on the topic: the event-store
+                            # creates an observation before any client
+                            # could possible hit the code above
+                            if observation.extra is None:
+                                observation.extra = SubscriptionExtra()
+                            elif not isinstance(observation.extra, SubscriptionExtra):
+                                raise Exception(
+                                    "incorrect 'extra' for '{}'".format(publish.topic)
+                                )
 
                         if observation.extra.retained_events:
                             if not publish.eligible and not publish.exclude:

--- a/docs/pages/programming-guide/pubsub/PubSub.md
+++ b/docs/pages/programming-guide/pubsub/PubSub.md
@@ -12,4 +12,5 @@ See the following pages
 * [[Publisher Exclusion]]
 * [[Subscriber Black and Whitelisting]]
 * [[Event History]]
+* [[Retained Events]]
 * [[Subscription Meta Events and Procedures]]

--- a/docs/pages/programming-guide/pubsub/Retained-Events.md
+++ b/docs/pages/programming-guide/pubsub/Retained-Events.md
@@ -1,0 +1,18 @@
+title: Retained Events
+toc: [Documentation, Programming Guide, Retained Events]
+
+# Retained Events
+
+When publishing an event, the publisher can set an option (`retained=True`) in the `PublishOptions` which will cause the Broker to retain the most-recent event published to this topic.
+
+Note that [[Event History]] is similar to this feature, but not the same.
+
+No configuration is required in Crossbar in order to take advantage of this; it is up to the publisher.
+
+# Retrieving an Event
+
+Upon subscription, a client can pass `get_retained=True` in the `SubscribeOptions`. If there is any retained event, it will be immediately sent to the subscriber.
+
+# Example
+
+There is a completely-worked example [in the Autobahn-Python repository](https://github.com/crossbario/autobahn-python/tree/master/examples/twisted/wamp/pubsub).


### PR DESCRIPTION
fixes #1030  as well as fixing a bug in the code whereby `observation.extra` wasn't getting set on events that also had event history enabled.