### PR TITLE
Base pypy image on -slim variant

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -65,7 +65,7 @@ qemu_deps:
 # we bake into the images
 #
 autobahn:
-	mkdir -p ./_node/web/js
+	mkdir -p ./node/web/js
 	cp ../../autobahn-js-built/autobahn.* ./node/web/js/
 	cp ../../autobahn-js-built/CHECKSUM.* ./node/web/js/
 	cp ../../autobahn-js-built/LICENSE ./node/web/js/

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -24,6 +24,7 @@ test: test_cpy3 test_pypy3
 prepare:
 	-rm -rf ./node
 	crossbar init --appdir ./node
+	mkdir node/web/js -p
 
 publish:
 	# amd64 / community / cpy3

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -66,7 +66,6 @@ qemu_deps:
 # we bake into the images
 #
 autobahn:
-	mkdir -p ./node/web/js
 	cp ../../autobahn-js-built/autobahn.* ./node/web/js/
 	cp ../../autobahn-js-built/CHECKSUM.* ./node/web/js/
 	cp ../../autobahn-js-built/LICENSE ./node/web/js/

--- a/docker/x86_64/Dockerfile.pypy3
+++ b/docker/x86_64/Dockerfile.pypy3
@@ -1,4 +1,4 @@
-FROM amd64/pypy:3
+FROM amd64/pypy:3-slim
 
 MAINTAINER The Crossbar.io Project <support@crossbario.com>
 
@@ -31,11 +31,9 @@ RUN    apt-get update \
                expat \
                build-essential \
                libssl-dev \
-
     # install Crossbar.io from PyPI
     && pip install --no-cache-dir -U pip \
     && pip install --no-cache-dir crossbar>=${CROSSBAR_VERSION} \
-
     # minimize image
     && apt-get remove -y wget expat build-essential \
     && rm -rf ~/.cache \


### PR DESCRIPTION
This reduces the size of pypy image from 301MB to 133MB.