### PR TITLE
Support AWS S3 index document hosting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ commands =
     sphinx-build -b spelling -d ./docs/_build/doctrees ./docs ./docs/_build/spelling
 
     # generate HTML output
-    sphinx-build -b html ./docs ./docs/_build
+    sphinx-build -b dirhtml ./docs ./docs/_build
 
     # move to HOME to preserve on Travis for upload to S3
     -rm -rf {homedir}/crossbar-docs


### PR DESCRIPTION
The AWS S3 Index document support  
( https://docs.aws.amazon.com/AmazonS3/latest/dev/IndexDocumentSupport.html )
From Sphinx manual:
sphinx-build -b dirhtml - Build HTML pages, but with a single directory per document. Makes for prettier URLs (no .html) if served from a webserver. 


