### PR TITLE
proxy improvements

### DIFF
--- a/crossbar/worker/proxy.py
+++ b/crossbar/worker/proxy.py
@@ -126,7 +126,6 @@ class Frontend(WampWebSocketServerProtocol):
     _backend_transport = None  # valid if we're completely setup
     _transport_d = None  # a Deferred if we're waiting for the backend
 
-
     def onConnect(self, request):
         print("frontend: onConnect: {}".format(request))
 
@@ -198,6 +197,7 @@ class Frontend(WampWebSocketServerProtocol):
             # XXX rawsocket-specific
             if not proto.isOpen():
                 orig = proto._on_handshake_complete
+
                 def _connected(*args, **kw):
                     x = orig(*args, **kw)
                     self._backend_transport.send(hello_msg)
@@ -345,8 +345,7 @@ class ProxyController(RouterController):
             raise RuntimeError("Only know about 'web' type services")
 
         # XXX remove "websocket" things from this config??
-        x = self.start_router_transport(transport_id, config, create_paths=False)
-        # print("started: {}".format(x))
+        self.start_router_transport(transport_id, config, create_paths=False)
 
         for path, path_config in config['paths'].items():
             if path_config['type'] == "websocket":

--- a/crossbar/worker/proxy.py
+++ b/crossbar/worker/proxy.py
@@ -32,6 +32,7 @@ from twisted.internet.defer import inlineCallbacks, maybeDeferred
 
 from autobahn import wamp
 from autobahn.wamp.exception import ApplicationError
+from autobahn.wamp.message import Hello
 from autobahn.twisted.wamp import Session
 from autobahn.twisted.resource import WebSocketResource
 from autobahn.twisted.websocket import WampWebSocketServerProtocol
