### PR TITLE
Adding "config" argument

### DIFF
--- a/crossbar/webservice/rest.py
+++ b/crossbar/webservice/rest.py
@@ -88,7 +88,11 @@ class RouterWebServiceRestCaller(RouterWebService):
 
         # now create the caller Twisted Web resource
         #
-        resource = CallerResource(config.get('options', {}), caller_session)
+        resource = CallerResource(
+            config.get('options', {}),
+            caller_session,
+            auth_config=config.get('auth', {})
+        )
 
         return RouterWebServiceRestCaller(transport, path, config, resource)
 


### PR DESCRIPTION
This addresses an issue reported by Philipp regarding ticket authentication with http bridge sessions. Ultimately it looks like it was just a missing parameter, possibly a refactoring regression issue. Now works with the customer's test case ...