### PR TITLE
Refactor workers

### DIFF
--- a/crossbar/common/process.py
+++ b/crossbar/common/process.py
@@ -34,7 +34,7 @@ import gc
 
 from datetime import datetime
 
-from twisted.internet.defer import DeferredList, inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.internet.task import LoopingCall
 
 

--- a/crossbar/common/process.py
+++ b/crossbar/common/process.py
@@ -235,8 +235,6 @@ class NativeProcessSession(ApplicationSession):
                 self.log.info('  {proc}', proc=reg.procedure)
         returnValue(regs)
 
-
-
     @inlineCallbacks
     def start_connection(self, id, config, details=None):
         """

--- a/crossbar/common/process.py
+++ b/crossbar/common/process.py
@@ -36,6 +36,7 @@ from datetime import datetime
 
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.internet.task import LoopingCall
+from twisted.python.failure import Failure
 
 
 try:
@@ -57,6 +58,7 @@ from autobahn.util import utcnow, utcstr, rtime
 from autobahn.twisted.wamp import ApplicationSession
 from autobahn.wamp.exception import ApplicationError
 from autobahn.wamp.types import PublishOptions, RegisterOptions
+from autobahn import wamp
 
 from txaio import make_logger
 
@@ -218,35 +220,22 @@ class NativeProcessSession(ApplicationSession):
         """
         Called when process has joined the node's management realm.
         """
-        procs = [
-            'start_manhole',
-            'stop_manhole',
-            'get_manhole',
 
-            'start_connection',
-            'stop_connection',
-            'get_connections',
+        regs = yield self.register(
+            self,
+            prefix=u'{}.'.format(self._uri_prefix),
+            options=RegisterOptions(details_arg='details'),
+        )
 
-            'trigger_gc',
+        self.log.info("Registered {len_reg} procedures", len_reg=len(regs))
+        for reg in regs:
+            if isinstance(reg, Failure):
+                self.log.error("Failed to register: {f}", f=reg, log_failure=reg)
+            else:
+                self.log.info('  {proc}', proc=reg.procedure)
+        returnValue(regs)
 
-            'utcnow',
-            'started',
-            'uptime',
 
-            'get_process_info',
-            'get_process_stats',
-            'set_process_stats_monitoring'
-        ]
-
-        dl = []
-        for proc in procs:
-            uri = u'{}.{}'.format(self._uri_prefix, proc)
-            self.log.debug("Registering procedure '{uri}'", uri=uri)
-            dl.append(self.register(getattr(self, proc), uri, options=RegisterOptions(details_arg='details')))
-
-        regs = yield DeferredList(dl)
-
-        self.log.debug("Registered {len_reg} procedures", len_reg=len(regs))
 
     @inlineCallbacks
     def start_connection(self, id, config, details=None):
@@ -357,6 +346,7 @@ class NativeProcessSession(ApplicationSession):
             res.append(c.marshal())
         return res
 
+    @wamp.register(None)
     def get_process_info(self, details=None):
         """
         Get process information (open files, sockets, ...).
@@ -372,6 +362,7 @@ class NativeProcessSession(ApplicationSession):
             emsg = "Could not retrieve process statistics: required packages not installed"
             raise ApplicationError(u"crossbar.error.feature_unavailable", emsg)
 
+    @wamp.register(None)
     def get_process_stats(self, details=None):
         """
         Get process statistics (CPU, memory, I/O).
@@ -386,6 +377,7 @@ class NativeProcessSession(ApplicationSession):
             emsg = "Could not retrieve process statistics: required packages not installed"
             raise ApplicationError(u"crossbar.error.feature_unavailable", emsg)
 
+    @wamp.register(None)
     def set_process_stats_monitoring(self, interval, details=None):
         """
         Enable/disable periodic publication of process statistics.
@@ -425,6 +417,7 @@ class NativeProcessSession(ApplicationSession):
             emsg = "Cannot setup process statistics monitor: required packages not installed"
             raise ApplicationError(u"crossbar.error.feature_unavailable", emsg)
 
+    @wamp.register(None)
     def trigger_gc(self, details=None):
         """
         Manually trigger a garbage collection in this native process.
@@ -483,6 +476,7 @@ class NativeProcessSession(ApplicationSession):
 
         return duration
 
+    @wamp.register(None)
     @inlineCallbacks
     def start_manhole(self, config, details=None):
         """
@@ -621,6 +615,7 @@ class NativeProcessSession(ApplicationSession):
 
         returnValue(started_info)
 
+    @wamp.register(None)
     @inlineCallbacks
     def stop_manhole(self, details=None):
         """
@@ -676,6 +671,7 @@ class NativeProcessSession(ApplicationSession):
 
         returnValue(stopped_info)
 
+    @wamp.register(None)
     def get_manhole(self, details=None):
         """
         Get current manhole service information.
@@ -694,6 +690,7 @@ class NativeProcessSession(ApplicationSession):
         else:
             return self._manhole_service.marshal()
 
+    @wamp.register(None)
     def utcnow(self, details=None):
         """
         Return current time as determined from within this process.
@@ -712,6 +709,7 @@ class NativeProcessSession(ApplicationSession):
 
         return utcnow()
 
+    @wamp.register(None)
     def started(self, details=None):
         """
         Return start time of this process.
