### PR TITLE
Change the docs deployment path from docs-new to docs

### DIFF
--- a/.travis-deploy.sh
+++ b/.travis-deploy.sh
@@ -60,4 +60,4 @@ echo 'building and uploading docs ..'
 tox -c tox.ini -e sphinx
 #aws s3 cp --recursive --acl public-read ${HOME}/crossbar-docs s3://${AWS_S3_BUCKET_NAME}/docs
 #aws s3 cp --recursive --acl public-read ${HOME}/crossbar-docs s3://${AWS_S3_BUCKET_NAME}/docs/crossbar
-aws s3 cp --recursive --acl public-read ${HOME}/crossbar-docs s3://${AWS_S3_BUCKET_NAME}/docs-new
+aws s3 cp --recursive --acl public-read ${HOME}/crossbar-docs s3://${AWS_S3_BUCKET_NAME}/docs


### PR DESCRIPTION
Any commits to docs are reflected in https://crossbar.io/docs-new/ and not in https://crossbar.io/docs/