### PR TITLE
Stop retaining old authids and empty sets in router.

### DIFF
--- a/crossbar/router/router.py
+++ b/crossbar/router/router.py
@@ -173,6 +173,8 @@ class Router(object):
         Internal helper.
         """
         self._authid_to_sessions[details['authid']].discard(session)
+        if not self._authid_to_sessions[details['authid']]:
+            del self._authid_to_sessions[details['authid']]
         self._authrole_to_sessions[details['authrole']].discard(session)
 
         # log session details, but skip Crossbar.io internal sessions


### PR DESCRIPTION
When all of the given sessions had disconnected for a given authid, the authid and empty set were
being held in a map. This meant that when Anonymous Authentication was used, you could have lots of
authids and empty sets being kept around, but the authid would be unlikely to be used again. This
commit removes the authid and empty set from the map, allowing that memory to be garbage collected.

Addresses #1202 