@@ -730,6 +728,7 @@ class NativeProcessSession(ApplicationSession):
 
         return utcstr(self._started)
 
+    @wamp.register(None)
     def uptime(self, details=None):
         """
         Return uptime of this process.

--- a/crossbar/controller/process.py
+++ b/crossbar/controller/process.py
@@ -50,6 +50,7 @@ from twisted.python.runtime import platform
 from autobahn.util import utcnow, utcstr
 from autobahn.wamp.exception import ApplicationError
 from autobahn.wamp.types import PublishOptions, RegisterOptions
+from autobahn import wamp
 
 import crossbar
 from crossbar.common import checkconfig
@@ -85,25 +86,6 @@ class NodeControllerSession(NativeProcessSession):
 
     log = make_logger()
 
-    PROCS = [
-        'get_info',
-        'shutdown',
-        'get_workers',
-        'get_worker',
-        'get_worker_log',
-
-        'start_worker',
-        # 'stop_worker',
-
-        'start_router',
-        'stop_router',
-        'start_container',
-        'stop_container',
-        'start_guest',
-        'stop_guest',
-        'start_websocket_testee',
-        'stop_websocket_testee',
-    ]
 
     NATIVE_WORKER = {
         'router': {
@@ -196,18 +178,7 @@ class NodeControllerSession(NativeProcessSession):
         self.subscribe(on_worker_ready, u'crossbar.worker..on_worker_ready', SubscribeOptions(match=u'wildcard'))
 
         yield NativeProcessSession.onJoin(self, details)
-
-        # register node controller procedures: 'crossbar.node.<ID>.<PROCEDURE>'
-        #
-        dl = []
-        for proc in self.PROCS:
-            uri = u'{}.{}'.format(self._uri_prefix, proc)
-            self.log.debug('Registering management API procedure "{proc}"', proc=uri)
-            dl.append(self.register(getattr(self, proc), uri, options=RegisterOptions(details_arg='details')))
-
-        regs = yield DeferredList(dl)
-
-        self.log.debug("Registered {cnt} management API procedures", cnt=len(regs))
+        # above upcall registers procedures we have marked with @wamp.register(None)
 
         # we need to catch SIGINT here to properly shutdown the
         # node explicitly (a Twisted system trigger wouldn't allow us to distinguish
@@ -223,6 +194,7 @@ class NodeControllerSession(NativeProcessSession):
 
         self.log.debug("Node controller ready")
 
+    @wamp.register(None)
     def get_info(self, details=None):
         """
         Return basic information about this node.
@@ -249,6 +221,7 @@ class NodeControllerSession(NativeProcessSession):
             u'management_node_extra': self._node._node_extra,
         }
 
+    @wamp.register(None)
     @inlineCallbacks
     def shutdown(self, restart=False, mode=None, details=None):
         """
@@ -286,6 +259,7 @@ class NodeControllerSession(NativeProcessSession):
 
         returnValue(shutdown_info)
 
+    @wamp.register(None)
     def get_workers(self, details=None):
         """
         Returns the list of workers currently running on this node.
@@ -310,6 +284,7 @@ class NodeControllerSession(NativeProcessSession):
             )
         return res
 
+    @wamp.register(None)
     def get_worker(self, id, details=None):
         if id not in self._workers:
             emsg = "No worker with ID '{}'".format(id)
@@ -331,6 +306,7 @@ class NodeControllerSession(NativeProcessSession):
 
         return worker_info
 
+    @wamp.register(None)
     def get_worker_log(self, id, limit=100, details=None):
         """
         Get buffered log for a worker.
@@ -348,6 +324,7 @@ class NodeControllerSession(NativeProcessSession):
 
         return self._workers[id].getlog(limit)
 
+    @wamp.register(None)
     def start_worker(self, worker_id, worker_type, worker_options=None, details=None):
         if worker_type in [u'router', u'container', u'websocket-testee']:
             return self._start_native_worker(worker_type, worker_id, worker_options, details=details)
@@ -358,6 +335,7 @@ class NodeControllerSession(NativeProcessSession):
         else:
             raise Exception('invalid worker type "{}"'.format(worker_type))
 
+    @wamp.register(None)
     def start_router(self, id, options=None, details=None):
         """
         Start a new router worker: a Crossbar.io native worker process
@@ -373,6 +351,7 @@ class NodeControllerSession(NativeProcessSession):
 
         return self._start_native_worker('router', id, options, details=details)
 
+    @wamp.register(None)
     def start_container(self, id, options=None, details=None):
         """
         Start a new container worker: a Crossbar.io native worker process
@@ -388,6 +367,7 @@ class NodeControllerSession(NativeProcessSession):
 
         return self._start_native_worker('container', id, options, details=details)
 
+    @wamp.register(None)
     def start_websocket_testee(self, id, options=None, details=None):
         """
         Start a new websocket-testee worker: a Crossbar.io native worker process
@@ -734,6 +714,7 @@ class NodeControllerSession(NativeProcessSession):
         except ProcessExitedAlready:
             pass  # ignore; it's already dead
 
+    @wamp.register(None)
     def stop_router(self, id, kill=False, details=None):
         """
         Stops a currently running router worker.
@@ -752,6 +733,7 @@ class NodeControllerSession(NativeProcessSession):
 
         return self._stop_native_worker('router', id, kill, details=details)
 
+    @wamp.register(None)
     def stop_container(self, id, kill=False, details=None):
         """
         Stops a currently running container worker.
