### PR TITLE
replace inline if

### DIFF
--- a/crossbar/router/service.py
+++ b/crossbar/router/service.py
@@ -254,7 +254,10 @@ class RouterServiceAgent(ApplicationSession):
         if session_id in self._router._session_id_to_session:
             session = self._router._session_id_to_session[session_id]
             if not is_restricted_session(session):
-                session_info = session._session_details.marshal() if hasattr(session, '_session_details') else dict()
+                if hasattr(session, '_session_details'):
+                    session_info = session._session_details.marshal() 
+                else:
+                    session_info = dict()         
                 session_info[u'transport'] = session._transport._transport_info if hasattr(session, '_transport') and hasattr(session._transport, '_transport_info') else None
                 return session_info
             else:


### PR DESCRIPTION
```python
session_info = session._session_details.marshal() if hasattr(session, '_session_details') else dict()
```
I replaced this inline if. I know it should work like that too, but for some reason it does give me the error below.

```
Traceback (most recent call last):
  File "/usr/local/site-packages/crossbar/router/router.py", line 257, in send
    session._transport.send(msg)
  File "/usr/local/site-packages/crossbar/router/session.py", line 251, in send
    self._session.onMessage(msg)
  File "/usr/local/site-packages/autobahn/wamp/protocol.py", line 1006, in onMessage
    on_reply = txaio.as_future(endpoint.fn, *invoke_args, **invoke_kwargs)
  File "/usr/local/site-packages/txaio/tx.py", line 429, in as_future
    return maybeDeferred(fun, *args, **kwargs)
--- <exception caught here> ---
  File "/usr/local/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/usr/local/site-packages/crossbar/router/service.py", line 255, in session_get
    session_info = session._session_details.marshal() if session._session_details else dict()
builtins.AttributeError: 'AuthenticateAuthorize' object has no attribute '_session_details'
```

This error goes away if I change the inline if to an explicit if. I am using the crossbar:pypy3-19.6.1 docker image.