### PR TITLE
Adding new test to check unsubscribe/detach fix

### DIFF
--- a/crossbar/router/test/test_broker.py
+++ b/crossbar/router/test/test_broker.py
@@ -34,7 +34,6 @@ from twisted.trial import unittest
 
 import txaio
 import mock
-import time
 
 from autobahn.wamp import types
 from autobahn.wamp import message

--- a/crossbar/router/test/test_broker.py
+++ b/crossbar/router/test/test_broker.py
@@ -611,8 +611,8 @@ class TestBrokerPublish(unittest.TestCase):
         class Session(mock.MagicMock):
             """
             Mock the session object, this is key to capturing all the replies and publications.
-            We get all replies in _private and publications in events, so we can issue the 
-            request we need to test, then check at the end _events contains the list of 
+            We get all replies in _private and publications in events, so we can issue the
+            request we need to test, then check at the end _events contains the list of
             pub's we are expecting.
             """
             _private = []

--- a/crossbar/router/test/test_broker.py
+++ b/crossbar/router/test/test_broker.py
@@ -620,9 +620,6 @@ class TestBrokerPublish(unittest.TestCase):
             _authrole = 'trusted'
             _session_id = 0
 
-            def __init__(self, *args, **kwargs):
-                super().__init__(*args, **kwargs)
-
             def send(self, *args, **argv):
                 self._private.append(args[0])
 
@@ -693,12 +690,7 @@ class TestBrokerPublish(unittest.TestCase):
                     test.assertEqual(len(unsubscribes), 0, 'incorrect response sequence for on_unsubscribe')
                     test.assertEqual(len(deletes), 0, 'incorrect response sequence for on_delete')
 
-                # So we need to give the reactor change to process anything submitted with 'callLater'
-                # (unsubscribe does this ...)
-                reactor.callLater(1, all_done)
-                # then we need to "not" exit until 'all_done' has had chance to run .. a call that does
-                # async sleep for 1 second, then call sync 'all_done' would be ideal .. anyone?"
-                time.sleep(1)
+                reactor.callLater(0, all_done)
 
         session = TestSession(types.ComponentConfig(u'realm1'))
         self.session_factory.add(session, authrole=u'trusted')

--- a/crossbar/router/test/test_broker.py
+++ b/crossbar/router/test/test_broker.py
@@ -527,9 +527,6 @@ class TestBrokerPublish(unittest.TestCase):
             _authrole = 'trusted'
             _session_id = 0
 
-            def __init__(self, *args, **kwargs):
-                super().__init__(*args, **kwargs)
-
             def send(self, *args, **argv):
                 self._private.append(args[0])
 
@@ -594,8 +591,7 @@ class TestBrokerPublish(unittest.TestCase):
                     test.assertEqual(len(unsubscribes), 0, 'incorrect response sequence for on_unsubscribe')
                     test.assertEqual(len(deletes), 0, 'incorrect response sequence for on_delete')
 
-                reactor.callLater(1, all_done)
-                time.sleep(1)
+                reactor.callLater(0, all_done)
 
         session = TestSession(types.ComponentConfig(u'realm1'))
         self.session_factory.add(session, authrole=u'trusted')


### PR DESCRIPTION
This is a unit test change to go with; https://github.com/crossbario/crossbar/pull/1431
This test fails prior to the fix, and succeeds with the fix applied.

I'm afraid this took quite a while for me to get my head around, I'm not sure if this pattern is ideal moving forward, but for now it should be good enough to pick up on the edge case in question. Specifically I'm testing subscribe/unsubscribe (which was on anyway) and subscribe / detach (which was where the issue was).

