### PR TITLE
Remove misc files from data_files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,6 @@ setup(
         ]},
     packages=find_packages(),
     include_package_data=True,
-    data_files=[('.', ['COPYRIGHT', 'LICENSE', 'LICENSE-FOR-API'])],
     zip_safe=False,
 
     # http://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Using data_files causes LICENSE,etc to be installed in prefix which could clobber another file. Using only MANIFEST will include it in the tarball without this risk.