### PR TITLE
Adding Fallback Resource

### DIFF
--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -1298,7 +1298,8 @@ def check_web_path_service_static(personality, config):
         check_dict_args({
             'enable_directory_listing': (False, [bool]),
             'mime_types': (False, [Mapping]),
-            'cache_timeout': (False, list(six.integer_types) + [type(None)])
+            'cache_timeout': (False, list(six.integer_types) + [type(None)]),
+            'enable_fallback': (False, [str])
         }, config['options'], "'options' in Web transport 'static' path service")
 
 

--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -1299,7 +1299,7 @@ def check_web_path_service_static(personality, config):
             'enable_directory_listing': (False, [bool]),
             'mime_types': (False, [Mapping]),
             'cache_timeout': (False, list(six.integer_types) + [type(None)]),
-            'enable_fallback': (False, [str])
+            'default_file': (False, [str]),
         }, config['options'], "'options' in Web transport 'static' path service")
 
 

--- a/crossbar/webservice/base.py
+++ b/crossbar/webservice/base.py
@@ -64,8 +64,8 @@ class ResourceFallback(File):
     def __init__(self, path, config, **kwargs):
         File.__init__(self, path, **kwargs)
         directory = config.get('directory', '')
-        file = config.get('options', {}).get('enable_fallback')
-        self.path = '{}/{}'.format(directory, file)
+        file = config.get('options', {}).get('default_file')
+        self.path = os.path.join(directory, file)
 
 
 class Resource404(Resource):

--- a/crossbar/webservice/base.py
+++ b/crossbar/webservice/base.py
@@ -37,6 +37,7 @@ from twisted.web import server
 from twisted.web._responses import NOT_FOUND
 from twisted.web.resource import Resource
 from twisted.web.proxy import ReverseProxyResource
+from twisted.web.static import File
 
 from autobahn.wamp.exception import ApplicationError
 
@@ -54,6 +55,17 @@ def set_cross_origin_headers(request):
     headers = request.getHeader(b'access-control-request-headers')
     if headers is not None:
         request.setHeader(b'access-control-allow-headers', headers)
+
+
+class ResourceFallback(File):
+    """
+    Handle requests for non-existent URL's
+    """
+    def __init__(self, path, config, **kwargs):
+        File.__init__(self, path, **kwargs)
+        directory = config.get('directory', '')
+        file = config.get('options', {}).get('enable_fallback')
+        self.path = '{}/{}'.format(directory, file)
 
 
 class Resource404(Resource):

--- a/crossbar/webservice/static.py
+++ b/crossbar/webservice/static.py
@@ -40,7 +40,7 @@ from twisted.web import http
 from twisted.web.static import File
 
 from crossbar.common.twisted.web import patchFileContentTypes
-from crossbar.webservice.base import RouterWebService, Resource404, set_cross_origin_headers
+from crossbar.webservice.base import RouterWebService, Resource404, ResourceFallback, set_cross_origin_headers
 
 DEFAULT_CACHE_TIMEOUT = 12 * 60 * 60
 
@@ -155,6 +155,10 @@ class RouterWebServiceStatic(RouterWebService):
 
         # render 404 page on any concrete path not found
         #
-        resource.childNotFound = Resource404(transport.templates, static_dir)
+        fallback = static_options.get('enable_fallback')
+        if fallback:
+            resource.childNotFound = ResourceFallback(path, config)
+        else:
+            resource.childNotFound = Resource404(transport.templates, static_dir)
 
         return RouterWebServiceStatic(transport, path, config, resource)

--- a/crossbar/webservice/static.py
+++ b/crossbar/webservice/static.py
@@ -155,7 +155,7 @@ class RouterWebServiceStatic(RouterWebService):
 
         # render 404 page on any concrete path not found
         #
-        fallback = static_options.get('enable_fallback')
+        fallback = static_options.get('default_file')
         if fallback:
             resource.childNotFound = ResourceFallback(path, config)
         else:


### PR DESCRIPTION
Ok, so I don't know if there's a better way of doing this, but this feels fairly straightforward. Essentially, if you have a static resource and add to the options;
```python
"default_file" : "index.html"
```
In the event that the resource is unable to deliver a URL, it will attempt to deliver "index.html" (from the configured 'directory') instead. So for example for a single page application, you might have;
```python
"/": {
    "type": "static",
    "directory": "../web",
    "options": {
        "enable_directory_listing": true,
        "default_file": "default.html"
    }
},
```
In this case, accessing a valid path will deliver the expected result, but any attempt to access "/" followed by an unknown word will deliver the file;
```python
/unknown => ../web/default.html
```
This should suffice for most SPA's, but if you need a directory hierarchy, you can always add;
```python
"subfolder": {
    "type": "static",
    "directory": "../web",
    "options": {
        "enable_directory_listing": false,
        "default_file": "default.html"
    }
},
```
Which will force any unknowns on the subfolder to map to the same pattern, i.e;
```python
/subfolder/unknown => ../web/default.html
```
If this is an acceptable solution, then I would envisage the same patch for the "archive" resource.