### PR TITLE
Container exit option

### DIFF
--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -2689,7 +2689,15 @@ def check_router_options(options):
 
 
 def check_container_options(options):
-    check_native_worker_options(options)
+    check_native_worker_options(options, extra_options=['shutdown'])
+    valid_modes = [u'shutdown-manual', u'shutdown-on-last-component-stopped']
+    if 'shutdown' in options:
+        if options['shutdown'] not in valid_modes:
+            raise InvalidConfigException(
+                "'shutdown' must be one of: {}".format(
+                    ', '.join(valid_modes)
+                )
+            )
 
 
 def check_websocket_testee_options(options):
@@ -2780,7 +2788,7 @@ def check_process_env(env):
                 raise InvalidConfigException("invalid type for environment variable value '{}' in 'options.env.vars' - must be a string ({} encountered)".format(v, type(v)))
 
 
-def check_native_worker_options(options):
+def check_native_worker_options(options, extra_options=[]):
     """
     Check native worker options.
 
@@ -2796,7 +2804,7 @@ def check_native_worker_options(options):
 
     for k in options:
         if k not in ['title', 'reactor', 'python', 'pythonpath', 'cpu_affinity',
-                     'env', 'expose_controller', 'expose_shared']:
+                     'env', 'expose_controller', 'expose_shared'] + extra_options:
             raise InvalidConfigException(
                 "encountered unknown attribute '{}' in 'options' in worker"
                 " configuration".format(k)

--- a/crossbar/controller/process.py
+++ b/crossbar/controller/process.py
@@ -402,6 +402,8 @@ class NodeControllerSession(NativeProcessSession):
         args.extend(["--realm", self._realm])
         args.extend(["--klass", worker_class])
         args.extend(["--loglevel", get_global_log_level()])
+        if "shutdown" in options:
+            args.extend(["--shutdown", options["shutdown"]])
 
         # Node-level callback to inject worker arguments
         #

--- a/crossbar/worker/container.py
+++ b/crossbar/worker/container.py
@@ -115,6 +115,9 @@ class ContainerWorkerSession(NativeWorkerSession):
         # map: component ID -> ContainerComponent
         self.components = {}
 
+        # when shall we exit?
+        self._exit_mode = (config.extra.shutdown or self.SHUTDOWN_MANUAL)
+
         # "global" shared between all components
         self.components_shared = {
             u'reactor': reactor
@@ -126,10 +129,7 @@ class ContainerWorkerSession(NativeWorkerSession):
         Called when worker process has joined the node's management realm.
         """
         self.log.info('Container worker "{worker_id}" session {session_id} initializing ..', worker_id=self._worker_id, session_id=details.session)
-
         yield NativeWorkerSession.onJoin(self, details, publish_ready=False)
-
-        self._exit_mode = self.SHUTDOWN_MANUAL
 
         self.log.info('Container worker "{worker_id}" session ready', worker_id=self._worker_id)
 

--- a/crossbar/worker/process.py
+++ b/crossbar/worker/process.py
@@ -129,6 +129,11 @@ def run():
                         default=False,
                         help='Expose a shared object to all components (this feature requires Crossbar.io Fabric extension).')
 
+    parser.add_argument('--shutdown',
+                        type=six.text_type,
+                        default=None,
+                        help='Shutdown method')
+
     options = parser.parse_args()
 
     # actually begin logging
@@ -145,11 +150,11 @@ def run():
 
     # now load the worker module and class
     _mod = importlib.import_module(worker_module)
-    Klass = getattr(_mod, worker_klass)
+    klass = getattr(_mod, worker_klass)
 
     log.info(
         'Started {worker_title} worker "{worker_id}" [{klass} / {python}-{reactor}]',
-        worker_title=Klass.WORKER_TITLE,
+        worker_title=klass.WORKER_TITLE,
         klass=options.klass,
         worker_id=options.worker,
         pid=os.getpid(),
@@ -242,7 +247,7 @@ def run():
 
         session_config = ComponentConfig(realm=options.realm, extra=options)
         session_factory = ApplicationSessionFactory(session_config)
-        session_factory.session = Klass
+        session_factory.session = klass
 
         # create a WAMP-over-WebSocket transport server factory
         #

--- a/docs/pages/ChangeLog.md
+++ b/docs/pages/ChangeLog.md
@@ -5,6 +5,7 @@ Crossbar.io master (unreleased)
 ===============================
 
 * new: router-realm options: enable_meta_api, bridge_meta_api
+* new: container shutdown option ("shutdown-manual", "shutdown-on-last-worker-exit")
 
 
 Crossbar 17.4.1 (2017-04-15)

--- a/docs/pages/administration/worker/Container-Configuration.md
+++ b/docs/pages/administration/worker/Container-Configuration.md
@@ -47,7 +47,9 @@ The worker itself has the options
 2. `options`: a dictionary of configuration options
 3. `components`: a list Python components to run in the container (*required*)
 
-`options` are those [shared by Native Workers](Native Worker Options)
+`options` are those [shared by Native Workers](Native Worker Options) as well as:
+
+1. `shutdown`: `shutdown-manual` (the default) or `shutdown-on-last-worker-exit`
 
 For a `component`, the `type` is *required* and may be either `class` or `wamplet`.
 


### PR DESCRIPTION
This allows configuring of the exit behavior of containers (introduced in b66528217acdefaec152b2ca166029a1ec48db6a).

Probably the default should actually be `shutdown-on-last-worker-exit` to match old behavior (and Fabric nodes can override the default somehow).