@@ -770,6 +752,7 @@ class NodeControllerSession(NativeProcessSession):
 
         return self._stop_native_worker('container', id, kill, details=details)
 
+    @wamp.register(None)
     def stop_websocket_testee(self, id, kill=False, details=None):
         """
         Stops a currently running websocket-testee worker.
@@ -831,6 +814,7 @@ class NodeControllerSession(NativeProcessSession):
 
         returnValue(stop_info)
 
+    @wamp.register(None)
     def start_guest(self, id, config, details=None):
         """
         Start a new guest process on this node.
@@ -1070,6 +1054,7 @@ class NodeControllerSession(NativeProcessSession):
 
         return worker.ready
 
+    @wamp.register(None)
     def stop_guest(self, id, kill=False, details=None):
         """
         Stops a currently running guest worker.

--- a/crossbar/controller/process.py
+++ b/crossbar/controller/process.py
@@ -43,13 +43,13 @@ except ImportError:
     from shutilwhich import which  # noqa
 
 from twisted.internet.error import ReactorNotRunning
-from twisted.internet.defer import Deferred, DeferredList, inlineCallbacks, returnValue
+from twisted.internet.defer import Deferred, inlineCallbacks, returnValue
 from twisted.internet.error import ProcessExitedAlready
 from twisted.python.runtime import platform
 
 from autobahn.util import utcnow, utcstr
 from autobahn.wamp.exception import ApplicationError
-from autobahn.wamp.types import PublishOptions, RegisterOptions
+from autobahn.wamp.types import PublishOptions
 from autobahn import wamp
 
 import crossbar
@@ -85,7 +85,6 @@ class NodeControllerSession(NativeProcessSession):
     """
 
     log = make_logger()
