### PR TITLE
no cookie auth if not in authmethods #33

### DIFF
--- a/crossbar/router/session.py
+++ b/crossbar/router/session.py
@@ -617,9 +617,16 @@ class RouterSession(BaseSession):
 
             # if the client had a reassigned realm during authentication, restore it from the cookie
             if hasattr(self._transport, '_authrealm') and self._transport._authrealm:
-                assert u'cookie' in authmethods
-                realm = self._transport._authrealm
-                authextra = self._transport._authextra
+                if u'cookie' in authmethods:
+                    realm = self._transport._authrealm
+                    authextra = self._transport._authextra
+                else:
+                    # revoke authentication and invalidate cookie (will be revalidated if following auth is successful)
+                    self._transport._authmethod = None
+                    self._transport._authrealm = None
+                    self._transport._authid = None                    
+                    if hasattr(self._transport, '_cbtid'):
+                        self._transport.factory._cookiestore.setAuth(self._transport._cbtid, None, None, None, None, None)
 
             # perform authentication
             if self._transport._authid is not None and (self._transport._authmethod == u'trusted' or self._transport._authprovider in authmethods):


### PR DESCRIPTION
If cookie is not in the authmethods given by the connecting client, then no cookie auth should be executed. 

The proposed solution allows the cookie auth initially on transport level but in the context of the onHello of the session the auth is reevaluated. If "cookie" is not in the given authmethods, the already given auth will not be transfered to the session level, but will be revoked. In this case the cookie will also be invalidated. If the following auth process goes through however, then the cookie will be revalidated with the then correct role. 

I think this is closer to the behaviour expected by the user. 
One detail remains:
It is a little unexpected that authentication methods will be tried in order only cookie auth is considered first regardless of the position in the authmethods array. This should be documented or fixed too. 

Note, that there is another way to invalidate a cookie, which could be used as a workaround too:
`session.leave('wamp.close.logout')` will invalidate the cookie according to [here](https://crossbar.io/docs/Ticket-Authentication/) 
