### PR TITLE
Fix typo on role attribute

### DIFF
--- a/docs-old/pages/administration/worker/Router-Configuration.md
+++ b/docs-old/pages/administration/worker/Router-Configuration.md
@@ -62,7 +62,7 @@ parameter | description
 **`id`** | Optional component ID (default: `"component<N>"`)
 **`type`** | Must be `"class"`.
 **`realm`** | The realm to join with the component.
-**`role`** | The atuhrole under which to attach the component.
+**`role`** | The authrole under which to attach the component.
 **`references`** | Please see below.
 **`classname`** | The fully qualified Python classname to use.
 **`extra`** | Arbitrary custom data forwarded to the class ctonstructor.

--- a/docs/Router-Configuration.rst
+++ b/docs/Router-Configuration.rst
@@ -81,7 +81,7 @@ Router components are either **plain Python classes**:
 +----------------------+--------------------------------------------------------------+
 | **``realm``**        | The realm to join with the component.                        |
 +----------------------+--------------------------------------------------------------+
-| **``role``**         | The atuhrole under which to attach the component.            |
+| **``role``**         | The authrole under which to attach the component.            |
 +----------------------+--------------------------------------------------------------+
 | **``references``**   | Please see below.                                            |
 +----------------------+--------------------------------------------------------------+


### PR DESCRIPTION
Previously authrole was written as atuhrole on router configuration page. This PR fixes that typo.