### PR TITLE
wait until worker exits on stop()

### DIFF
--- a/crossbar/controller/process.py
+++ b/crossbar/controller/process.py
@@ -710,6 +710,10 @@ class NodeControllerSession(NativeProcessSession):
             self._workers[worker_id].factory.stopFactory()
             self._workers[worker_id].proto.transport.signalProcess('TERM')
 
+        # wait until the worker is actually done before we return from
+        # this call
+        yield self._workers[worker_id].proto.is_closed
+
         returnValue(stop_info)
 
     def _start_guest_worker(self, worker_id, worker_config, details=None):


### PR DESCRIPTION
For use-cases where you `stop()` a bunch of workers and then re-start them, they may still be running when you try and re-start (without waiting).