### PR TITLE
Fix error in wamp.session.list and wamp.session.count …

### DIFF
--- a/crossbar/router/service.py
+++ b/crossbar/router/service.py
@@ -192,30 +192,6 @@ class RouterServiceAgent(ApplicationSession):
         if not isinstance(failure.value, ApplicationError):
             super(RouterServiceAgent, self).onUserError(failure, msg)
 
-    @wamp.register('wamp.session.summary')
-    def session_summary(self, filter_authroles=None, details=None):
-        """
-        Get summary of sessions currently joined on the router grouped by authroles.
-
-        :param filter_authroles: If provided, only return sessions counts for authroles from this list.
-        :type filter_authroles: None or list
-
-        :returns: Summary of WAMP session counts (associative array role -> count, order undefined).
-        :rtype: list
-        """
-        assert (filter_authroles is None or type(filter_authroles) == list)
-        session_counts = {}
-        for session in self._router._session_id_to_session.values():
-            if not is_restricted_session(session):
-                if filter_authroles is None or (hasattr(session, '_session_details') and session._session_details.authrole in filter_authroles):
-                    auth_role = session._session_details.authrole
-                    if auth_role in session_counts:
-                        session_counts[auth_role] += 1
-                    else:
-                        session_counts[auth_role] = 1
-
-        return session_counts
-
     @wamp.register('wamp.session.list')
     def session_list(self, filter_authroles=None, details=None):
         """


### PR DESCRIPTION
When any sessions that are not derived from `RouterSession` or `PendingAuth` are present (native workers, authorizers, authenticators etc.) calls to `wamp.session.list` or `wamp.session.count` fail with ```object has no attribute '_session_details'```

Whe list of authroles is provided (filter_authroles) attempt to get `_session_details` may fail
```if filter_authroles is None or session._session_details.authrole in filter_authroles```

The PR uses `hasattr(session, '_session_details')` which is already used in other places of the same file.

Not part of the fix, but something to consider adding is `wamp.session.summary`.  Which would return counts of sessions grouped by authrole.  Alternative to it is calling `wamp.session.count` for each role separately, which makes it O(M * N) as it has to enumerate all N sessions for M roles.