### PR TITLE
Add missing authmethod and authextra to session details

### DIFF
--- a/crossbar/router/auth/scram.py
+++ b/crossbar/router/auth/scram.py
@@ -108,6 +108,9 @@ class PendingAuthScram(PendingAuth):
             error = self._assign_principal(principal)
             if error:
                 return error
+            
+            self._session_details[u'authmethod'] = self._authmethod  # from AUTHMETHOD, via base
+            self._session_details[u'authextra'] = details.authextra
 
             # XXX TODO this needs to include (optional) channel-binding
             extra = self._compute_challenge()

--- a/crossbar/router/auth/scram.py
+++ b/crossbar/router/auth/scram.py
@@ -96,6 +96,9 @@ class PendingAuthScram(PendingAuth):
 
         if self._authid is None:
             return types.Deny(message=u'cannot identify client: no authid requested')
+            
+        self._session_details[u'authmethod'] = self._authmethod  # from AUTHMETHOD, via base
+        self._session_details[u'authextra'] = details.authextra
 
         def on_authenticate_ok(principal):
             self._salt = binascii.a2b_hex(principal[u'salt'])  # error if no salt per-user
@@ -108,9 +111,6 @@ class PendingAuthScram(PendingAuth):
             error = self._assign_principal(principal)
             if error:
                 return error
-            
-            self._session_details[u'authmethod'] = self._authmethod  # from AUTHMETHOD, via base
-            self._session_details[u'authextra'] = details.authextra
 
             # XXX TODO this needs to include (optional) channel-binding
             extra = self._compute_challenge()


### PR DESCRIPTION
When trying to distinguish between authentication methods in my dynamic authorizer, I noticed that the authmethod and authextra were missing. A quick comparison to `ticket` showed the missing lines: https://github.com/crossbario/crossbar/blob/master/crossbar/router/auth/ticket.py#L98