### PR TITLE
snap: read version from central place

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,9 @@
 name: crossbar
+# Fallback version
 version: '17.9.2'
+version-script: |
+    grep -E '^(__version__)' crossbar/__init__.py | \
+    cut -d ' ' -f3 | sed -e 's|["'\'']||g'
 summary: Crossbar.io - Polyglot application router.
 description: |
   Crossbar.io is a networking platform for distributed and microservice


### PR DESCRIPTION
The snap version is now read from crossbar/__init__.py