@@ -121,65 +122,133 @@ class Frontend(WampWebSocketServerProtocol):
     has contacted the proxy.
     """
 
-    def onConnect(self, request):
-        # print("frontend: onConnect: {}".format(request))
+    _await_hello = None  # a Request if we're still waiting for the Hello message
+    _backend_transport = None  # valid if we're completely setup
+    _transport_d = None  # a Deferred if we're waiting for the backend
 
-        # whenever a client connects, we create a (new) client-type
-        # connection to our configured backend. (In the future, this
-        # could be a lazily-created multiplex connection -- that
-        # exists only while we have >= 1 client active)
+
+    def onConnect(self, request):
+        print("frontend: onConnect: {}".format(request))
+
+        # okay, so we actually wait for the first message from the
+        # client before connecting to the backend -- this message MUST
+        # be a "Hello" message which will tell us the realm. This
+        # allows configuration of different backends per-realm.
+
+        # could check if _await_hello is not None, which means two
+        # connects in a row (that is, some error-handling code should
+        # cancel any previous backend connection setup attempts in
+        # such a case).
+        self._await_hello = request
+        print("Frontend.onConnect(): request protocols: {}".format(request.protocols))
+        x = super(Frontend, self).onConnect(request)
+        # print("returning: {}".format(x))
+        return x
+
+    def _hello_received(self, request, hello_msg):
+        """
+        Whenever a client connects, we create a (new) client-type
+        connection to our configured backend. We actually wait for the
+        first client message to arrive -- a Hello message -- so that
+        we can choose a different backend based on the realm (and/or
+        any request headers).
+
+        (In the future, this could be a lazily-created multiplex
+        connection -- that exists only while we have >= 1 client
+        active)
+        """
+
+        self._await_hello = None
 
         from twisted.internet import reactor
         from autobahn.wamp.component import _create_transport
         from autobahn.twisted.component import _create_transport_factory, _create_transport_endpoint
 
-        backend_config = {
-            "type": "rawsocket",
-            "endpoint": {
-                "type": "unix",
-                "path": "router.sock"
-            },
-            "url": "rs://localhost",
-            "serializer": "cbor"
-        }
-        backend = _create_transport(0, backend_config)
+        controller = self.factory._controller
+        backend_config = controller._find_backend_for(request, hello_msg.realm)
+        print("found config: {}".format(backend_config))
+        print("found config: {}".format(backend_config['transport']))
+        backend = _create_transport(0, backend_config["transport"])
+
+        # print("control: {}".format(controller))
+        # print("backend: {}".format(backend))
+
         # client-factory
         factory = _create_transport_factory(reactor, backend, BackendProxySession)
-        endpoint = _create_transport_endpoint(reactor, backend_config["endpoint"])
-        d = endpoint.connect(factory)
+        endpoint = _create_transport_endpoint(reactor, backend_config["transport"]["endpoint"])
+        self._transport_d = endpoint.connect(factory)
 
         def good(proto):
+            # print("got backend protocol: {}".format(proto))
+            self._transport_d = None
             # we give the backend a way to get back to us .. perhaps
             # there's another / better way?
             proto._proxy_other_side = self
             self._backend_transport = proto
-            # print("Frontend.onConnect(): request protocols: {}".format(request.protocols))
-            x = super(Frontend, self).onConnect(request)
-            # print("returning: {}".format(x))
-            return x
+
+            # So, we need to wait for the connection to "be open"
+            # before we can forward the Hello .. but there's no
+            # listener interface on RawSocket :/ so we have to wrap
+            # things ... at least we know "it's all Twisted" here (but
+            # also: perhaps there SHOULD be a more-general interface
+            # for this, because we'll have the same problem with a
+            # WebSocket backend .. and also need to know what kind of
+            # backend we have so we wrap the correct thing)
+
+            # XXX rawsocket-specific
+            if not proto.isOpen():
+                orig = proto._on_handshake_complete
+                def _connected(*args, **kw):
+                    x = orig(*args, **kw)
+                    self._backend_transport.send(hello_msg)
+                    return x
+                proto._on_handshake_complete = _connected
+            else:
+                self._backend_transport.send(hello_msg)
 
         def bad(f):
+            self._transport_d = None
             print("fail: {}".format(f))
             self._teardown()
-        d.addCallbacks(good, bad)
-        return d
+        self._transport_d.addCallbacks(good, bad)
+        return self._transport_d
 
     def onMessage(self, payload, isBinary):
         # print("Frontend.onMessage: {} bytes isBinary={}".format(len(payload), isBinary))
         # self._serializer is set by parent in onConnect()
         # (i.e. during sub-protocol negotiation)
         messages = self._serializer.unserialize(payload, isBinary)
-        for msg in messages:
-            self._backend_transport.send(msg)
 
-        # if we knew, for example, that we were using the same
-        # serializer as the backend .. then we could do something like
-        # this (e.g. AND we know the backend is raw-socket):
-        if False:
-            assert isBinary
-            import struct
-            self._backend_transport.transport.write(struct.pack("!I", len(payload)))
-            self._backend_transport.transport.write(payload)
+        if self._backend_transport:
+            # we have already got a backend transport so we are
+            # completely set up and just forwarding messages...
+            for msg in messages:
+                self._backend_transport.send(msg)
+
+        else:
+            # we haven't yet connected to the backend, because we are
+            # waiting for a Hello message. I don't think any client
+            # should send more than *just* a Hello until they receive
+            # something back from us .. this is double-checking that assumption
+            if self._transport_d is not None:
+                raise Exception(
+                    "Received '{}' while setting up backend".format(
+                        msg
+                    )
+                )
+
+            if len(messages) != 1 or not isinstance(messages[0], Hello):
+                raise Exception(
+                    "Expecting single 'Hello', but received {} messages: {}".format(
+                        len(messages),
+                        ", ".join([str(msg) for msg in messages]),
+                    )
+                )
+
+            # okay, we have received a single Hello message .. so we
+            # can set up the backend connection (which will also send
+            # the Hello to it once established)
+            self._hello_received(self._await_hello, messages[0])
 
     def _teardown(self):
         print("_teardown")
@@ -202,6 +271,7 @@ class ProxyWebSocketService(RouterWebService):
         from autobahn.twisted.websocket import WampWebSocketServerFactory
         websocket_factory = WampWebSocketServerFactory(FrontendProxySession)
         websocket_factory.protocol = Frontend
+        websocket_factory._controller = controller
 
         resource = WebSocketResource(websocket_factory)
 
@@ -239,6 +309,29 @@ class ProxyController(RouterController):
 
         yield self.publish_ready()
 
+    def _find_backend_for(self, request, realm):
+        """
+        Returns the backend configuration for the given request + realm. A
+        backend with no 'realm' key is a default one.
+        """
+        default_config = None
+        for name, config in self._backend_configs.items():
+            if realm == config.get("realm", None):
+                return config
+            if config.get("realm", None) is None:
+                default_config = config
+
+        # we didn't find a config for the given realm .. but perhaps
+        # there is a default config?
+        if default_config is None:
+            raise ApplicationError(
+                u"crossbar.error",
+                "No backend for realm '{}' (and no default backend)".format(
+                    realm,
+                )
+            )
+        return default_config
+
     @wamp.register(None)
     @inlineCallbacks
     def start_proxy_transport(self, transport_id, config, details=None):
@@ -253,7 +346,7 @@ class ProxyController(RouterController):
 
         # XXX remove "websocket" things from this config??
         x = self.start_router_transport(transport_id, config, create_paths=False)
-        print("started: {}".format(x))
+        # print("started: {}".format(x))
 
         for path, path_config in config['paths'].items():
             if path_config['type'] == "websocket":
@@ -265,12 +358,11 @@ class ProxyController(RouterController):
                 webservice = yield maybeDeferred(ProxyWebSocketService.create, transport, path, config, self)
                 transport.root[path] = webservice
             else:
-                x = yield self.start_web_transport_service(
+                yield self.start_web_transport_service(
                     transport_id,
                     path,
                     path_config
                 )
-                print("started: {}".format(x))
 
     @wamp.register(None)
     @inlineCallbacks
@@ -290,12 +382,24 @@ class ProxyController(RouterController):
             name=name,
             options=options,
         )
-        if len(self._backend_configs) > 0:
+        # names must be unique
+        if name in self._backend_configs:
             raise ApplicationError(
-                u"crossbarfabric.error",
-                u"Can only have a single backend currently",
+                u"crossbar.error",
+                u"Multiple backends with name '{}'".format(name),
             )
 
-        # XXX FIXME checkconfig
+        # all backends must have unique realms configured. there may
+        # be a single default realm (i.e. no "realm" tag at all)
+        for existing in self._backend_configs.values():
+            if existing.get('realm', None) == options.get('realm', None):
+                # if the realm is None, there isn't one .. which means
+                # "default", but there can be only one default
+                if existing.get('realm', None) is None:
+                    raise ApplicationError(
+                        u"crossbar.error",
+                        u"There can be only one default backend",
+                    )
 
+        # XXX FIXME checkconfig
         self._backend_configs[name] = options


### PR DESCRIPTION
This makes the backend config "not actually hard-coded" and also spies on the Hello message so a backend per realm can be configured. Currently, this works like this:

 - a backend config MAY have a `"realm"` key
 - a backend with no `"realm"` key is a "default backend"
 - when a client connects, we wait for the `Hello`:
    - if a backend exists with a matching realm, it is used
    - if none match, and there's a "default backend", it is used
    - if neither of the above, an error occurs