### PR TITLE
Base snap on python 3.8

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+CACHE_DIR="$SNAP_DATA"/pycache
+PY=$SNAP/usr/bin/python3.8
+
+rm -rf "$CACHE_DIR"
+mkdir -p "$CACHE_DIR"
+export PYTHONPYCACHEPREFIX=$CACHE_DIR
+$PY -m compileall -x .*\.syntaxerror.py$ -q $SNAP/lib/python3.8/site-packages $SNAP/usr/lib/python3.8

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -6,4 +6,4 @@ PY=$SNAP/usr/bin/python3.8
 rm -rf "$CACHE_DIR"
 mkdir -p "$CACHE_DIR"
 export PYTHONPYCACHEPREFIX=$CACHE_DIR
-$PY -m compileall -x .*\.syntaxerror.py$ -q $SNAP/lib/python3.8/site-packages $SNAP/usr/lib/python3.8
+$PY -m compileall -x .*\.syntaxerror.py$ -q $SNAP/crossbar $SNAP/usr/lib/python3.8

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,9 +1,1 @@
-#!/bin/sh
-
-CACHE_DIR="$SNAP_DATA"/pycache
-PY=$SNAP/usr/bin/python3.8
-
-rm -rf "$CACHE_DIR"
-mkdir -p "$CACHE_DIR"
-export PYTHONPYCACHEPREFIX=$CACHE_DIR
-$PY -m compileall -x .*\.syntaxerror.py$ -q $SNAP/lib/python3.8/site-packages $SNAP/usr/lib/python3.8
+install

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-mkdir -p $SNAP_DATA/pycache
-rm -rf $SNAP_DATA/pycache/*
-export PYTHONPYCACHEPREFIX=$SNAP_DATA/pycache
-$SNAP/usr/bin/python3.8 -m compileall -x .*\.syntaxerror.py$ -q $SNAP/lib/python3.8/site-packages
+CACHE_DIR="$SNAP_DATA"/pycache
+PY=$SNAP/usr/bin/python3.8
+
+rm -rf "$CACHE_DIR"
+mkdir -p "$CACHE_DIR"
+export PYTHONPYCACHEPREFIX=$CACHE_DIR
+$PY -m compileall -x .*\.syntaxerror.py$ -q $SNAP/lib/python3.8/site-packages $SNAP/usr/lib/python3.8

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+mkdir -p $SNAP_DATA/pycache
+rm -rf $SNAP_DATA/pycache/*
+export PYTHONPYCACHEPREFIX=$SNAP_DATA/pycache
+$SNAP/usr/bin/python3.8 -m compileall -x .*\.syntaxerror.py$ -q $SNAP/lib/python3.8/site-packages

--- a/snap/plugins/py38.py
+++ b/snap/plugins/py38.py
@@ -1,0 +1,70 @@
+import os
+import shlex
+import shutil
+import subprocess
+
+import snapcraft
+
+
+class PythonPlugin(snapcraft.BasePlugin):
+    @classmethod
+    def schema(cls):
+        schema = super().schema()
+        schema['properties']['python-packages'] = {
+            'type': 'array',
+            'minitems': 1,
+            'uniqueItems': True,
+            'items': {'type': 'string'},
+            'default': [],
+        }
+        schema['anyOf'] = [{'required': ['source']}, {'required': ['python-packages']}]
+        return schema
+
+    @classmethod
+    def get_pull_properties(cls):
+        return ['python-packages']
+
+    def _enable_py38_ppa(self):
+        self._run('apt install software-properties-common -y')
+        self._run('add-apt-repository ppa:deadsnakes/ppa -y')
+
+    def _ensure_py38(self):
+        self._run('apt install python3.8 python3.8-venv python3.8-dev -y')
+
+    def _run(self, command, cwd=None):
+        subprocess.check_call(shlex.split(command), cwd=cwd)
+
+    def build(self):
+        super().build()
+        self._ensure_py38()
+        self._run('ln -s python3.8 python3', cwd=os.path.join(self.installdir, 'usr/bin'))
+        self._run('ln -s python3.8 python', cwd=os.path.join(self.installdir, 'usr/bin'))
+
+        target = os.path.join(self.installdir, 'crossbar')
+
+        self._run('rm -rf {}'.format(target))
+        self._run('mkdir {}'.format(target))
+
+        if self.options.python_packages and '__none__' in self.options.python_packages:
+            return
+
+        self._run('/usr/bin/python3.8 -m ensurepip')
+
+        if self.options.source:
+            self._run('/usr/bin/python3.8 -m pip install -t {} .'.format(target))
+
+        if self.options.python_packages:
+            packages = ' '.join(self.options.python_packages)
+            self._run('/usr/bin/python3.8 -m pip install -t {} {}'.format(target, packages))
+
+        for root, _, _ in os.walk(self.installdir, topdown=False):
+            if root.endswith('__pycache__') and os.path.exists(root):
+                shutil.rmtree(root)
+
+    @property
+    def stage_packages(self):
+        self._enable_py38_ppa()
+        packages = super().stage_packages
+        if 'python3.8' not in packages:
+            packages.append('python3.8')
+        return packages

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,19 +23,41 @@ architectures:
 
 apps:
   crossbar:
-    command: crossbar
+    command: python3.8 -u $SNAP/bin/crossbar
+    environment:
+      PYTHONPYCACHEPREFIX: $SNAP_DATA/pycache
+      PYTHONPATH: $PYTHONPATH:$SNAP/lib/python3.8/site-packages
     plugs:
       - home
       - network
       - network-bind
 
 parts:
+  py38:
+    plugin: nil
+    override-build: |
+      add-apt-repository ppa:deadsnakes/ppa -y
+      apt update
+      apt install python3.8 python3.8-venv python3.8-dev -y
   crossbar:
-    plugin: python
+    plugin: nil
     source: .
+    after:
+      - py38
+    override-build: |
+      snapcraftctl build
+      snapcraftctl set-version $(git describe --always --dirty | sed -e 's/-/+git/;y/-/./' | tail -c +2)
+      rm -rf venv
+      /usr/bin/python3.8 -m venv venv
+      venv/bin/python3 -m pip install .
+      find venv -type d -name __pycache__ -print0 | xargs -0 rm -rf
+      cp -r venv/* ${SNAPCRAFT_PART_INSTALL}
     stage-packages:
       - libsnappy1v5
+      - libunwind8
+      - python3.8
     build-packages:
+      - build-essential
       - gcc
       - libffi-dev
       - libssl-dev
@@ -44,15 +66,7 @@ parts:
       - libsnappy-dev
       - libunwind-dev
       - git
-    override-pull: |
-      snapcraftctl pull
-      snapcraftctl set-version $(git describe --always | sed -e 's/-/+git/;y/-/./' | tail -c +2)
-    override-prime: |
-      snapcraftctl prime
-      echo "Compiling pyc files..."
-      # Delete the file that would fail the compilation process
-      rm $SNAPCRAFT_PRIME/lib/python3.6/site-packages/crossbar/worker/test/examples/syntaxerror.py
-      $SNAPCRAFT_PART_INSTALL/usr/bin/python3 -m compileall -q $SNAPCRAFT_PRIME
+      - software-properties-common
 
 slots:
   runtime-dir:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,39 +23,26 @@ architectures:
 
 apps:
   crossbar:
-    command: python3.8 -u $SNAP/bin/crossbar
+    command: python -u $SNAP/crossbar/bin/crossbar
     environment:
       PYTHONPYCACHEPREFIX: $SNAP_DATA/pycache
-      PYTHONPATH: $PYTHONPATH:$SNAP/lib/python3.8/site-packages
+      PYTHONPATH: $PYTHONPATH:$SNAP/crossbar
+      PATH: $PATH:$SNAP/crossbar/bin
     plugs:
       - home
       - network
       - network-bind
 
 parts:
-  py38:
-    plugin: nil
-    override-build: |
-      add-apt-repository ppa:deadsnakes/ppa -y
-      apt update
-      apt install python3.8 python3.8-venv python3.8-dev -y
   crossbar:
-    plugin: nil
+    plugin: py38
     source: .
-    after:
-      - py38
     override-build: |
       snapcraftctl build
       snapcraftctl set-version $(git describe --always --dirty | sed -e 's/-/+git/;y/-/./' | tail -c +2)
-      rm -rf venv
-      /usr/bin/python3.8 -m venv venv
-      venv/bin/python3 -m pip install .
-      find venv -type d -name __pycache__ -print0 | xargs -0 rm -rf
-      cp -r venv/* ${SNAPCRAFT_PART_INSTALL}
     stage-packages:
       - libsnappy1v5
       - libunwind8
-      - python3.8
     build-packages:
       - build-essential
       - gcc
@@ -66,7 +53,6 @@ parts:
       - libsnappy-dev
       - libunwind-dev
       - git
-      - software-properties-common
 
 slots:
   runtime-dir:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,6 +21,9 @@ architectures:
   - build-on: armhf
     run-on: armhf
 
+  - build-on: arm64
+    run-on: arm64
+
 apps:
   crossbar:
     command: python -u $SNAP/crossbar/bin/crossbar


### PR DESCRIPTION
* Use python 3.8.0
* re-enable arm64 builds
* Reduces snap size from 49mb to 30mb by producing pycache post-install
* Improves the snap start performance as there is less unpacking to do

relevant snapcraft conversation https://forum.snapcraft.io/t/post-install-python-bytecompile/13827