### PR TITLE
controller/cli: Fix crash if checking a process with no arguments

### DIFF
--- a/crossbar/controller/cli.py
+++ b/crossbar/controller/cli.py
@@ -165,7 +165,7 @@ def _is_crossbar_process(cmdline):
     """
     if len(cmdline) > 1 and 'crossbar' in cmdline[1]:
         return True
-    if cmdline[0] == 'crossbar-controller':
+    if len(cmdline) > 0 and cmdline[0] == 'crossbar-controller':
         return True
     return False
 


### PR DESCRIPTION
I ran into the following issue, as my node.pid file seemed to have stale data.

```
2017-11-07T12:20:35+0000 [Controller  30524] Traceback (most recent call last):
2017-11-07T12:20:35+0000 [Controller  30524]   File "/opt/crossbar/bin/crossbar", line 11, in <module>
2017-11-07T12:20:35+0000 [Controller  30524]     sys.exit(run())
2017-11-07T12:20:35+0000 [Controller  30524]   File "/opt/crossbar/site-packages/crossbar/controller/cli.py", line 998, in run
2017-11-07T12:20:35+0000 [Controller  30524]     options.func(options, reactor=reactor)
2017-11-07T12:20:35+0000 [Controller  30524]   File "/opt/crossbar/site-packages/crossbar/controller/cli.py", line 525, in run_command_start
2017-11-07T12:20:35+0000 [Controller  30524]     pid_data = check_is_running(options.cbdir)
2017-11-07T12:20:35+0000 [Controller  30524]   File "/opt/crossbar/site-packages/crossbar/controller/cli.py", line 164, in check_is_running
2017-11-07T12:20:35+0000 [Controller  30524]     if not _is_crossbar_process(cmdline):
2017-11-07T12:20:35+0000 [Controller  30524]   File "/opt/crossbar/site-packages/crossbar/controller/cli.py", line 121, in _is_crossbar_process
2017-11-07T12:20:35+0000 [Controller  30524]     if cmdline[0] == 'crossbar-controller':
2017-11-07T12:20:35+0000 [Controller  30524] IndexError: list index out of range
```

After adding this fix, crossbar reported:

```
2017-11-07T12:26:25+0000 [Controller   5094] "/etc/crossbar/node.pid" points to PID 1079 which is not a crossbar process:
2017-11-07T12:26:25+0000 [Controller   5094]
2017-11-07T12:26:25+0000 [Controller   5094] Verify manually and either kill 1079 or delete /etc/crossbar/node.pid
```

Process 1079 on my machine at the time was:

```
root      1079  0.0  0.0      0     0 ?        S    11:28   0:00 [kworker/1:2]
```

So I assume since the process had no arguments, that caused the error condition fixed here.