### PR TITLE
Fix handling of authextra for ticket + cookie case

### DIFF
--- a/crossbar/router/auth/pending.py
+++ b/crossbar/router/auth/pending.py
@@ -130,8 +130,8 @@ class PendingAuth:
             self._authrole = self._config[u'default-role']
 
         # allow forwarding of application-specific "welcome data"
-        if u'extra' in principal:
-            self._authextra = principal[u'extra']
+        if u'authextra' in principal:
+            self._authextra = principal[u'authextra']
 
         # a realm must have been assigned by now, otherwise bail out!
         if not self._realm:

--- a/crossbar/router/auth/ticket.py
+++ b/crossbar/router/auth/ticket.py
@@ -73,6 +73,7 @@ class PendingAuthTicket(PendingAuth):
             if self._authid in self._config.get(u'principals', {}):
 
                 principal = self._config[u'principals'][self._authid]
+                principal[u'authextra'] = details.authextra
 
                 error = self._assign_principal(principal)
                 if error:

--- a/crossbar/router/protocol.py
+++ b/crossbar/router/protocol.py
@@ -206,6 +206,7 @@ class WampWebSocketServerProtocol(websocket.WampWebSocketServerProtocol):
             self._authrole = None
             self._authrealm = None
             self._authmethod = None
+            self._authextra = None
             self._authprovider = None
 
             # cookie tracking and cookie-based authentication
@@ -237,7 +238,7 @@ class WampWebSocketServerProtocol(websocket.WampWebSocketServerProtocol):
                 #
                 if 'auth' in self.factory._config and 'cookie' in self.factory._config['auth']:
 
-                    self._authid, self._authrole, self._authmethod, self._authrealm, authextra = self.factory._cookiestore.getAuth(self._cbtid)
+                    self._authid, self._authrole, self._authmethod, self._authrealm, self._authextra = self.factory._cookiestore.getAuth(self._cbtid)
 
                     if self._authid:
                         # there is a cookie set, and the cookie was previously successfully authenticated,
@@ -477,6 +478,7 @@ class WampRawSocketServerProtocol(rawsocket.WampRawSocketServerProtocol):
         self._authrealm = None
         self._authmethod = None
         self._authprovider = None
+        self._authextra = None
 
         # cookie tracking ID
         #

--- a/crossbar/router/role.py
+++ b/crossbar/router/role.py
@@ -393,6 +393,7 @@ class RouterRoleDynamicAuth(RouterRole):
                 u'authrole': session._authrole,
                 u'authmethod': session._authmethod,
                 u'authprovider': session._authprovider,
+                u'authextra': session._authextra,
                 u'transport': {
                     u'type': u'stdio',  # or maybe "embedded"?
                 }

--- a/crossbar/router/session.py
+++ b/crossbar/router/session.py
@@ -382,6 +382,7 @@ class RouterSession(BaseSession):
                 self._authrole = authrole
                 self._authmethod = authmethod
                 self._authprovider = authprovider
+                self._authextra = authextra
 
                 roles = self._router.attach(self)
 
@@ -611,10 +612,13 @@ class RouterSession(BaseSession):
         try:
             # default authentication method is "WAMP-Anonymous" if client doesn't specify otherwise
             authmethods = details.authmethods or [u'anonymous']
+            authextra = None
 
             # if the client had a reassigned realm during authentication, restore it from the cookie
             if hasattr(self._transport, '_authrealm') and self._transport._authrealm:
+                assert u'cookie' in authmethods
                 realm = self._transport._authrealm
+                authextra = self._transport._authextra
 
             # perform authentication
             if self._transport._authid is not None and (self._transport._authmethod == u'trusted' or self._transport._authprovider in authmethods):
@@ -630,7 +634,7 @@ class RouterSession(BaseSession):
                                         authrole=self._transport._authrole,
                                         authmethod=self._transport._authmethod,
                                         authprovider=self._transport._authprovider,
-                                        authextra=None)
+                                        authextra=authextra)
                 else:
                     return types.Deny(ApplicationError.NO_SUCH_ROLE, message="session was previously authenticated (via transport), but role '{}' no longer exists on realm '{}'".format(self._transport._authrole, realm))
 
@@ -755,6 +759,7 @@ class RouterSession(BaseSession):
             u'authid': details.authid,
             u'authrole': details.authrole,
             u'authmethod': details.authmethod,
+            u'authextra': details.authextra,
             u'authprovider': details.authprovider,
             u'transport': self._transport._transport_info
         }


### PR DESCRIPTION
Further fixes to authextra handling when a ticket-authenticated session re-authenticates via a set cookie (previously, the authextra was not sent to the second session).

This could use a unit-test; does have a CTS integration test.