### PR TITLE
snap: fix ensurepip failure

### DIFF
--- a/snap/plugins/py38.py
+++ b/snap/plugins/py38.py
@@ -49,8 +49,6 @@ class PythonPlugin(snapcraft.BasePlugin):
         if self.options.python_packages and '__none__' in self.options.python_packages:
             return
 
-        self._run('/usr/bin/python3.8 -m ensurepip')
-
         if self.options.source:
             self._run('/usr/bin/python3.8 -m pip install --no-compile -t {} .'.format(target))
 


### PR DESCRIPTION
Call to `ensurepip` was not required. fixes snap build failure