### PR TITLE
Update Role.py (RouterRoleDynamicAuth.authorize) - Fix issue #1437

### DIFF
--- a/crossbar/router/role.py
+++ b/crossbar/router/role.py
@@ -400,12 +400,12 @@ class RouterRoleDynamicAuth(RouterRole):
             }
         else:
             details = {
-                u'session': details.session,
-                u'authid': details.authid,
-                u'authrole': details.authrole,
-                u'authmethod': details.authmethod,
-                u'authprovider': details.authprovider,
-                u'authextra': details.authextra
+                u'session': session_details.session,
+                u'authid': session_details.authid,
+                u'authrole': session_details.authrole,
+                u'authmethod': session_details.authmethod,
+                u'authprovider': session_details.authprovider,
+                u'authextra': session_details.authextra
                 u'transport': session._transport._transport_info
             }
 

--- a/crossbar/router/role.py
+++ b/crossbar/router/role.py
@@ -405,7 +405,7 @@ class RouterRoleDynamicAuth(RouterRole):
                 u'authrole': session_details.authrole,
                 u'authmethod': session_details.authmethod,
                 u'authprovider': session_details.authprovider,
-                u'authextra': session_details.authextra
+                u'authextra': session_details.authextra,
                 u'transport': session._transport._transport_info
             }
 

--- a/crossbar/router/role.py
+++ b/crossbar/router/role.py
@@ -409,7 +409,6 @@ class RouterRoleDynamicAuth(RouterRole):
                 u'transport': session._transport._transport_info
             }
 
-
         self.log.debug(
             "CrossbarRouterRoleDynamicAuth.authorize {uri} {action} {details}",
             uri=uri, action=action, details=details)

--- a/crossbar/router/role.py
+++ b/crossbar/router/role.py
@@ -382,8 +382,8 @@ class RouterRoleDynamicAuth(RouterRole):
 
         :return: bool -- Flag indicating whether session is authorized or not.
         """
-        details = getattr(session, '_session_details', None)
-        if details is None:
+        session_details = getattr(session, '_session_details', None)
+        if session_details is None:
             # this happens for "embedded" sessions -- perhaps we
             # should have a better way to detect this -- also
             # session._transport should be a RouterApplicationSession

--- a/crossbar/router/role.py
+++ b/crossbar/router/role.py
@@ -382,12 +382,12 @@ class RouterRoleDynamicAuth(RouterRole):
 
         :return: bool -- Flag indicating whether session is authorized or not.
         """
-        session_details = getattr(session, '_session_details', None)
-        if session_details is None:
+        details = getattr(session, '_session_details', None)
+        if details is None:
             # this happens for "embedded" sessions -- perhaps we
             # should have a better way to detect this -- also
             # session._transport should be a RouterApplicationSession
-            session_details = {
+            details = {
                 u'session': session._session_id,
                 u'authid': session._authid,
                 u'authrole': session._authrole,
@@ -398,12 +398,23 @@ class RouterRoleDynamicAuth(RouterRole):
                     u'type': u'stdio',  # or maybe "embedded"?
                 }
             }
+        else:
+            details = {
+                u'session': details.session,
+                u'authid': details.authid,
+                u'authrole': details.authrole,
+                u'authmethod': details.authmethod,
+                u'authprovider': details.authprovider,
+                u'authextra': details.authextra
+                u'transport': session._transport._transport_info
+            }
+
 
         self.log.debug(
             "CrossbarRouterRoleDynamicAuth.authorize {uri} {action} {details}",
-            uri=uri, action=action, details=session_details)
+            uri=uri, action=action, details=details)
 
-        d = self._session.call(self._authorizer, session_details, uri, action, options)
+        d = self._session.call(self._authorizer, details, uri, action, options)
 
         # we could do backwards-compatibility for clients that didn't
         # yet add the 5th "options" argument to their authorizers like


### PR DESCRIPTION
Fix issue #1437 (Dynamic authorizer stop working after upgrade to 18.11.1)

Since `RouterSession` store `_session_details` [session.py#L770](https://github.com/crossbario/crossbar/blob/master/crossbar/router/session.py#L770) as  `autobahn.wamp.types.SessionDetails` object instead of `Dict`, `RoleDynamicAuth` **must convert `_session_details` as dict** before passing it to `_session.call`. (in the same way as  `RouterSession.onJoin` before `_service_session.publish`).