### PR TITLE
Python 3: fall back to native shutil.which

### DIFF
--- a/crossbar/controller/process.py
+++ b/crossbar/controller/process.py
@@ -34,9 +34,12 @@ import os
 import sys
 import signal
 from datetime import datetime
-# backport of shutil.which
-import shutilwhich  # noqa
-import shutil
+try:
+    # try backport of shutil.which first
+    from shutilwhich import which
+except ImportError:
+    # try Python 3.3+ native module
+    from shutil import which
 
 from twisted.internet.error import ReactorNotRunning
 from twisted.internet.defer import Deferred, DeferredList, inlineCallbacks, returnValue
@@ -869,7 +872,7 @@ class NodeControllerSession(NativeProcessSession):
         else:
             # try to detect the fully qualified path for the guest
             # executable by doing a "which" on the configured executable name
-            exe = shutil.which(config['executable'])
+            exe = which(config['executable'])
             if exe is not None and check_executable(exe):
                 self.log.info("Using guest worker executable '{exe}' (executable path detected from environment)",
                               exe=exe)


### PR DESCRIPTION
Try to import shutilwhich module, if it fails we're most likely
running Python 3.3+, so we can import the native module.