### PR TITLE
Unpin urllib3

### DIFF
--- a/requirements-latest.txt
+++ b/requirements-latest.txt
@@ -41,7 +41,7 @@ txtorcon>=0.19.3
 u-msgpack-python>=2.4.1
 # urllib3 is an indirect dependency, but we force a recent version because of https://nvd.nist.gov/vuln/detail/CVE-2019-11324
 # workaround for version conflict in requests vs sth else:
-urllib3<1.25,>=1.21.1
+urllib3<1.27,>=1.21.1
 vmprof>=0.4.12; platform_machine=='x86_64' or platform_machine=='i386' or platform_machine=='arm'
 watchdog>=0.8.3
 werkzeug>=0.14.1

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -38,7 +38,7 @@ txtorcon>=20.0.0
 u-msgpack-python>=2.4.1
 # urllib3 is an indirect dependency, but we force a recent version because of https://nvd.nist.gov/vuln/detail/CVE-2019-11324
 # workaround for version conflict in requests vs sth else:
-urllib3<1.25,>=1.21.1
+urllib3<1.27,>=1.21.1
 vmprof>=0.4.12; platform_machine=='x86_64' or platform_machine=='i386' or platform_machine=='arm'
 watchdog>=0.8.3
 werkzeug>=0.14.1


### PR DESCRIPTION
Please consider increasing pinned version pin, 1.25+ is a requirement to more and more libraries recently.  For example:  [botocore](https://github.com/boto/botocore/blob/develop/setup.py#L32), [responses](https://github.com/getsentry/responses/blob/master/setup.py#L26)

This PR is probably an incorrect/incomplete way to unpin it.