### PR TITLE
Allow cryptosign-key to be set by env-variable

### DIFF
--- a/crossbar/common/checkconfig.py
+++ b/crossbar/common/checkconfig.py
@@ -512,6 +512,11 @@ def check_transport_auth_cryptosign(config):
                 'role': (False, [str]),
                 'realm': (False, [str]),
             }, principal, "WAMP-Cryptosign - principal '{}' configuration".format(authid))
+            # allow to set value from environment variable
+            for idx in range(len(principal['authorized_keys'])):
+                principal['authorized_keys'][idx] = maybe_from_env(
+                    'auth.wampcra.cryptosign["{}"].authorized_key[{}]'.format(authid, idx),
+                    principal['authorized_keys'][idx], hide_value=True)
             for pubkey in principal['authorized_keys']:
                 if not isinstance(pubkey, str):
                     raise InvalidConfigException("invalid type {} for pubkey in authorized_keys of principal".format(type(pubkey)))


### PR DESCRIPTION
This allows to set the (or more than one) public-key by env-variable.

I read that you need a "Contributor Assignment Agreement" to merge the code. Before I go trough that I want to check out if that PR makes sense to you and if you want that to functionality in your code-base.