### PR TITLE
Batched trace edgecase

### DIFF
--- a/crossbar/router/broker.py
+++ b/crossbar/router/broker.py
@@ -570,13 +570,10 @@ class Broker(object):
                                 # which event is last...
                                 receivers_this_chunk = []
                                 for receiver in receivers[:chunk_size]:
-                                    if (me_also or receiver != session) and receiver != self._event_store:
-                                        # the receiving subscriber session might have no transport,
-                                        # or no longer be joined
-                                        if receiver._session_id and receiver._transport:
-                                            receivers_this_chunk.append(receiver)
-                                        else:
-                                            vanished_receivers.append(receiver)
+                                    if receiver._session_id and receiver._transport:
+                                        receivers_this_chunk.append(receiver)
+                                    else:
+                                        vanished_receivers.append(receiver)
 
                                 receivers = receivers[chunk_size:]
 
@@ -607,7 +604,10 @@ class Broker(object):
                                     # to a single subscription matching the event
                                     txaio.resolve(all_d, None)
 
-                            _notify_some(list(receivers))
+                            _notify_some([
+                                recv for recv in receivers
+                                if (me_also or recv != session) and recv != self._event_store
+                            ])
 
                     return txaio.gather(all_dl)
 

--- a/crossbar/router/test/test_broker.py
+++ b/crossbar/router/test/test_broker.py
@@ -454,7 +454,10 @@ class TestBrokerPublish(unittest.TestCase):
         session2 = TestSession()
         session3 = TestSession()
         session4 = TestSession()
-        sessions = [session0, session1, session2, session3, session4]
+        # NOTE! We ensure that "session0" (the publishing session) is
+        # *last* in the observation-list to trigger a (now fixed)
+        # edge-case)
+        sessions = [session1, session2, session3, session4, session0]
         router = mock.MagicMock()
         router.send = mock.Mock()
         router.new_correlation_id = lambda: u'fake correlation id'
@@ -463,6 +466,10 @@ class TestBrokerPublish(unittest.TestCase):
         with replace_loop(clock):
             broker = Broker(router, clock)
             broker._options.event_dispatching_chunk_size = 2
+
+            # to ensure we get "session0" last, we turn on ordering in
+            # the observations
+            broker._subscription_map._ordered = 1
 
             # let's just "cheat" our way a little to the right state by
             # injecting our subscription "directly" (e.g. instead of


### PR DESCRIPTION
This fixes an edgecase of the batching tracing dispatching that was revealed after an unrelated merge; fixes also the test-case to use `OrderedSet` so it reliably (would have) repeated the failure.