-
 
     NATIVE_WORKER = {
         'router': {

--- a/crossbar/worker/container.py
+++ b/crossbar/worker/container.py
@@ -105,6 +105,7 @@ class ContainerWorkerSession(NativeWorkerSession):
     a WAMP transport) and attached to a given realm on the application router.
     """
     WORKER_TYPE = u'container'
+    WORKER_TITLE = u'Container'
 
     def __init__(self, config=None, reactor=None):
         NativeWorkerSession.__init__(self, config, reactor)

--- a/crossbar/worker/container.py
+++ b/crossbar/worker/container.py
@@ -34,14 +34,13 @@ from functools import partial
 from datetime import datetime
 
 from twisted import internet
-from twisted.internet.defer import Deferred, DeferredList, inlineCallbacks
+from twisted.internet.defer import Deferred, inlineCallbacks
 from twisted.internet.defer import returnValue
 from twisted.python.failure import Failure
 
 from autobahn.util import utcstr
 from autobahn.wamp.exception import ApplicationError
 from autobahn.wamp.types import ComponentConfig, PublishOptions
-from autobahn.wamp.types import RegisterOptions
 from autobahn import wamp
 
 from crossbar.common import checkconfig

--- a/crossbar/worker/container.py
+++ b/crossbar/worker/container.py
@@ -42,6 +42,7 @@ from autobahn.util import utcstr
 from autobahn.wamp.exception import ApplicationError
 from autobahn.wamp.types import ComponentConfig, PublishOptions
 from autobahn.wamp.types import RegisterOptions
+from autobahn import wamp
 
 from crossbar.common import checkconfig
 from crossbar.worker import _appsession_loader
@@ -104,7 +105,6 @@ class ContainerWorkerSession(NativeWorkerSession):
     a WAMP transport) and attached to a given realm on the application router.
     """
     WORKER_TYPE = u'container'
-    PROCS = []
 
     def __init__(self, config=None, reactor=None):
         NativeWorkerSession.__init__(self, config, reactor)
@@ -126,31 +126,12 @@ class ContainerWorkerSession(NativeWorkerSession):
 
         yield NativeWorkerSession.onJoin(self, details, publish_ready=False)
 
-        # the procedures registered
-        self.PROCS = [
-            u'stop',
-            u'start_component',
-            u'stop_component',
-            u'restart_component',
-            u'get_component',
-            u'list_components',
-        ]
-
-        dl = []
-        for proc in self.PROCS:
-            uri = u'{}.{}'.format(self._uri_prefix, proc)
-            self.log.info('Registering management API procedure <{proc}>', proc=uri)
-            dl.append(self.register(getattr(self, proc), uri, options=RegisterOptions(details_arg='details')))
-
-        regs = yield DeferredList(dl)
-
-        self.log.info('Ok, registered {cnt} management API procedures', cnt=len(regs))
-
         self.log.info('Container worker "{worker_id}" session ready', worker_id=self._worker_id)
 
         # NativeWorkerSession.publish_ready()
         yield self.publish_ready()
 
+    @wamp.register(None)
     def stop(self, details=None):
         """
         Stops the whole container gracefully by stopping all components
@@ -171,6 +152,7 @@ class ContainerWorkerSession(NativeWorkerSession):
         self.disconnect()
         return stopped_component_ids
 
+    @wamp.register(None)
     def start_component(self, component_id, config, reload_modules=False, details=None):
         """
         Starts a component in this container worker.
@@ -387,6 +369,7 @@ class ContainerWorkerSession(NativeWorkerSession):
             self.publish(topic, event)
         return event
 
+    @wamp.register(None)
     @inlineCallbacks
     def restart_component(self, component_id, reload_modules=False, details=None):
         """
@@ -432,6 +415,7 @@ class ContainerWorkerSession(NativeWorkerSession):
 
         returnValue(restarted)
 
+    @wamp.register(None)
     @inlineCallbacks
     def stop_component(self, component_id, details=None):
         """
@@ -480,6 +464,7 @@ class ContainerWorkerSession(NativeWorkerSession):
 
         returnValue(stopped)
 
+    @wamp.register(None)
     def get_component(self, component_id, details=None):
         """
         Get a component currently running within this container.
@@ -500,6 +485,7 @@ class ContainerWorkerSession(NativeWorkerSession):
 
         return self.components[component_id].marshal()
 
+    @wamp.register(None)
     def list_components(self, ids_only=True, details=None):
         """
         Get components currently running within this container.

--- a/crossbar/worker/process.py
+++ b/crossbar/worker/process.py
@@ -216,6 +216,28 @@ def run():
         WORKER_TYPE_TO_CLASS[worker_type] = klass
         log.info('Worker type {worker_type} configured with class {worker_class}', worker_type=worker_type, worker_class=klass)
 
+    # set process title if requested to
+    #
+    try:
+        import setproctitle
+    except ImportError:
+        log.debug("Could not set worker process title (setproctitle not installed)")
+    else:
+        if options.title:
+            setproctitle.setproctitle(options.title)
+        else:
+            if options.type == u'custom':
+                proc_title = 'crossbar-worker [{}]'.format(
+                    getattr(worker_class, 'proctitle', 'custom')
+                )
+            else:
+                proc_title = {
+                    'router': 'crossbar-worker [router]',
+                    'container': 'crossbar-worker [container]',
+                    'websocket-testee': 'crossbar-worker [websocket-testee]'
+                }[options.type]
+            setproctitle.setproctitle(proc_title)
+
     from twisted.internet.error import ConnectionDone
     from autobahn.twisted.websocket import WampWebSocketServerProtocol
 

--- a/crossbar/worker/process.py
+++ b/crossbar/worker/process.py
@@ -72,6 +72,23 @@ def run():
     import platform
     import signal
 
+    # make sure logging to something else than stdio is setup _first_
+    #
+    from crossbar._logging import make_JSON_observer, cb_logging_aware
+    from txaio import make_logger, start_logging
+    from twisted.logger import globalLogPublisher
+    from twisted.python.reflect import qual
+
+    log = make_logger()
+
+    # Print a magic phrase that tells the capturing logger that it supports
+    # Crossbar's rich logging
+    print(cb_logging_aware, file=sys.__stderr__)
+    sys.__stderr__.flush()
+
+    flo = make_JSON_observer(sys.__stderr__)
+    globalLogPublisher.addObserver(flo)
+
     # Ignore SIGINT so we get consistent behavior on control-C versus
     # sending SIGINT to the controller process. When the controller is
     # shutting down, it sends TERM to all its children but ctrl-C
@@ -84,6 +101,30 @@ def run():
     def ignore(sig, frame):
         log.debug("Ignoring SIGINT in worker.")
     signal.signal(signal.SIGINT, ignore)
+
+    from crossbar.worker.router import RouterWorkerSession
+    from crossbar.worker.container import ContainerWorkerSession
+    from crossbar.worker.testee import WebSocketTesteeWorkerSession
+
+    # default worker type classes
+    WORKER_TYPE_TO_CLASS = {
+        u'router': RouterWorkerSession,
+        u'container': ContainerWorkerSession,
+        u'websocket-testee': WebSocketTesteeWorkerSession
+    }
+
+    # get new worker type classes, or worker type class overrides from the
+    # plugin system (we need this early, to add --type choices to CLI)
+    worker_classes = get_worker_classes()
+    for ep, worker_class in worker_classes.items():
+        klass = worker_class['class']
+        worker_type = klass.WORKER_TYPE
+        WORKER_TYPE_TO_CLASS[worker_type] = klass
+        log.info(
+            "Worker type '{worker_type}' with '{worker_class}'",
+            worker_type=worker_type,
+            worker_class=qual(klass),
+        )
 
     # create the top-level parser
     #
@@ -112,7 +153,7 @@ def run():
 
     parser.add_argument('-t',
                         '--type',
-                        choices=['router', 'container', 'websocket-testee'],
+                        choices=WORKER_TYPE_TO_CLASS.keys(),
                         help='Worker type (required).')
 
     parser.add_argument('-w',
@@ -137,21 +178,7 @@ def run():
 
     options = parser.parse_args()
 
-    # make sure logging to something else than stdio is setup _first_
-    #
-    from crossbar._logging import make_JSON_observer, cb_logging_aware
-    from txaio import make_logger, start_logging
-    from twisted.logger import globalLogPublisher
-
-    log = make_logger()
-
-    # Print a magic phrase that tells the capturing logger that it supports
-    # Crossbar's rich logging
-    print(cb_logging_aware, file=sys.__stderr__)
-    sys.__stderr__.flush()
-
-    flo = make_JSON_observer(sys.__stderr__)
-    globalLogPublisher.addObserver(flo)
+    # actually begin logging
     start_logging(None, options.loglevel)
 
     # we use an Autobahn utility to import the "best" available Twisted reactor
@@ -159,19 +186,14 @@ def run():
     from autobahn.twisted.choosereactor import install_reactor
     reactor = install_reactor(options.reactor)
 
-    WORKER_TYPE_TO_TITLE = {
-        'router': 'Router',
-        'container': 'Container',
-        'websocket-testee': 'WebSocket Testee'
-    }
-
-    from twisted.python.reflect import qual
-    log.info('{worker_title} worker "{worker_id}" process {pid} starting on {python}-{reactor} ..',
-             worker_title=WORKER_TYPE_TO_TITLE[options.type],
-             worker_id=options.worker,
-             pid=os.getpid(),
-             python=platform.python_implementation(),
-             reactor=qual(reactor.__class__).split('.')[-1])
+    log.info(
+        '{worker_title} worker "{worker_id}" process {pid} starting on {python}-{reactor} ..',
+        worker_title=WORKER_TYPE_TO_CLASS[options.type].WORKER_TITLE,
+        worker_id=options.worker,
+        pid=os.getpid(),
+        python=platform.python_implementation(),
+        reactor=qual(reactor.__class__).split('.')[-1],
+    )
 
     # set process title if requested to
     #
@@ -183,12 +205,7 @@ def run():
         if options.title:
             setproctitle.setproctitle(options.title)
         else:
-            WORKER_TYPE_TO_PROCESS_TITLE = {
-                'router': 'crossbar-worker [router]',
-                'container': 'crossbar-worker [container]',
-                'websocket-testee': 'crossbar-worker [websocket-testee]'
-            }
-            setproctitle.setproctitle(WORKER_TYPE_TO_PROCESS_TITLE[options.type].strip())
+            setproctitle.setproctitle('crossbar-worker [{}]'.format(options.type))
 
     # node directory
     #
@@ -196,26 +213,6 @@ def run():
     os.chdir(options.cbdir)
     # log.msg("Starting from node directory {}".format(options.cbdir))
 
-    from crossbar.worker.router import RouterWorkerSession
-    from crossbar.worker.container import ContainerWorkerSession
-    from crossbar.worker.testee import WebSocketTesteeWorkerSession
-
-    # default worker type classes
-    WORKER_TYPE_TO_CLASS = {
-        u'router': RouterWorkerSession,
-        u'container': ContainerWorkerSession,
-        u'websocket-testee': WebSocketTesteeWorkerSession
-    }
-
-    # get new worker type classes, or worker type class overrides from the
-    # plugin system
-    worker_classes = get_worker_classes()
-    for ep, worker_class in worker_classes.items():
-        klass = worker_class['class']
-        worker_type = klass.WORKER_TYPE
-        WORKER_TYPE_TO_CLASS[worker_type] = klass
-        log.info('Worker type {worker_type} configured with class {worker_class}', worker_type=worker_type, worker_class=klass)
-
     # set process title if requested to
     #
     try:
@@ -226,17 +223,9 @@ def run():
         if options.title:
             setproctitle.setproctitle(options.title)
         else:
-            if options.type == u'custom':
-                proc_title = 'crossbar-worker [{}]'.format(
-                    getattr(worker_class, 'proctitle', 'custom')
-                )
-            else:
-                proc_title = {
-                    'router': 'crossbar-worker [router]',
-                    'container': 'crossbar-worker [container]',
-                    'websocket-testee': 'crossbar-worker [websocket-testee]'
-                }[options.type]
-            setproctitle.setproctitle(proc_title)
+            setproctitle.setproctitle(
+                'crossbar-worker [{}]'.format(options.type)
+            )
 
     from twisted.internet.error import ConnectionDone
     from autobahn.twisted.websocket import WampWebSocketServerProtocol

--- a/crossbar/worker/router.py
+++ b/crossbar/worker/router.py
@@ -47,6 +47,7 @@ from twisted.python.threadpool import ThreadPool
 from autobahn.util import utcstr
 from autobahn.twisted.wamp import ApplicationSession
 from autobahn.wamp.exception import ApplicationError
+from autobahn import wamp
 
 from crossbar.twisted.resource import StaticResource, StaticResourceNoListing
 
@@ -845,7 +846,6 @@ class RouterWorkerSession(NativeWorkerSession):
     multiple (embedded) application components.
     """
     WORKER_TYPE = u'router'
-    PROCS = []
 
     def __init__(self, config=None, reactor=None):
         NativeWorkerSession.__init__(self, config, reactor)
@@ -882,44 +882,12 @@ class RouterWorkerSession(NativeWorkerSession):
 
         yield NativeWorkerSession.onJoin(self, details, publish_ready=False)
 
-        # the procedures registered
-        self.PROCS.extend([
-            u'get_router_realms',
-            u'start_router_realm',
-            u'stop_router_realm',
-
-            u'get_router_realm_roles',
-            u'start_router_realm_role',
-            u'stop_router_realm_role',
-
-            u'get_router_realm_uplinks',
-            u'start_router_realm_uplink',
-            u'stop_router_realm_uplink',
-
-            u'get_router_components',
-            u'start_router_component',
-            u'stop_router_component',
-
-            u'get_router_transports',
-            u'start_router_transport',
-            u'stop_router_transport',
-        ])
-
-        dl = []
-        for proc in self.PROCS:
-            uri = u'{}.{}'.format(self._uri_prefix, proc)
-            self.log.info('Registering management API procedure <{proc}>', proc=uri)
-            dl.append(self.register(getattr(self, proc), uri, options=RegisterOptions(details_arg='details')))
-
-        regs = yield DeferredList(dl)
-
-        self.log.info('Ok, registered {cnt} management API procedures', cnt=len(regs))
-
         self.log.info('Router worker "{worker_id}" session ready', worker_id=self._worker_id)
 
         # NativeWorkerSession.publish_ready()
         yield self.publish_ready()
 
+    @wamp.register(None)
     def get_router_realms(self, details=None):
         """
         Get realms currently running on this router worker.
@@ -931,6 +899,7 @@ class RouterWorkerSession(NativeWorkerSession):
 
         return sorted(self.realms.keys())
 
+    @wamp.register(None)
     @inlineCallbacks
     def start_router_realm(self, realm_id, config, enable_trace=False, details=None):
         """
@@ -989,6 +958,7 @@ class RouterWorkerSession(NativeWorkerSession):
 
         self.publish(u'{}.on_realm_started'.format(self._uri_prefix), realm_id)
 
+    @wamp.register(None)
     def stop_router_realm(self, realm_id, close_sessions=False, details=None):
         """
         Stop a realm currently running on this router worker.
@@ -1006,6 +976,7 @@ class RouterWorkerSession(NativeWorkerSession):
         # FIXME
         raise NotImplementedError()
 
+    @wamp.register(None)
     def get_router_realm_roles(self, id, details=None):
         """
         Get roles currently running on a realm running on this router worker.
@@ -1023,6 +994,7 @@ class RouterWorkerSession(NativeWorkerSession):
 
         return self.realms[id].roles.values()
 
+    @wamp.register(None)
     def start_router_realm_role(self, realm_id, role_id, role_config, details=None):
         """
         Start a role on a realm running on this router worker.
@@ -1056,6 +1028,7 @@ class RouterWorkerSession(NativeWorkerSession):
 
         self.log.info('role {role_id} on realm {realm_id} started', realm_id=realm_id, role_id=role_id, role_config=role_config)
 
+    @wamp.register(None)
     def stop_router_realm_role(self, id, role_id, details=None):
         """
         Stop a role currently running on a realm running on this router worker.
@@ -1075,6 +1048,7 @@ class RouterWorkerSession(NativeWorkerSession):
 
         del self.realms[id].roles[role_id]
 
+    @wamp.register(None)
     def get_router_realm_uplinks(self, id, details=None):
         """
         Get uplinks currently running on a realm running on this router worker.
@@ -1092,6 +1066,7 @@ class RouterWorkerSession(NativeWorkerSession):
 
         return self.realms[id].uplinks.values()
 
+    @wamp.register(None)
     @inlineCallbacks
     def start_router_realm_uplink(self, realm_id, uplink_id, uplink_config, details=None):
         """
@@ -1136,6 +1111,7 @@ class RouterWorkerSession(NativeWorkerSession):
 
         self.log.info("Realm is connected to Crossbar.io uplink router")
 
+    @wamp.register(None)
     def stop_router_realm_uplink(self, id, uplink_id, details=None):
         """
         Stop an uplink currently running on a realm running on this router worker.
@@ -1149,6 +1125,7 @@ class RouterWorkerSession(NativeWorkerSession):
 
         raise NotImplementedError()
 
+    @wamp.register(None)
     def get_router_components(self, details=None):
         """
         Get app components currently running in this router worker.
@@ -1191,6 +1168,7 @@ class RouterWorkerSession(NativeWorkerSession):
         # *after* the components got a chance to shutdown.
         dl.addBoth(lambda _: super(RouterWorkerSession, self).onLeave(details))
 
+    @wamp.register(None)
     def start_router_component(self, id, config, details=None):
         """
         Start an app component in this router worker.
@@ -1308,6 +1286,7 @@ class RouterWorkerSession(NativeWorkerSession):
             name=class_name(session),
         )
 
+    @wamp.register(None)
     def stop_router_component(self, id, details=None):
         """
         Stop an app component currently running in this router worker.
@@ -1329,6 +1308,7 @@ class RouterWorkerSession(NativeWorkerSession):
         else:
             raise ApplicationError(u"crossbar.error.no_such_object", "No component {}".format(id))
 
+    @wamp.register(None)
     def get_router_transports(self, details=None):
         """
         Get transports currently running in this router worker.
@@ -1347,6 +1327,7 @@ class RouterWorkerSession(NativeWorkerSession):
             })
         return res
 
