### PR TITLE
docs: fix environment variable example

### DIFF
--- a/docs-old/pages/administration/auth/Ticket-Authentication.md
+++ b/docs-old/pages/administration/auth/Ticket-Authentication.md
@@ -49,7 +49,7 @@ You can use **environment variables** to hold the secret if you do not want to a
 ```javascript
         "principals": {
             "joe": {
-                "ticket": "$(MYTICKET)",
+                "ticket": "${MYTICKET}",
                 "role": "frontend"
             }
         }


### PR DESCRIPTION
Took me some time to realize that the variable was not evaluated when specified with `()` instead of `{}`