### PR TITLE
dont construct the signing key in worker controller

### DIFF
--- a/crossbar/worker/controller.py
+++ b/crossbar/worker/controller.py
@@ -51,13 +51,6 @@ class WorkerController(NativeProcess):
         # Release (public) key
         self._release_pubkey = _read_release_key()
 
-        # Node (private) key (as a string, in hex)
-        node_key_hex = _read_node_key(self.config.extra.cbdir, private=True)['hex']
-        privkey = nacl.signing.SigningKey(node_key_hex, encoder=nacl.encoding.HexEncoder)
-
-        # WAMP-cryptosign signing key
-        self._node_key = cryptosign.SigningKey(privkey)
-
     def onConnect(self):
         """
         Called when the worker has connected to the node's management router.

--- a/crossbar/worker/controller.py
+++ b/crossbar/worker/controller.py
@@ -11,15 +11,12 @@ import pkg_resources
 import jinja2
 import signal
 
-import nacl
-
 from twisted.internet.error import ReactorNotRunning
 from twisted.internet.defer import inlineCallbacks
 
 from autobahn.util import utcnow
 from autobahn.wamp.exception import ApplicationError
 from autobahn.wamp.types import PublishOptions, Challenge
-from autobahn.wamp import cryptosign
 from autobahn import wamp
 
 from txaio import make_logger
@@ -27,7 +24,7 @@ from txaio import make_logger
 from crossbar.common.reloader import TrackingModuleReloader
 from crossbar.common.process import NativeProcess
 from crossbar.common.profiler import PROFILERS
-from crossbar.common.key import _read_node_key, _read_release_key
+from crossbar.common.key import _read_release_key
 from crossbar._util import term_print
 
 __all__ = ('WorkerController', )


### PR DESCRIPTION
The worker controller file now has `get_public_key` and `sign_challenge` methods. Don't try to construct the SingingKey object manually as that's redundant and may cause issues