### PR TITLE
Change snap confinement to classic

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
   on your app's features.
 
 grade: devel
-confinement: strict
+confinement: classic
 
 apps:
   crossbar:


### PR DESCRIPTION
I was running the Django [example](https://github.com/crossbario/crossbar-examples/tree/master/django/realtimemonitor) and found out that crossbar was not able to start because it did not find django in the environment. The reason for that is with "strict" confinement, the snap is only able to look for paths within its own container, which is bad for tools like crossbar.

The fix was to use the classic [confinement](https://snapcraft.io/docs/reference/confinement), which allows the package to be able to read paths outside it space.