+    @wamp.register(None)
     def start_router_transport(self, id, config, details=None):
         """
         Start a transport on this router worker.
@@ -1384,6 +1365,7 @@ class RouterWorkerSession(NativeWorkerSession):
         d.addCallbacks(ok, fail)
         return d
 
+    @wamp.register(None)
     def stop_router_transport(self, id, details=None):
         """
         Stop a transport currently running in this router worker.

--- a/crossbar/worker/router.py
+++ b/crossbar/worker/router.py
@@ -68,7 +68,7 @@ from crossbar.worker.testee import WebSocketTesteeServerFactory, \
 
 from crossbar.twisted.endpoint import create_listening_port_from_config
 
-from autobahn.wamp.types import RegisterOptions, PublishOptions
+from autobahn.wamp.types import PublishOptions
 
 try:
     from twisted.web.wsgi import WSGIResource

--- a/crossbar/worker/router.py
+++ b/crossbar/worker/router.py
@@ -846,6 +846,7 @@ class RouterWorkerSession(NativeWorkerSession):
     multiple (embedded) application components.
     """
     WORKER_TYPE = u'router'
+    WORKER_TITLE = u'Router'
 
     def __init__(self, config=None, reactor=None):
         NativeWorkerSession.__init__(self, config, reactor)

--- a/crossbar/worker/testee.py
+++ b/crossbar/worker/testee.py
@@ -144,6 +144,7 @@ class WebSocketTesteeWorkerSession(NativeWorkerSession):
     A native Crossbar.io worker that runs a WebSocket testee.
     """
     WORKER_TYPE = 'websocket-testee'
