### PR TITLE
move where backend transports are defined

### DIFF
--- a/crossbar/node/node.py
+++ b/crossbar/node/node.py
@@ -750,6 +750,8 @@ class Node(object):
     def _configure_native_worker_proxy(self, worker_logname, worker_id, worker):
         yield self._configure_native_worker_common(worker_logname, worker_id, worker)
 
+        backends = []
+
         # start transports on proxy
         for i, transport in enumerate(worker.get('transports', [])):
 
@@ -778,7 +780,17 @@ class Node(object):
                 transport_id=hlid(transport_id),
             )
 
-        for i, backend in enumerate(worker.get('backends', [])):
+            for path_id, path_config in transport.get('paths', dict()).items():
+                if 'backends' in path_config:
+                    backends.extend(path_config['backends'])
+
+        # ...so backends are configured per-transport, but we're
+        # starting them all as a group here. What if two different
+        # transports have defined the same backend? (I think we can
+        # simply de-duplicate it .. in _find_backend_for(), it will
+        # find the correct backend). The only issue may be when there
+        # are multiple (different) notions of a "default" backend?
+        for i, backend in enumerate(backends):
 
             if 'id' in backend:
                 backend_id = backend['id']
@@ -792,10 +804,12 @@ class Node(object):
                 backend_id=hlid(backend_id),
             )
 
-            yield self._controller.call(u'crossbar.worker.{}.start_proxy_backend'.format(worker_id),
-                                        backend_id,
-                                        backend,
-                                        options=CallOptions())
+            yield self._controller.call(
+                u'crossbar.worker.{}.start_proxy_backend'.format(worker_id),
+                backend_id,
+                backend,
+                options=CallOptions(),
+            )
             self.log.info(
                 "Ok, {worker_logname} has started BackendTransport {backend_id}",
                 worker_logname=worker_logname,


### PR DESCRIPTION
As discussed here: https://github.com/crossbario/crossbar-examples/pull/128#issuecomment-548265605

This moves the proxy "backend" configurations underneath the paths in a proxy. 

Anyway. If this looks like a better way to organize the configuration, I can fix up the example. I didn't move where the "start the backend" code is managed (in the `proxy` worker, `ProxyController`). It probably makes sense to put that (and e.g. `_find_backend_for`) in the transport / service code (`ProxyWebSocketService`) since that's where the backends are configured now. Then (when multiplexing works) there will be one "actual backend connection" for every configured "backend" transport in the config (which might make the whole thing easier to think about for people doing the configuration).
