### PR TITLE
Add default template for master config

### DIFF
--- a/crossbar/node/main.py
+++ b/crossbar/node/main.py
@@ -554,7 +554,10 @@ def _run_command_init(options, reactor, personality):
 
     log.info("Initializing application directory '{options.appdir}' ..", options=options)
 
-    get_started_hint = Templates.init(options.appdir, template='default')
+    if personality.NAME == 'master':
+        get_started_hint = Templates.init(options.appdir, template='master')
+    else:
+        get_started_hint = Templates.init(options.appdir, template='default')
 
     _maybe_generate_key(cbdir)
 

--- a/crossbar/node/template.py
+++ b/crossbar/node/template.py
@@ -35,6 +35,13 @@ class Templates:
             'basedir': "node/templates/default",
             'params': {},
             'skip_jinja': ['autobahn.js', 'autobahn.min.js', 'autobahn.min.jgz']
+        },
+        'master': {
+            'name': 'master',
+            'help': 'A WAMP router speaking WebSocket plus a static Web server.',
+            'basedir': "node/templates/master",
+            'params': {},
+            'skip_jinja': ['autobahn.js', 'autobahn.min.js', 'autobahn.min.jgz']
         }
     }
     """

--- a/crossbar/node/templates/master/.crossbar/config.json
+++ b/crossbar/node/templates/master/.crossbar/config.json
@@ -1,0 +1,283 @@
+{
+    "version": 2,
+    "controller": {
+        "id": "center1"
+    },
+    "workers": [
+        {
+            "id": "cfrouter1",
+            "type": "router",
+            "options": {
+                "expose_controller": true
+            },
+            "realms": [
+                {
+                    "name": "com.crossbario.fabric",
+                    "roles": [
+                        {
+                            "name": "public",
+                            "permissions": [
+                                {
+                                    "uri": "crossbarfabriccenter.public.",
+                                    "match": "prefix",
+                                    "allow": {
+                                        "call": true,
+                                        "register": false,
+                                        "publish": false,
+                                        "subscribe": true
+                                    },
+                                    "disclose": {
+                                        "caller": true,
+                                        "publisher": false
+                                    },
+                                    "cache": true
+                                }
+                            ]
+                        },
+                        {
+                            "name": "user",
+                            "permissions": [
+                                {
+                                    "uri": "",
+                                    "match": "prefix",
+                                    "allow": {
+                                        "call": true,
+                                        "register": true,
+                                        "publish": true,
+                                        "subscribe": true
+                                    },
+                                    "disclose": {
+                                        "caller": true,
+                                        "publisher": true
+                                    },
+                                    "cache": true
+                                }
+                            ]
+                        },
+                        {
+                            "name": "user-backend",
+                            "permissions": [
+                                {
+                                    "uri": "",
+                                    "match": "prefix",
+                                    "allow": {
+                                        "call": true,
+                                        "register": true,
+                                        "publish": true,
+                                        "subscribe": true
+                                    },
+                                    "disclose": {
+                                        "caller": true,
+                                        "publisher": true
+                                    },
+                                    "cache": true
+                                }
+                            ]
+                        },
+                        {
+                            "name": "authenticator",
+                            "permissions": [
+                                {
+                                    "uri": "com.crossbario.fabric.authenticate",
+                                    "match": "exact",
+                                    "allow": {
+                                        "call": true,
+                                        "register": true
+                                    },
+                                    "cache": true
+                                },
+                                {
+                                    "uri": "crossbarfabriccenter.node.",
+                                    "match": "prefix",
+                                    "allow": {
+                                        "subscribe": true
+                                    },
+                                    "cache": true
+                                },
+                                {
+                                    "uri": "crossbarfabriccenter.mrealm.",
+                                    "match": "prefix",
+                                    "allow": {
+                                        "subscribe": true
+                                    },
+                                    "cache": true
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "transports": [
+                {
+                    "type": "rawsocket",
+                    "serializers": ["cbor"],
+                    "endpoint": {
+                        "type": "unix",
+                        "path": "sock1"
+                    },
+                    "options": {
+                        "max_message_size": 1048576
+                    },
+                    "auth": {
+                        "anonymous": {
+                            "type": "static",
+                            "role": "trusted"
+                        }
+                    }
+                },
+                {
+                    "type": "rawsocket",
+                    "serializers": ["cbor"],
+                    "endpoint": {
+                        "type": "unix",
+                        "path": "sock2"
+                    },
+                    "options": {
+                        "max_message_size": 1048576
+                    },
+                    "auth": {
+                        "anonymous": {
+                            "type": "static",
+                            "role": "user",
+                            "authid": "superuser"
+                        }
+                    }
+                },
+                {
+                    "type": "web",
+                    "endpoint": {
+                        "type": "tcp",
+                        "port": 9000
+                    },
+                    "paths": {
+                        "/": {
+                            "type": "registerme"
+                        },
+                        "info": {
+                            "type": "nodeinfo"
+                        },
+                        "autobahn": {
+                           "type": "archive",
+                           "archive": "autobahn-v20.2.1.zip",
+                           "origin": "https://github.com/crossbario/autobahn-js-browser/archive/v20.2.1.zip",
+                           "object_prefix": "autobahn-js-browser-20.2.1",
+                           "default_object": "autobahn.min.js",
+                           "download": true,
+                           "cache": true,
+                           "hashes": [
+                              "b69cd17ac043cceceea8ed589a09a2555b5c39e32c2fea18ecc26dc5baf67de8"
+                           ],
+                           "mime_types": {
+                              ".min.js": "text/javascript",
+                              ".jgz": "text/javascript"
+                           }
+                        },
+                        "ws": {
+                            "type": "websocket",
+                            "serializers": [
+                                "cbor", "msgpack", "json"
+                            ],
+                            "options": {
+                                "allowed_origins": ["*"],
+                                "allow_null_origin": true,
+                                "enable_webstatus": true,
+                                "max_frame_size": 1048576,
+                                "max_message_size": 1048576,
+                                "auto_fragment_size": 65536,
+                                "fail_by_drop": true,
+                                "open_handshake_timeout": 2500,
+                                "close_handshake_timeout": 1000,
+                                "auto_ping_interval": 10000,
+                                "auto_ping_timeout": 5000,
+                                "auto_ping_size": 4,
+                                "compression": {
+                                    "deflate": {
+                                        "request_no_context_takeover": false,
+                                        "request_max_window_bits": 13,
+                                        "no_context_takeover": false,
+                                        "max_window_bits": 13,
+                                        "memory_level": 5
+                                    }
+                                }
+                            },
+                            "auth": {
+                                "anonymous": {
+                                    "type": "static",
+                                    "role": "public"
+                                },
+                                "cryptosign": {
+                                    "type": "dynamic",
+                                    "authenticator": "com.crossbario.fabric.authenticate",
+                                    "authenticator-realm": "com.crossbario.fabric",
+                                    "authenticator-role": "authenticator"
+                                }
+                           }
+                        }
+                    }
+                }
+            ],
+            "components": [
+                {
+                    "type": "class",
+                    "classname": "crossbar.master.node.authenticator.Authenticator",
+                    "realm": "com.crossbario.fabric",
+                    "role": "authenticator",
+                    "extra": {
+                        "mailgun": {
+                            "submit_url": "https://api.mailgun.net/v3/mailing.crossbar.io/messages",
+                            "access_key": null
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "id": "cfrealmmanager1",
+            "type": "container",
+            "options": {
+                "pythonpath": [".."],
+                "expose_shared": true,
+                "expose_controller": true,
+                "restart": "restart-always",
+                "shutdown": "shutdown-manual"
+            },
+            "components": [
+                {
+                    "type": "class",
+                    "classname": "crossbar.master.node.DomainController",
+                    "realm": "com.crossbario.fabric",
+                    "extra": {
+                        "metering": {
+                            "period": 300,
+                            "submit": {
+                                "period": 300,
+                                "url": "${CROSSBARFX_METERING_URL}",
+                                "timeout": 5,
+                                "maxerrors": 10
+                            }
+                        },
+                        "auto_default_mrealm": {
+                            "enabled": true,
+                            "watch_to_pair": "${CROSSBARFX_WATCH_TO_PAIR}",
+                            "watch_to_pair_pattern": null,
+                            "write_pairing_file": true,
+                            "management_url": "${CROSSBAR_FABRIC_URL}",
+                            "include_activation_code": true
+                        }
+                    },
+                    "transport": {
+                        "type": "rawsocket",
+                        "serializer": "cbor",
+                        "endpoint": {
+                           "type": "unix",
+                           "path": "sock1"
+                        },
+                        "options": {
+                            "max_message_size": 1048576
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/crossbar/node/templates/master/README.md
+++ b/crossbar/node/templates/master/README.md
@@ -1,0 +1,1 @@
+Generated from Crossbar.io default node template.

--- a/crossbar/node/templates/master/web/README.md
+++ b/crossbar/node/templates/master/web/README.md
@@ -1,0 +1,6 @@
+Put your Web files here. Eg a "index.html" file would automatically render (and hide this otherwise generated directory listing.)
+
+Other URLs and Web services configured in this example node configuration:
+
+* `/ws`: WAMP-over-WebSocket endpoint with default "realm1" (anonymous authentication and everything allowed!)
+* `/info`: Node info page


### PR DESCRIPTION
Adds a default config for crossbar master when `crossbar master init` is run. Note the json config is a copy of https://github.com/crossbario/crossbar/blob/master/crossbar/master/node/config.json

One alternative could be to create a `template` directory inside https://github.com/crossbario/crossbar/blob/master/crossbar/master/node/ and put the existing config.json there inside a `.crossbar` subdirectory.

If this is an acceptable change, a similar thing could be done for `edge` as well.