+    WORKER_TITLE = u'WebSocket Testee'
 
     @inlineCallbacks
     def onJoin(self, details):

--- a/crossbar/worker/testee.py
+++ b/crossbar/worker/testee.py
@@ -37,6 +37,7 @@ from autobahn.twisted.websocket import WebSocketServerFactory, \
     WebSocketServerProtocol
 from autobahn.wamp.types import RegisterOptions
 from autobahn.wamp.exception import ApplicationError
+from autobahn import wamp
 
 from txaio import make_logger
 
@@ -151,31 +152,16 @@ class WebSocketTesteeWorkerSession(NativeWorkerSession):
         """
         yield NativeWorkerSession.onJoin(self, details, publish_ready=False)
 
-        # the procedures registered
-        procs = [
-            'get_websocket_testee_transport',
-            'start_websocket_testee_transport',
-            'stop_websocket_testee_transport',
-        ]
-
-        dl = []
-        for proc in procs:
-            uri = '{}.{}'.format(self._uri_prefix, proc)
-            self.log.debug("Registering management API procedure {proc}", proc=uri)
-            dl.append(self.register(getattr(self, proc), uri, options=RegisterOptions(details_arg='details')))
-
-        regs = yield DeferredList(dl)
-
-        self.log.debug("Registered {cnt} management API procedures", cnt=len(regs))
-
         # NativeWorkerSession.publish_ready()
         yield self.publish_ready()
 
+    @wamp.register(None)
     def get_websocket_testee_transport(self, details=None):
         """
         """
         self.log.debug("{name}.get_websocket_testee_transport", name=self.__class__.__name__)
 
+    @wamp.register(None)
     def start_websocket_testee_transport(self, id, config, details=None):
         """
         """
@@ -234,6 +220,7 @@ class WebSocketTesteeWorkerSession(NativeWorkerSession):
         d.addCallbacks(ok, fail)
         return d
 
+    @wamp.register(None)
     def stop_websocket_testee_transport(self, id, details=None):
         """
         """

--- a/crossbar/worker/testee.py
+++ b/crossbar/worker/testee.py
@@ -30,12 +30,11 @@
 
 from __future__ import absolute_import
 
-from twisted.internet.defer import inlineCallbacks, DeferredList
+from twisted.internet.defer import inlineCallbacks
 from twisted.internet import protocol
 
 from autobahn.twisted.websocket import WebSocketServerFactory, \
     WebSocketServerProtocol
-from autobahn.wamp.types import RegisterOptions
 from autobahn.wamp.exception import ApplicationError
 from autobahn import wamp
 

--- a/crossbar/worker/worker.py
+++ b/crossbar/worker/worker.py
@@ -101,19 +101,7 @@ class NativeWorkerSession(NativeProcessSession):
         Called when worker process has joined the node's management realm.
         """
         yield NativeProcessSession.onJoin(self, details)
