### PR TITLE
Don't use psutil.Process().io_counters() on MacOS

### DIFF
--- a/crossbar/common/monitor.py
+++ b/crossbar/common/monitor.py
@@ -29,6 +29,7 @@
 #####################################################################################
 
 import datetime
+import sys
 import psutil
 
 from twisted.internet.threads import deferToThread
@@ -151,6 +152,12 @@ class ProcessMonitor(Monitor):
         Monitor.__init__(self, config)
         self._p = psutil.Process()
         self._worker_type = worker_type
+
+        # psutil does not support io_counters() on MacOS. For details, see:
+        # https://psutil.readthedocs.io/en/release-3.4.2/#psutil.Process.io_counters
+        if sys.platform.startswith('darwin'):
+            self._has_io_counters = False
+            return
 
         try:
             self._p.io_counters()


### PR DESCRIPTION
The [`psutil` documentation](https://psutil.readthedocs.io/en/release-3.4.2/#psutil.Process.io_counters) says that `io_counters()` is not supported on MacOS:

Return process I/O statistics as a namedtuple including the number of read and write operations
performed by the process and the amount of bytes read and written. For Linux refer to /proc
filesysem documentation. On BSD there’s apparently no way to retrieve bytes counters, hence -1 is
returned for read_bytes and write_bytes fields. OSX is not supported.