### PR TITLE
Click.option-s should have help text

### DIFF
--- a/crossbar/bridge/mqtt/test/interop.py
+++ b/crossbar/bridge/mqtt/test/interop.py
@@ -66,8 +66,8 @@ class Result(object):
 
 
 @click.command()
-@click.option("--host")
-@click.option("--port")
+@click.option("--host", help='Host address to test.')
+@click.option("--port", type=int, help='Post of the host to test.')
 def run(host, port):
 
     port = int(port)


### PR DESCRIPTION
## What?
Add `help` text to click.option

## Why?
Click.option should ideally have a `help` text defined to be useful.
