### PR TITLE
Add the ability to run crossbar docker images on x86 (not recommended)

### DIFF
--- a/docker/Dockerfile.cpy-slim
+++ b/docker/Dockerfile.cpy-slim
@@ -2,6 +2,8 @@
 # however, CROSSBAR_ARCH will _not_ be available further down the line because of this ordering!
 ARG CROSSBAR_ARCH
 
+FROM multiarch/qemu-user-static:x86_64-aarch64 as qemu
+FROM multiarch/qemu-user-static:x86_64-arm as qemuarm
 FROM ${CROSSBAR_ARCH}/python:3.9-slim
 
 MAINTAINER The Crossbar.io Project <support@crossbario.com>
@@ -19,9 +21,8 @@ ENV CROSSBAR_VCS_REF $CROSSBAR_VCS_REF
 ENV CROSSBAR_VERSION $CROSSBAR_VERSION
 
 # we bindly copy over qemu deps for all archs regardless of arch
-# do we really need this any more?
-#COPY .qemu/qemu-aarch64-static /usr/bin/qemu-aarch64-static
-#COPY .qemu/qemu-arm-static /usr/bin/qemu-arm-static
+COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin/
+COPY --from=qemuarm /usr/bin/qemu-arm-static /usr/bin/
 
 ENV LANG C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive

--- a/docker/Dockerfile.pypy-slim
+++ b/docker/Dockerfile.pypy-slim
@@ -81,15 +81,15 @@ RUN rustc --version
 # install vmprof: until it supports arm64, only on amd64
 RUN if [ "$CROSSBAR_ARCH" = "amd64" ]; then pip install --no-cache-dir "vmprof>=0.4.12"; fi
 
-RUN pip install --no-cache-dir /tmp/txaio-latest-py2.py3-none-any.whl
-RUN pip install --no-cache-dir /tmp/zlmdb-latest-py2.py3-none-any.whl
-RUN pip install --no-cache-dir /tmp/autobahn-latest-py2.py3-none-any.whl[asyncio,twisted,encryption,compress,serialization,scram,xbr]
-RUN pip install --no-cache-dir /tmp/crossbar-latest-py2.py3-none-any.whl
-
 # Copy built wheels from host.
 # IMPORTANT: there must be exactly one wheel version per packages below
 COPY ./.wheels /tmp
 RUN ls -la /tmp
+
+RUN pip install --no-cache-dir /tmp/txaio-latest-py2.py3-none-any.whl
+RUN pip install --no-cache-dir /tmp/zlmdb-latest-py2.py3-none-any.whl
+RUN pip install --no-cache-dir /tmp/autobahn-latest-py2.py3-none-any.whl[asyncio,twisted,encryption,compress,serialization,scram,xbr]
+RUN pip install --no-cache-dir /tmp/crossbar-latest-py2.py3-none-any.whl
 
 # Install wheels.
 # IMPORTANT: do NOT touch (uses globbing and find to make it work together with pip extras)

--- a/docker/Dockerfile.pypy-slim
+++ b/docker/Dockerfile.pypy-slim
@@ -2,6 +2,8 @@
 # however, CROSSBAR_ARCH will _not_ be available further down the line because of this ordering!
 ARG CROSSBAR_ARCH
 
+FROM multiarch/qemu-user-static:x86_64-aarch64 as qemu
+FROM multiarch/qemu-user-static:x86_64-arm as qemuarm
 # PyPy only comes in 3.7 for now
 FROM ${CROSSBAR_ARCH}/pypy:3.7-slim
 
@@ -20,8 +22,8 @@ ENV CROSSBAR_VCS_REF $CROSSBAR_VCS_REF
 ENV CROSSBAR_VERSION $CROSSBAR_VERSION
 
 # we bindly copy over qemu deps for all archs regardless of arch
-COPY .qemu/qemu-aarch64-static /usr/bin/qemu-aarch64-static
-COPY .qemu/qemu-arm-static /usr/bin/qemu-arm-static
+COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin/
+COPY --from=qemuarm /usr/bin/qemu-arm-static /usr/bin/
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.

--- a/docker/Dockerfile.pypy-slim
+++ b/docker/Dockerfile.pypy-slim
@@ -100,8 +100,8 @@ RUN pip install /tmp/txaio-*-py2.py3-none-any.whl && \
     pip install /tmp/crossbar-*-py2.py3-none-any.whl
 
 # Check versions of CLI
-RUN /usr/local/bin/xbrnetwork version && \
-    /usr/local/bin/crossbar version
+RUN xbrnetwork version && \
+    crossbar version
 
 ## SETUP RUNTIME ENVIRONMENT #############################################################
 

--- a/docker/Dockerfile.pypy-slim
+++ b/docker/Dockerfile.pypy-slim
@@ -122,5 +122,5 @@ WORKDIR /node
 USER crossbar
 EXPOSE 8080 8000
 
-ENTRYPOINT ["/usr/local/bin/crossbar"]
+ENTRYPOINT ["crossbar"]
 CMD ["start", "--cbdir", "/node/.crossbar", "--loglevel", "info"]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -80,9 +80,7 @@ requirements:
 
 # Install Qemu (this is needed for cross-building armhf/aarch64 on amd64)
 qemu_deps:
-	mkdir -p ./.qemu
-	cp /usr/bin/qemu-system-aarch64 ./.qemu
-	cp /usr/bin/qemu-system-arm ./.qemu
+	@echo "this target is no longer needed"
 
 #
 # Copy over current AutobahnJS into the default node directory


### PR DESCRIPTION
A few notes:

* I can't build the aarch64 images on x86 due to rust issues. I'm not sure if this is a problem with my machine or a deeper problem, I did not investigate
* 32bit arm is untested, maybe we remove the arm target completely?
* qemu is now copied from docker and not from system. That works better (works at all on my machine) and makes it independent of version of qemu installed. There is probably some cleanup to be done on github workflows for that
* binaries are installed in /opt/pypy/bin and not /usr/local/bin for crossbar wheel, I did not investigate why