### PR TITLE
Remove usage of auth_config as its no longer supported

### DIFF
--- a/crossbar/webservice/rest.py
+++ b/crossbar/webservice/rest.py
@@ -89,8 +89,7 @@ class RouterWebServiceRestCaller(RouterWebService):
         #
         resource = CallerResource(
             config.get('options', {}),
-            caller_session,
-            auth_config=config.get('auth', {})
+            caller_session)
         )
 
         return RouterWebServiceRestCaller(transport, path, config, resource)

--- a/crossbar/webservice/rest.py
+++ b/crossbar/webservice/rest.py
@@ -89,7 +89,7 @@ class RouterWebServiceRestCaller(RouterWebService):
         #
         resource = CallerResource(
             config.get('options', {}),
-            caller_session)
+            caller_session
         )
 
         return RouterWebServiceRestCaller(transport, path, config, resource)


### PR DESCRIPTION
Crossbar won't start if REST bridge was enabled in the config, this fixes that.