### PR TITLE
Fix REST error reporting.

### DIFF
--- a/crossbar/_log_categories.py
+++ b/crossbar/_log_categories.py
@@ -53,7 +53,7 @@ log_categories = {
     "AR452": "Non-accepted content type. (must be one of '{accepted}', not '{given}')",
     "AR453": "Request body was invalid JSON.",
     "AR454": "Request body was valid JSON, but not well formed (must be a dict).",
-    "AR455": "Request body was valid JSON, but not well formed (missing key -- '{key}).",
+    "AR455": "Request body was valid JSON, but not well formed (missing key '{key}').",
     "AR456": "REST bridge publish failed.",
     "AR457": "REST bridge webhook request failed.",
     "AR458": "REST bridge call failed: {exc}",

--- a/crossbar/adapter/rest/common.py
+++ b/crossbar/adapter/rest/common.py
@@ -107,7 +107,8 @@ class _CommonResource(Resource):
 
         self.log.debug(code=code, **kwargs)
 
-        body = dump_json({"error": log_categories[kwargs['log_category']],
+        error_str = log_categories[kwargs['log_category']].format(**kwargs)
+        body = dump_json({"error": error_str,
                           "args": [], "kwargs": {}}, True).encode('utf8')
         request.setResponseCode(code)
         return body

--- a/crossbar/adapter/rest/test/test_publisher.py
+++ b/crossbar/adapter/rest/test/test_publisher.py
@@ -181,5 +181,5 @@ class PublisherTestCase(TestCase):
         self.assertEqual(errors[0]["code"], 400)
 
         self.assertEqual(json.loads(native_string(request.get_written_data())),
-                         {"error": log_categories["AR455"],
+                         {"error": log_categories["AR455"].format(key="topic"),
                           "args": [], "kwargs": {}})


### PR DESCRIPTION
Before:

    "error": "Request body was valid JSON, but not well formed (missing key -- '{key}).",

After:

    "error": "Request body was valid JSON, but not well formed (missing key -- 'my_key').",