### PR TITLE
wildcard perms

### DIFF
--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -2392,10 +2392,6 @@ def check_router_realm_role(role):
 
             if role_uri.endswith('*'):
                 role_uri = role_uri[:-1]
-            if not _URI_PAT_STRICT_LAST_EMPTY.match(role_uri):
-                raise InvalidConfigException(
-                    "invalid role URI '{}' in role permissions".format(role['uri']),
-                )
 
             check_dict_args({
                 'uri': (True, [six.text_type]),
@@ -2408,6 +2404,12 @@ def check_router_realm_role(role):
             if 'match' in role:
                 if role['match'] not in [u'exact', u'prefix', u'wildcard']:
                     raise InvalidConfigException("invalid value '{}' for 'match' attribute in role permissions".format(role['match']))
+
+            if not _URI_PAT_STRICT_LAST_EMPTY.match(role_uri):
+                if role.get('match', None) != 'wildcard':
+                    raise InvalidConfigException(
+                        "invalid role URI '{}' in role permissions".format(role['uri']),
+                    )
 
             if 'allow' in role:
                 check_dict_args({

--- a/crossbar/router/role.py
+++ b/crossbar/router/role.py
@@ -285,7 +285,7 @@ class RouterRoleStaticAuth(RouterRole):
             if permissions.match != u'prefix' and uri != permissions.uri:
                 permissions = self._default
 
-        except KeyError as e:
+        except KeyError:
             # workaround because of https://bitbucket.org/gsakkis/pytrie/issues/4/string-keys-of-zero-length-are-not
             permissions = self._permissions.get(u'', self._default)
 

--- a/crossbar/router/test/test_authorize.py
+++ b/crossbar/router/test/test_authorize.py
@@ -329,6 +329,7 @@ class TestRouterRoleStaticAuth(unittest.TestCase):
                 authorization = role.authorize(None, uri, action)
                 self.assertEqual(authorization[u'allow'], allow)
 
+
 class TestRouterRoleStaticAuthWild(unittest.TestCase):
 
     def setUp(self):

--- a/crossbar/router/test/test_authorize.py
+++ b/crossbar/router/test/test_authorize.py
@@ -328,3 +328,81 @@ class TestRouterRoleStaticAuth(unittest.TestCase):
             for action in actions:
                 authorization = role.authorize(None, uri, action)
                 self.assertEqual(authorization[u'allow'], allow)
+
+class TestRouterRoleStaticAuthWild(unittest.TestCase):
+
+    def setUp(self):
+        permissions = [
+            {
+                u'uri': u'com..private',
+                u'match': 'wildcard',
+                u'allow': {
+                    u'call': True,
+                    u'register': False,
+                    u'publish': False,
+                    u'subscribe': False,
+                }
+            },
+            {
+                u'uri': u'com.something_specific.private',
+                u'match': 'exact',
+                u'allow': {
+                    u'call': False,
+                    u'register': True,
+                    u'publish': False,
+                    u'subscribe': False
+                }
+            },
+            {
+                u'uri': u'com.',
+                u'match': 'prefix',
+                u'allow': {
+                    u'call': False,
+                    u'register': False,
+                    u'publish': True,
+                    u'subscribe': False
+                }
+            }
+        ]
+        self.role = RouterRoleStaticAuth(None, u'testrole', permissions)
+
+    def test_exact_before_wildcard(self):
+        # exact matches should always be preferred over wildcards
+        self.assertEqual(
+            False,
+            self.role.authorize(None, u'com.something_specific.private', 'call')[u'allow']
+        )
+        self.assertEqual(
+            True,
+            self.role.authorize(None, u'com.something_specific.private', 'register')[u'allow']
+        )
+
+    def test_wildcard_before_prefix(self):
+        # wildcards should be preferred over prefix
+        self.assertEqual(
+            True,
+            self.role.authorize(None, u'com.foo.private', 'call')[u'allow']
+        )
+        self.assertEqual(
+            False,
+            self.role.authorize(None, u'com.foo.private', 'register')[u'allow']
+        )
+        self.assertEqual(
+            False,
+            self.role.authorize(None, u'com.foo.private', 'publish')[u'allow']
+        )
+
+    def test_prefix(self):
+        # wildcards should be preferred over prefix
+        self.assertEqual(
+            False,
+            self.role.authorize(None, u'com.whatever', 'call')[u'allow']
+        )
+        self.assertEqual(
+            False,
+            self.role.authorize(None, u'com.whatever', 'register')[u'allow']
+        )
+        self.assertEqual(
+            True,
+            self.role.authorize(None, u'com.whatever', 'publish')[u'allow']
+        )


### PR DESCRIPTION
See #280 -- this is a stab at enabling wildcard permissions in static auth configurations.

"exact" permissions are always preferred. If a "wildcard" matches, it is preferred over a "prefix".