### PR TITLE
please update https://pypi.org/simple/autobahn/

### DIFF
--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,5 +1,5 @@
 attrs>=17.2.0
-autobahn[asyncio,twisted,encryption,compress,serialization,scram]>=19.11.2
+autobahn[asyncio,twisted,encryption,compress,serialization,scram]>=19.11.1
 bitstring>=3.1.5
 bcrypt>=3.1.6
 cbor>=1.0.0


### PR DESCRIPTION
please update https://pypi.org/simple/autobahn/ with latest, autobahn-19.11.2.tar.gz or don't update requirements-min.txt autobahn==19.11.2