### PR TITLE
Add a meta-event for specific registration URI

### DIFF
--- a/crossbar/router/dealer.py
+++ b/crossbar/router/dealer.py
@@ -524,6 +524,12 @@ class Dealer(object):
                                     registration_details,
                                     options=options
                                 )
+                                service_session.publish(
+                                    'wamp.registration.on_create.' + registration.uri,
+                                    session._session_id,
+                                    registration_details,
+                                    options=options
+                                )
 
                         if not was_already_registered:
                             if options:


### PR DESCRIPTION
I'm not sure if this is way out-of-line as a feature request, as it does get into WAMP specification territory. Just figured this was the easiest way to see if this was something that would be considered or not. Feel free to toss it out if it's a bad idea!

Mainly, I have Components that use a combination of "wamp.registration.lookup" and subscribing to the "wamp.registration.on_create/delete" events to determine if an end-point is available to be called. The deletion/creation of an end-point is used for a Component to know it may need to re-load some data from the other Component. Unfortunately, the "wamp.registration.on_create" event is very noisy in the case that many Components are coming online at once. Ultimately, I only care about a few select end-points, so it would be nice to be able to subscribe to specific end-point registration events and let Crossbar do the filtering instead of the client Components.

Other options are to either add a single Component that translates the "on_create" into the individual per-URI events for my specific use-case, but then I have to manage that Component, and ensure it scales as well as Crossbar, or I can have the individual Components emit application-specific "I'm ready" events when they register their end-points, but the "on_create" meta-event is already there and feels so close to what I need.

Maybe my issue is just that I'm relying on these introspection/debug events for actual application logic, and ultimately application-specific events are the way to go.

Corresponding on_delete, on_subscribe, on_unsubscribe could, of course, be added if this is actually something you are interested in doing.