### PR TITLE
Better naming for nighly snap builds

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: crossbar
-version: 'latest'
-version-script: python3 -c "exec(open('crossbar/_version.py').read()); print(__version__)"
+version: latest
+version-script: git describe --always | sed -e 's/-/+git/;y/-/./' | tail -c +2
 summary: Crossbar.io - Polyglot application router.
 description: |
   Crossbar.io is a networking platform for distributed and microservice
@@ -48,5 +48,5 @@ parts:
       snapcraftctl prime
       echo "Compiling pyc files..."
       # Delete the file that would fail the compilation process
-      rm "$SNAPCRAFT_PRIME/lib/python3.6/site-packages/crossbar/worker/test/examples/syntaxerror.py"
-      "$SNAPCRAFT_PART_INSTALL/usr/bin/python3" -m compileall -q "$SNAPCRAFT_PRIME"
+      rm $SNAPCRAFT_PRIME/lib/python3.6/site-packages/crossbar/worker/test/examples/syntaxerror.py
+      $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m compileall -q $SNAPCRAFT_PRIME


### PR DESCRIPTION
Today all daily snap builds have their version number set to last stable version of crossbar because we read from https://github.com/crossbario/crossbar/blob/master/crossbar/_version.py#L31

This PR changes that and now we use `git describe` to include the commit hash for daily builds. The format for daily builds `19.3.5+git5.g0fc8f58b`

Note: If we tag a new release and push that, then the build that is triggered won't have the git commit hash and only contain the version number, just like what we currently have, so this change will also help us distinguish between "stable" and "nightly" in snapcraft.io web interface.