### PR TITLE
Ticket430 dynamic auth method

### DIFF
--- a/crossbar/router/broker.py
+++ b/crossbar/router/broker.py
@@ -301,7 +301,7 @@ class Broker(object):
 
             # authorize PUBLISH action
             #
-            d = self._router.authorize(session, publish.topic, u'publish')
+            d = self._router.authorize(session, publish.topic, u'publish', options=publish.marshal_options())
 
             def on_authorize_success(authorization):
 
@@ -529,7 +529,7 @@ class Broker(object):
 
         # authorize SUBSCRIBE action
         #
-        d = self._router.authorize(session, subscribe.topic, u'subscribe')
+        d = self._router.authorize(session, subscribe.topic, u'subscribe', options=subscribe.marshal_options())
 
         def on_authorize_success(authorization):
             if not authorization[u'allow']:

--- a/crossbar/router/dealer.py
+++ b/crossbar/router/dealer.py
@@ -275,7 +275,7 @@ class Dealer(object):
 
         # authorize REGISTER action
         #
-        d = self._router.authorize(session, register.procedure, u'register')
+        d = self._router.authorize(session, register.procedure, u'register', options=register.marshal_options())
 
         def on_authorize_success(authorization):
             if not authorization[u'allow']:
@@ -436,7 +436,7 @@ class Dealer(object):
 
             # authorize CALL action
             #
-            d = self._router.authorize(session, call.procedure, u'call')
+            d = self._router.authorize(session, call.procedure, u'call', options=call.marshal_options())
 
             def on_authorize_success(authorization):
                 # the call to authorize the action _itself_ succeeded. now go on depending on whether

--- a/crossbar/router/role.py
+++ b/crossbar/router/role.py
@@ -169,7 +169,7 @@ class RouterRole(object):
         self.uri = uri
         self.allow_by_default = allow_by_default
 
-    def authorize(self, session, uri, action):
+    def authorize(self, session, uri, action, options):
         """
         Authorize a session connected under this role to perform the given
         action on the given URI.
@@ -194,10 +194,10 @@ class RouterTrustedRole(RouterRole):
     service session run internally run by a router.
     """
 
-    def authorize(self, session, uri, action):
+    def authorize(self, session, uri, action, options):
         self.log.debug(
-            "CrossbarRouterTrustedRole.authorize {myuri} {uri} {action}",
-            myuri=self.uri, uri=uri, action=action)
+            "CrossbarRouterTrustedRole.authorize {myuri} {uri} {action} {options}",
+            myuri=self.uri, uri=uri, action=action, options=options)
         return True
 
 
@@ -249,7 +249,7 @@ class RouterRoleStaticAuth(RouterRole):
             perms = RouterPermissions.from_dict(obj)
             self._permissions[perms.uri] = perms
 
-    def authorize(self, session, uri, action):
+    def authorize(self, session, uri, action, options):
         """
         Authorize a session connected under this role to perform the given
         action on the given URI.
@@ -347,7 +347,7 @@ class RouterRoleDynamicAuth(RouterRole):
         # the default service session on the realm
         self._session = router._realm.session
 
-    def authorize(self, session, uri, action):
+    def authorize(self, session, uri, action, options):
         """
         Authorize a session connected under this role to perform the given
         action on the given URI.
@@ -381,7 +381,7 @@ class RouterRoleDynamicAuth(RouterRole):
             "CrossbarRouterRoleDynamicAuth.authorize {uri} {action} {details}",
             uri=uri, action=action, details=session_details)
 
-        d = self._session.call(self._authorizer, session_details, uri, action)
+        d = self._session.call(self._authorizer, session_details, uri, action, options)
 
         def sanity_check(authorization):
             """
@@ -442,7 +442,7 @@ class RouterRoleLMDBAuth(RouterRole):
         RouterRole.__init__(self, router, uri)
         self._store = store
 
-    def authorize(self, session, uri, action):
+    def authorize(self, session, uri, action, options):
         """
         Authorize a session connected under this role to perform the given
         action on the given URI.

--- a/crossbar/router/router.py
+++ b/crossbar/router/router.py
@@ -293,7 +293,7 @@ class Router(object):
         else:
             return False
 
-    def authorize(self, session, uri, action):
+    def authorize(self, session, uri, action, options):
         """
         Authorizes a session for an action on an URI.
 
@@ -309,7 +309,7 @@ class Router(object):
         if role in self._roles:
             # the authorizer procedure of the role which we will call ..
             authorize = self._roles[role].authorize
-            d = txaio.as_future(authorize, session, uri, action)
+            d = txaio.as_future(authorize, session, uri, action, options)
         else:
             # normally, the role should exist on the router (and hence we should not arrive
             # here), but the role might have been dynamically removed - and anyway, safety first!

--- a/crossbar/router/test/test_authorize.py
+++ b/crossbar/router/test/test_authorize.py
@@ -286,7 +286,7 @@ class TestRouterRoleStaticAuth(unittest.TestCase):
         uris = [u'com.example.1', u'myuri', u'']
         for uri in uris:
             for action in actions:
-                authorization = role.authorize(None, uri, action)
+                authorization = role.authorize(None, uri, action, {})
                 self.assertFalse(authorization[u'allow'])
 
     def test_ruleset_1(self):
@@ -306,7 +306,7 @@ class TestRouterRoleStaticAuth(unittest.TestCase):
         uris = [(u'com.example.1', True), (u'myuri', False), (u'', False)]
         for uri, allow in uris:
             for action in actions:
-                authorization = role.authorize(None, uri, action)
+                authorization = role.authorize(None, uri, action, {})
                 self.assertEqual(authorization[u'allow'], allow)
 
     def test_ruleset_2(self):
@@ -326,5 +326,5 @@ class TestRouterRoleStaticAuth(unittest.TestCase):
         uris = [(u'com.example.1', True), (u'myuri', True), (u'', True)]
         for uri, allow in uris:
             for action in actions:
-                authorization = role.authorize(None, uri, action)
+                authorization = role.authorize(None, uri, action, {})
                 self.assertEqual(authorization[u'allow'], allow)


### PR DESCRIPTION
This adds a new arg to authorizer methods (see #430) and also handles backwards-compatibility so at least existing authorizer methods will still work (except with an additional round-trip to the authorizer after detecting the error). Depends also on associated Autobahn PR: https://github.com/crossbario/autobahn-python/pull/840