### PR TITLE
 Node config startup hooks

### DIFF
--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -2961,7 +2961,7 @@ def check_worker(worker, native_workers):
 
     ptype = worker['type']
 
-    if ptype not in native_workers.keys():#['router', 'container', 'guest', 'websocket-testee']:
+    if ptype not in list(native_workers.keys()) + ['guest']:
         raise InvalidConfigException("invalid attribute value '{}' for attribute 'type' in worker item (valid items are: {})\n\n{}".format(ptype, ', '.join(native_workers.keys()), pformat(worker)))
 
     try:

--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -219,7 +219,6 @@ class _NativeWorkerFactory(object):
 
 from crossbar.controller.processtypes import RouterWorkerProcess, \
     ContainerWorkerProcess, \
-    GuestWorkerProcess, \
     WebSocketTesteeWorkerProcess
 from crossbar.worker.router import RouterWorkerSession
 from crossbar.worker.container import ContainerWorkerSession
@@ -279,7 +278,6 @@ class Node(object):
     ROUTER_SERVICE = RouterServiceSession
 
     _native_workers = default_native_workers()
-
 
     # A Crossbar.io node is the running a controller process and one or multiple
     # worker processes.
@@ -661,8 +659,8 @@ class Node(object):
             # now actually start the worker ..
             yield self._controller.call(u'crossbar.start_worker', worker_id, worker_type, worker_options, options=CallOptions())
 
-            # native worker processes setup: router, container, websocket-testee
-            if worker_type in self._native_workers:#['router', 'container', 'websocket-testee']:
+            # native worker processes setup
+            if worker_type in self._native_workers:
 
                 # setup native worker generic stuff
                 method_name = '_configure_native_worker_{}'.format(worker_type.replace('-', '_'))
@@ -802,7 +800,6 @@ class Node(object):
                 logname=worker_logname,
                 tid=transport_id,
             )
-
 
     @inlineCallbacks
     def _configure_native_worker_container(self, worker_logname, worker_id, worker):

--- a/crossbar/controller/node.py
+++ b/crossbar/controller/node.py
@@ -62,8 +62,14 @@ from crossbar.router.router import RouterFactory
 from crossbar.router.session import RouterSessionFactory
 from crossbar.router.service import RouterServiceSession
 from crossbar.worker.router import RouterRealm
+from crossbar.worker.router import RouterWorkerSession
 from crossbar.common import checkconfig
 from crossbar.controller.process import NodeControllerSession
+from crossbar.controller.processtypes import RouterWorkerProcess
+from crossbar.controller.processtypes import ContainerWorkerProcess
+from crossbar.controller.processtypes import WebSocketTesteeWorkerProcess
+from crossbar.worker.container import ContainerWorkerSession
+from crossbar.worker.testee import WebSocketTesteeWorkerSession
 
 
 def _read_release_pubkey():
@@ -205,24 +211,6 @@ def _write_node_key(filepath, tags, msg):
             if value is None:
                 value = 'unknown'
             f.write(u'{}: {}\n'.format(tag, value))
-
-
-# XXX could do something like this, but .. too complex?
-class _NativeWorkerFactory(object):
-
-    def __init__(self):
-        self._workers = dict()
-
-    def set_worker_type(self, kind, **config):
-        self._workers[kind] = config
-
-
-from crossbar.controller.processtypes import RouterWorkerProcess, \
-    ContainerWorkerProcess, \
-    WebSocketTesteeWorkerProcess
-from crossbar.worker.router import RouterWorkerSession
-from crossbar.worker.container import ContainerWorkerSession
-from crossbar.worker.testee import WebSocketTesteeWorkerSession
 
 
 def default_native_workers():

--- a/crossbar/controller/process.py
+++ b/crossbar/controller/process.py
@@ -58,17 +58,10 @@ from crossbar.common import checkconfig
 from crossbar.twisted.processutil import WorkerProcessEndpoint
 from crossbar.controller.native import create_native_worker_client_factory
 from crossbar.controller.guest import create_guest_worker_client_factory
-from crossbar.controller.processtypes import NativeWorkerProcess, \
-    RouterWorkerProcess, \
-    ContainerWorkerProcess, \
-    GuestWorkerProcess, \
-    WebSocketTesteeWorkerProcess
+from crossbar.controller.processtypes import NativeWorkerProcess
+from crossbar.controller.processtypes import GuestWorkerProcess
 from crossbar.common.process import NativeProcessSession
 from crossbar.common.fswatcher import HAS_FS_WATCHER, FilesystemWatcher
-
-from crossbar.worker.router import RouterWorkerSession
-from crossbar.worker.container import ContainerWorkerSession
-from crossbar.worker.testee import WebSocketTesteeWorkerSession
 
 from txaio import make_logger, get_global_log_level
 


### PR DESCRIPTION
This re-factors some of the "start from config" logic to make it possible for subclasses of `Node` to have a chance to do startup-things for any custom native worker types they may have.