### PR TITLE
Expand environment variables in sock path

### DIFF
--- a/crossbar/common/twisted/endpoint.py
+++ b/crossbar/common/twisted/endpoint.py
@@ -426,7 +426,7 @@ def create_listening_endpoint_from_config(config, cbdir, reactor, log):
 
         # the path
         #
-        path = FilePath(join(cbdir, config['path']))
+        path = FilePath(join(cbdir, os.path.expandvars(config['path'])))
 
         # if there is already something there, delete it.
         #


### PR DESCRIPTION
Potential fix for https://github.com/crossbario/crossbar/issues/1518