### PR TITLE
check for YAML configuration first, then JSON

### DIFF
--- a/crossbar/controller/cli.py
+++ b/crossbar/controller/cli.py
@@ -1073,7 +1073,7 @@ def run(prog=None, args=None, reactor=None):
     if hasattr(options, 'config'):
         # if not explicit config filename is given, try to auto-detect .
         if not options.config:
-            for f in ['config.json', 'config.yaml']:
+            for f in ['config.yaml', 'config.json']:
                 fn = os.path.join(options.cbdir, f)
                 if os.path.isfile(fn) and os.access(fn, os.R_OK):
                     options.config = f


### PR DESCRIPTION
The JSON configuration file is present by default in the Docker image.
Checking for YAML first removes the need for an explicit --config
command line argument.