-
-        regs = yield self.register(
-            self,
-            prefix=u'{}.'.format(self._uri_prefix),
-            options=RegisterOptions(details_arg='details'),
-        )
-
-        self.log.info("Registered {cnt} management API procedures", cnt=len(regs))
-        for reg in regs:
-            if isinstance(reg, Failure):
-                self.log.error("Failed to register: {f}", f=reg)
-                self.log.failure()
-            self.log.info('  {proc}', proc=reg.procedure)
+        # above upcall registers all our "@wamp.register(None)" methods
 
         # setup SIGTERM handler to orderly shutdown the worker
         def shutdown(sig, frame):

--- a/crossbar/worker/worker.py
+++ b/crossbar/worker/worker.py
@@ -38,10 +38,12 @@ import signal
 
 from twisted.internet.error import ReactorNotRunning
 from twisted.internet.defer import DeferredList, inlineCallbacks
+from twisted.python.failure import Failure
 
 from autobahn.util import utcnow
 from autobahn.wamp.exception import ApplicationError
 from autobahn.wamp.types import PublishOptions, RegisterOptions
+from autobahn import wamp
 
 from txaio import make_logger
 
@@ -100,34 +102,18 @@ class NativeWorkerSession(NativeProcessSession):
         """
         yield NativeProcessSession.onJoin(self, details)
 
-        procs = [
-            # orderly shutdown worker "from inside"
-            'shutdown',
+        regs = yield self.register(
+            self,
+            prefix=u'{}.'.format(self._uri_prefix),
+            options=RegisterOptions(details_arg='details'),
+        )
 
-            # CPU affinity for this worker process
-            'get_cpu_count',
-            'get_cpu_affinity',
-            'set_cpu_affinity',
-
-            # PYTHONPATH used for this worker
-            'get_pythonpath',
-            'add_pythonpath',
-
-            # profiling control
-            'get_profilers',
-            'start_profiler',
-            'get_profile',
-        ]
-
-        dl = []
-        for proc in procs:
-            uri = u'{}.{}'.format(self._uri_prefix, proc)
-            self.log.debug("Registering management API procedure {proc}", proc=uri)
-            dl.append(self.register(getattr(self, proc), uri, options=RegisterOptions(details_arg='details')))
-
-        regs = yield DeferredList(dl)
-
-        self.log.debug("Registered {cnt} management API procedures", cnt=len(regs))
+        self.log.info("Registered {cnt} management API procedures", cnt=len(regs))
+        for reg in regs:
+            if isinstance(reg, Failure):
+                self.log.error("Failed to register: {f}", f=reg)
+                self.log.failure()
+            self.log.info('  {proc}', proc=reg.procedure)
 
         # setup SIGTERM handler to orderly shutdown the worker
         def shutdown(sig, frame):
@@ -170,6 +156,7 @@ class NativeWorkerSession(NativeProcessSession):
         self.log.debug("Worker '{worker}' running as PID {pid}",
                        worker=self.config.extra.worker, pid=os.getpid())
 
+    @wamp.register(None)
     @inlineCallbacks
     def shutdown(self, details=None):
         """
