### PR TITLE
fix: remove None value

### DIFF
--- a/crossbar/node/native.py
+++ b/crossbar/node/native.py
@@ -64,8 +64,8 @@ class NativeWorkerClientProtocol(WampWebSocketClientProtocol):
         self._authprovider = 'programcode'
 
         # FIXME / CHECKME
-        self._cbtid = None
-        self._transport_info = None
+        self._cbtid = {}
+        self._transport_info = {}
 
     def connectionLost(self, reason):
         if isinstance(reason.value, ConnectionDone):


### PR DESCRIPTION
None value lead this error:
```
  File "d:\programdata\anaconda3\envs\skynet\lib\site-packages\autobahn\wamp\websocket.py", line 60, in onOpen
    self._session.onOpen(self)
  File "d:\programdata\anaconda3\envs\skynet\lib\site-packages\crossbar\router\session.py", line 338, in onOpen
    self._transport._transport_info[u'channel_id'] = binascii.b2a_hex(channel_id).decode('ascii')
TypeError: 'NoneType' object does not support item assignment
```

