### PR TITLE
Snap shared runtime

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: crossbar
-version: latest
-version-script: git describe --always | sed -e 's/-/+git/;y/-/./' | tail -c +2
+adopt-info: crossbar
 summary: Crossbar.io - Polyglot application router.
 description: |
   Crossbar.io is a networking platform for distributed and microservice
@@ -44,6 +43,10 @@ parts:
       - libbz2-dev
       - libsnappy-dev
       - libunwind-dev
+      - git
+    override-pull: |
+      snapcraftctl pull
+      snapcraftctl set-version $(git describe --always | sed -e 's/-/+git/;y/-/./' | tail -c +2)
     override-prime: |
       snapcraftctl prime
       echo "Compiling pyc files..."

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -60,3 +60,4 @@ slots:
     content: executables
     read:
       - $SNAP/lib/python3.6/site-packages
+      - $SNAP/bin

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -50,3 +50,10 @@ parts:
       # Delete the file that would fail the compilation process
       rm $SNAPCRAFT_PRIME/lib/python3.6/site-packages/crossbar/worker/test/examples/syntaxerror.py
       $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m compileall -q $SNAPCRAFT_PRIME
+
+slots:
+  runtime-dir:
+    interface: content
+    content: executables
+    read:
+      - $SNAP/lib/python3.6/site-packages


### PR DESCRIPTION
* This enables third-party snaps to reuse the crossbar runtime environment, without the need to ship their own copy of things
* Helps projects like https://github.com/deskconn/deskconnd reduce their installed footprint.