### PR TITLE
Implement auth settings for longpoll connections

### DIFF
--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -1369,6 +1369,7 @@ def check_web_path_service_longpoll(config):
     check_dict_args({
         'type': (True, [six.text_type]),
         'options': (False, [Mapping]),
+        'auth': (False, [Mapping]),
     }, config, "Web transport 'longpoll' path service")
 
     if 'options' in config:
@@ -1380,6 +1381,9 @@ def check_web_path_service_longpoll(config):
             'queue_limit_bytes': (False, six.integer_types),
             'queue_limit_messages': (False, six.integer_types),
         }, config['options'], "Web transport 'longpoll' path service")
+
+    if 'auth' in config:
+        check_transport_auth(config['auth'])
 
 
 def check_web_path_service_rest_post_body_limit(limit):

--- a/crossbar/router/longpoll.py
+++ b/crossbar/router/longpoll.py
@@ -289,6 +289,11 @@ class WampLongPollResourceSession(Resource):
         self._serializer = transport_details['serializer']
         self._session = None
 
+        if(hasattr(self._parent, '_auth')):
+            # Create a config entry so that the auth settings are picked up by the session
+            self._config = {'auth' : self._parent._auth}
+
+
         # session authentication information
         #
         self._authid = None
@@ -583,7 +588,8 @@ class WampLongPollResource(Resource):
                  queueLimitBytes=128 * 1024,
                  queueLimitMessages=100,
                  debug_transport_id=None,
-                 reactor=None):
+                 reactor=None,
+                 auth=None):
         """
         Create new HTTP WAMP Web resource.
 
@@ -605,6 +611,8 @@ class WampLongPollResource(Resource):
         :type debug_transport_id: str
         :param reactor: The Twisted reactor to run under.
         :type reactor: obj
+        :param auth: Optional authentication settings for the WAMP connection
+        :type auth: obj
         """
         Resource.__init__(self)
 
@@ -621,6 +629,7 @@ class WampLongPollResource(Resource):
         self._killAfter = killAfter
         self._queueLimitBytes = queueLimitBytes
         self._queueLimitMessages = queueLimitMessages
+        self._auth = auth
 
         if serializers is None:
             serializers = []

--- a/crossbar/router/session.py
+++ b/crossbar/router/session.py
@@ -315,6 +315,9 @@ class RouterSession(BaseSession):
         # transport configuration
         if hasattr(self._transport, 'factory') and hasattr(self._transport.factory, '_config'):
             self._transport_config = self._transport.factory._config
+        elif hasattr(self._transport, '_config'):
+            # Longpoll transports have a config saved directly on the transport
+            self._transport_config = self._transport._config
         else:
             self._transport_config = {}
 

--- a/crossbar/worker/router.py
+++ b/crossbar/worker/router.py
@@ -689,12 +689,15 @@ def _create_resource(reactor, path_config, templates, log, cbdir, _router_sessio
 
         path_options = path_config.get('options', {})
 
+        auth = path_config.get('auth')
+
         lp_resource = WampLongPollResource(_router_session_factory,
                                            timeout=path_options.get('request_timeout', 10),
                                            killAfter=path_options.get('session_timeout', 30),
                                            queueLimitBytes=path_options.get('queue_limit_bytes', 128 * 1024),
                                            queueLimitMessages=path_options.get('queue_limit_messages', 100),
-                                           debug_transport_id=path_options.get('debug_transport_id', None)
+                                           debug_transport_id=path_options.get('debug_transport_id', None),
+                                           auth=auth
                                            )
         lp_resource._templates = templates
 


### PR DESCRIPTION
Fixes #1205 .

Modified config validation to accept an `auth` entry in `longpoll` sections
Passed auth options into WampLongPollResource
Updated WAMP transport and Session classes to reference auth settings if available