@@ -202,6 +189,7 @@ class NativeWorkerSession(NativeProcessSession):
         #
         self._reactor.callLater(0, self.leave)
 
+    @wamp.register(None)
     def get_profilers(self, details=None):
         """
         Registered under: ``crossbar.worker.<worker_id>.get_profilers``
@@ -215,6 +203,7 @@ class NativeWorkerSession(NativeProcessSession):
         """
         return [p.marshal() for p in PROFILERS.items()]
 
+    @wamp.register(None)
     def start_profiler(self, profiler, runtime=10, async=True, details=None):
         """
         Registered under: ``crossbar.worker.<worker_id>.start_profiler``
@@ -311,6 +300,7 @@ class NativeWorkerSession(NativeProcessSession):
             # actually finished - and return the complete profile
             return profile_finished
 
+    @wamp.register(None)
     def get_profile(self, profile_id, details=None):
         """
         Get a profile previously produced by a profiler run.
@@ -326,6 +316,7 @@ class NativeWorkerSession(NativeProcessSession):
         else:
             raise ApplicationError(u'crossbar.error.no_such_object', 'no profile with ID {} saved'.format(profile_id))
 
+    @wamp.register(None)
     def get_cpu_count(self, logical=True):
         """
         Returns the CPU core count on the machine this process is running on.
@@ -355,6 +346,7 @@ class NativeWorkerSession(NativeProcessSession):
 
         return psutil.cpu_count(logical=logical)
 
+    @wamp.register(None)
     def get_cpu_affinity(self, details=None):
         """
         Get CPU affinity of this process.
@@ -390,6 +382,7 @@ class NativeWorkerSession(NativeProcessSession):
         else:
             return current_affinity
 
+    @wamp.register(None)
     def set_cpu_affinity(self, cpus, details=None):
         """
         Set CPU affinity of this process.
@@ -445,6 +438,7 @@ class NativeWorkerSession(NativeProcessSession):
             #
             return new_affinity
 
+    @wamp.register(None)
     def get_pythonpath(self, details=None):
         """
         Returns the current Python module search paths.
@@ -458,6 +452,7 @@ class NativeWorkerSession(NativeProcessSession):
         self.log.debug("{klass}.get_pythonpath", klass=self.__class__.__name__)
         return sys.path
 
+    @wamp.register(None)
     def add_pythonpath(self, paths, prepend=True, details=None):
         """
         Add paths to Python module search paths.

--- a/crossbar/worker/worker.py
+++ b/crossbar/worker/worker.py
@@ -37,12 +37,11 @@ import jinja2
 import signal
 
 from twisted.internet.error import ReactorNotRunning
-from twisted.internet.defer import DeferredList, inlineCallbacks
-from twisted.python.failure import Failure
+from twisted.internet.defer import inlineCallbacks
 
 from autobahn.util import utcnow
 from autobahn.wamp.exception import ApplicationError
-from autobahn.wamp.types import PublishOptions, RegisterOptions
+from autobahn.wamp.types import PublishOptions
 from autobahn import wamp
 
 from txaio import make_logger


### PR DESCRIPTION
Depends upon https://github.com/crossbario/autobahn-python/pull/880

This re-factors three things:

 - use `prefix=` AB feature to get rid of `self.PROCS` and lists of procedures
 - move a bunch of router's transport/endpoint things to be bare helper methods
 - refine concept of `entrypoints=` discoverable worker types