### PR TITLE
Dynamic SCRAM authenticator

### DIFF
--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -527,36 +527,36 @@ def check_transport_auth_scram(config):
     """
     Check a WAMP-SCRAM configuration item.
     """
-    for k in [u'type', u'principals']:
-        if k not in config:
-            raise InvalidConfigException(
-                "missing mandatory attribute '{}' in WAMP-SCRAM configuration".format(k)
-            )
-    if config[u'type'] != u'static':
+    if u'type' not in config:
         raise InvalidConfigException(
-            "Only static SCRAM configuration allowed currently"
+            "missing mandatory attribute '{}' in WAMP-SCRAM configuration".format(u'type')
         )
-
-    # check map of principals
-    for authid, principal in config['principals'].items():
-        check_dict_args({
-            'kdf': (True, [six.text_type]),
-            'iterations': (True, [six.integer_types]),
-            'memory': (True, [six.integer_types]),
-            'salt': (True, [six.text_type]),
-            'stored-key': (True, [six.text_type]),
-            'server-key': (True, [six.text_type]),
-            'role': (False, [six.text_type]),
-        }, principal, "WAMP-SCRAM - principal '{}' configuration".format(authid))
-        available_kdfs = (u'argon2id-13', u'pbkdf2')
-        kdf = principal[u'kdf']
-        if kdf not in available_kdfs:
-            raise ValueError(
-                "WAMP-SCRAM illegal KDF '{}' not one of {}".format(
-                    kdf,
-                    ', '.join(available_kdfs),
-                )
+    if config[u'type'] == u'static':
+        if u'principals' not in config:
+            raise InvalidConfigException(
+                "missing mandatory attribute '{}' in WAMP-SCRAM configuration".format(u'principals')
             )
+
+        # check map of principals
+        for authid, principal in config['principals'].items():
+            check_dict_args({
+                'kdf': (True, [six.text_type]),
+                'iterations': (True, [six.integer_types]),
+                'memory': (True, [six.integer_types]),
+                'salt': (True, [six.text_type]),
+                'stored-key': (True, [six.text_type]),
+                'server-key': (True, [six.text_type]),
+                'role': (False, [six.text_type]),
+            }, principal, "WAMP-SCRAM - principal '{}' configuration".format(authid))
+            available_kdfs = (u'argon2id-13', u'pbkdf2')
+            kdf = principal[u'kdf']
+            if kdf not in available_kdfs:
+                raise ValueError(
+                    "WAMP-SCRAM illegal KDF '{}' not one of {}".format(
+                        kdf,
+                        ', '.join(available_kdfs),
+                    )
+                )
 
 
 def check_transport_auth_cookie(config):

--- a/crossbar/router/auth/scram.py
+++ b/crossbar/router/auth/scram.py
@@ -138,7 +138,7 @@ class PendingAuthScram(PendingAuth):
             def on_authenticate_error(err):
                 return self._marshal_dynamic_authenticator_error(err)
 
-            d.addCallbacks(on_authenticate_error, on_authenticate_ok)
+            d.addCallbacks(on_authenticate_ok, on_authenticate_error)
 
             return d
 

--- a/crossbar/router/auth/scram.py
+++ b/crossbar/router/auth/scram.py
@@ -94,31 +94,33 @@ class PendingAuthScram(PendingAuth):
         # XXX should we just "saslprep()" it here?
         self._authid = details.authid
 
+        if self._authid is None:
+            return types.Deny(message=u'cannot identify client: no authid requested')
+
+        def on_authenticate_ok(principal):
+            self._salt = binascii.a2b_hex(principal[u'salt'])  # error if no salt per-user
+            self._iterations = principal[u'iterations']
+            self._memory = principal[u'memory']
+            self._kdf = principal[u'kdf']
+            self._stored_key = binascii.a2b_hex(principal[u'stored-key'])
+            # do we actually need the server-key? can we compute it ourselves?
+            self._server_key = binascii.a2b_hex(principal[u'server-key'])
+            error = self._assign_principal(principal)
+            if error:
+                return error
+
+            # XXX TODO this needs to include (optional) channel-binding
+            extra = self._compute_challenge()
+            return types.Challenge(self._authmethod, extra)
+
         # use static principal database from configuration
         if self._config['type'] == 'static':
+            
             self._authprovider = u'static'
-
-            if self._authid is None:
-                return types.Deny(message=u'cannot identify client: no authid requested')
 
             if self._authid in self._config.get(u'principals', {}):
                 # we've already validated the configuration
-                principal = self._config[u'principals'][self._authid]
-                self._salt = binascii.a2b_hex(principal[u'salt'])  # error if no salt per-user
-                self._iterations = principal[u'iterations']
-                self._memory = principal[u'memory']
-                self._kdf = principal[u'kdf']
-                self._stored_key = binascii.a2b_hex(principal[u'stored-key'])
-                # do we actually need the server-key? can we compute it ourselves?
-                self._server_key = binascii.a2b_hex(principal[u'server-key'])
-                error = self._assign_principal(principal)
-                if error:
-                    return error
-
-                # XXX TODO this needs to include (optional) channel-binding
-                extra = self._compute_challenge()
-                return types.Challenge(self._authmethod, extra)
-
+                return on_authenticate_ok(self._config[u'principals'][self._authid])
             else:
                 self.log.debug("No pricipal found for {authid}", authid=details.authid)
                 return types.Deny(
@@ -126,7 +128,15 @@ class PendingAuthScram(PendingAuth):
                 )
 
         elif self._config[u'type'] == u'dynamic':
-            return types.Deny(message=u"dynamic SCRAM not implemented")
+            
+            d = self._authenticator_session.call(self._authenticator, realm, details.authid, self._session_details)
+
+            def on_authenticate_error(err):
+                return self._marshal_dynamic_authenticator_error(err)
+
+            d.addCallbacks(on_authenticate_error, on_authenticate_ok)
+
+            return d
 
         else:
             # should not arrive here, as config errors should be caught earlier

--- a/crossbar/router/auth/scram.py
+++ b/crossbar/router/auth/scram.py
@@ -129,6 +129,10 @@ class PendingAuthScram(PendingAuth):
 
         elif self._config[u'type'] == u'dynamic':
             
+            error = self._init_dynamic_authenticator()
+            if error:
+                return error
+            
             d = self._authenticator_session.call(self._authenticator, realm, details.authid, self._session_details)
 
             def on_authenticate_error(err):

--- a/crossbar/router/auth/scram.py
+++ b/crossbar/router/auth/scram.py
@@ -115,7 +115,7 @@ class PendingAuthScram(PendingAuth):
 
         # use static principal database from configuration
         if self._config['type'] == 'static':
-            
+
             self._authprovider = u'static'
 
             if self._authid in self._config.get(u'principals', {}):
@@ -128,11 +128,11 @@ class PendingAuthScram(PendingAuth):
                 )
 
         elif self._config[u'type'] == u'dynamic':
-            
+
             error = self._init_dynamic_authenticator()
             if error:
                 return error
-            
+
             d = self._authenticator_session.call(self._authenticator, realm, details.authid, self._session_details)
 
             def on_authenticate_error(err):


### PR DESCRIPTION
This is the basis for the dynamic SCRAM authenticator. The principals are retrieved by calling the dynamic authenticator, and the rest (client signature, server proof, etc) remains the same as when they were stored in the config file. This way, we can dynamically add users with SCRAM. The authenticator can be as simple as retrieving the correct principal from a database.

This is the extension to dynamic authenticators, building on the code of https://github.com/crossbario/crossbar/pull/1265