### PR TITLE
Outstanding invoke tracking

### DIFF
--- a/crossbar/router/dealer.py
+++ b/crossbar/router/dealer.py
@@ -755,9 +755,6 @@ class Dealer(object):
         if (session._session_id, cancel.request) in self._invocations_by_call:
             invocation_request = self._invocations_by_call[session._session_id, cancel.request]
 
-            if invocation_request.caller is not session:
-                raise ProtocolError(u"Dealer.processCancel(): CANCEL received for non-owned call request ID {0}".format(cancel.request))
-
             # for those that repeatedly push elevator buttons
             if invocation_request.canceled:
                 return

--- a/crossbar/router/dealer.py
+++ b/crossbar/router/dealer.py
@@ -133,7 +133,9 @@ class Dealer(object):
         # map: session -> in-flight invocations
         self._caller_to_invocations = {}
 
-        # map: call -> in-flight invocations
+        # careful here: the 'request' IDs are unique per-session
+        # (only) so we map from (session_id, call) tuples to in-flight invocations
+        # map: (session_id, call) -> in-flight invocations
         self._invocations_by_call = {}
 
         # pending callee invocation requests
@@ -709,7 +711,7 @@ class Dealer(object):
         """
         invoke_request = InvocationRequest(invocation_request_id, registration, session, call, callee)
         self._invocations[invocation_request_id] = invoke_request
-        self._invocations_by_call[call.request] = invoke_request
+        self._invocations_by_call[session._session_id, call.request] = invoke_request
         invokes = self._callee_to_invocations.get(callee, [])
         invokes.append(invoke_request)
         self._callee_to_invocations[callee] = invokes
@@ -737,7 +739,12 @@ class Dealer(object):
             del self._caller_to_invocations[invocation_request.caller]
 
         del self._invocations[invocation_request.id]
-        del self._invocations_by_call[invocation_request.call.request]
+
+        # the session_id will be None if the caller session has
+        # already vanished
+        caller_id = invocation_request.caller._session_id
+        if caller_id is not None:
+            del self._invocations_by_call[caller_id, invocation_request.call.request]
 
     # noinspection PyUnusedLocal
     def processCancel(self, session, cancel):
@@ -745,8 +752,8 @@ class Dealer(object):
         """
         Implements :func:`crossbar.router.interfaces.IDealer.processCancel`
         """
-        if cancel.request in self._invocations_by_call:
-            invocation_request = self._invocations_by_call[cancel.request]
+        if (session._session_id, cancel.request) in self._invocations_by_call:
+            invocation_request = self._invocations_by_call[session._session_id, cancel.request]
 
             if invocation_request.caller is not session:
                 raise ProtocolError(u"Dealer.processCancel(): CANCEL received for non-owned call request ID {0}".format(cancel.request))

--- a/crossbar/router/test/test_dealer.py
+++ b/crossbar/router/test/test_dealer.py
@@ -334,56 +334,6 @@ class TestDealer(unittest.TestCase):
         interrupt_msg = last_message['1']
         self.assertIsNone(interrupt_msg)
 
-    def test_call_cancel_nonowned_call(self):
-        last_message = {'1': []}
-
-        def session_send(msg):
-            last_message['1'] = msg
-
-        session = mock.Mock()
-        session._transport.send = session_send
-        session._session_roles = {'callee': role.RoleCalleeFeatures(call_canceling=True)}
-
-        dealer = self.router._dealer
-        dealer.attach(session)
-
-        def authorize(*args, **kwargs):
-            return defer.succeed({u'allow': True, u'disclose': False})
-
-        self.router.authorize = mock.Mock(side_effect=authorize)
-
-        dealer.processRegister(session, message.Register(
-            1,
-            u'com.example.my.proc',
-            u'exact',
-            message.Register.INVOKE_SINGLE,
-            1
-        ))
-
-        registered_msg = last_message['1']
-        self.assertIsInstance(registered_msg, message.Registered)
-
-        dealer.processCall(session, message.Call(
-            2,
-            u'com.example.my.proc',
-            []
-        ))
-
-        invocation_msg = last_message['1']
-        self.assertIsInstance(invocation_msg, message.Invocation)
-
-        bad_session = mock.Mock()
-        bad_session._session_roles = {'callee': role.RoleCalleeFeatures(call_canceling=True)}
-
-        dealer.attach(bad_session)
-
-        def attempt_bad_cancel():
-            dealer.processCancel(bad_session, message.Cancel(
-                2
-            ))
-
-        self.failUnlessRaises(ProtocolError, attempt_bad_cancel)
-
     def test_force_reregister_kick(self):
         """
         Kick an existing registration with force_reregister=True


### PR DESCRIPTION
The IDs of "Call" messages are only supposed to be unique per-session -- this fixes "outstanding call" invoke tracking to be the 2-tuple `(session_id, request)` to fix this behavior.