### PR TITLE
proxy: reduce log noise

### DIFF
--- a/crossbar/router/auth/cryptosign.py
+++ b/crossbar/router/auth/cryptosign.py
@@ -260,7 +260,7 @@ class PendingAuthCryptosign(PendingAuth):
                     return types.Challenge(self._authmethod, extra)
 
                 def on_authenticate_error(err):
-                    self.log.info(
+                    self.log.debug(
                         '{klass}.hello(realm="{realm}", details={details}) -> on_authenticate_error(err={err})',
                         klass=self.__class__.__name__,
                         realm=realm,

--- a/crossbar/router/auth/cryptosign.py
+++ b/crossbar/router/auth/cryptosign.py
@@ -244,7 +244,7 @@ class PendingAuthCryptosign(PendingAuth):
                 auth_d = txaio.as_future(self._authenticator, realm, details.authid, self._session_details)
 
                 def on_authenticate_ok(principal):
-                    self.log.info(
+                    self.log.debug(
                         '{klass}.hello(realm="{realm}", details={details}) -> on_authenticate_ok(principal={principal})',
                         klass=self.__class__.__name__,
                         realm=realm,

--- a/crossbar/worker/proxy.py
+++ b/crossbar/worker/proxy.py
@@ -377,7 +377,7 @@ class ProxyFrontendSession(object):
         Now we do any authentication necessary with them and connect
         to our backend.
         """
-        self.log.info('{func}(msg={msg})', func=hltype(self._process_Hello), msg=msg)
+        self.log.debug('{func}(msg={msg})', func=hltype(self._process_Hello), msg=msg)
         self._pending_session_id = util.id()
         self._goodbye_sent = False
 
@@ -415,6 +415,7 @@ class ProxyFrontendSession(object):
                                      authextra=msg.authextra,
                                      session_roles=msg.roles,
                                      pending_session=self._pending_session_id)
+
         auth_config = self._transport_config.get('auth', None)
 
         # if authentication is _not_ configured, allow anyone to join as "anonymous"!
@@ -701,9 +702,9 @@ def make_backend_connection(backend_config, frontend_session, cbdir):
 
     :param cbdir: The node directory.
     """
-    log.info('{func}() connecting with config=\n{config}',
-             func=hltype(make_backend_connection),
-             config=pformat(backend_config))
+    log.debug('{func}() connecting with config=\n{config}',
+              func=hltype(make_backend_connection),
+              config=pformat(backend_config))
 
     from twisted.internet import reactor
 
@@ -741,6 +742,11 @@ def make_backend_connection(backend_config, frontend_session, cbdir):
 
     # client-factory
     factory = _create_transport_factory(reactor, backend, create_session)
+    # Reduce noise from logs, otherwise for each connect/disconnect to the backend
+    # we get an entry in the router logs like
+    # Starting factory <autobahn.twisted.rawsocket.WampRawSocketClientFactory object at 0x7f38954ed9c0>
+    # Stopping factory <autobahn.twisted.rawsocket.WampRawSocketClientFactory object at 0x7f38954ed9c0>
+    factory.noisy = False
     endpoint = _create_transport_endpoint(reactor, backend_config['transport']['endpoint'])
     transport_d = endpoint.connect(factory)
 
@@ -1213,7 +1219,7 @@ class ProxyController(TransportController):
         else:
             realm_routes = None
             result = False
-        self.log.info(
+        self.log.debug(
             '{func}(realm="{realm}", authrole="{authrole}") -> {result} [routes={routes}, realm_routes={realm_routes}]',
             func=hltype(ProxyController.has_role),
             realm=hlid(realm),
@@ -1351,7 +1357,7 @@ class ProxyController(TransportController):
                 # session and delete it
                 backend.leave()
                 del self._backends_by_frontend[frontend]
-                self.log.info(
+                self.log.debug(
                     '{func}: ok, unmapped frontend session {frontend_session_id} from backend session {backend_session_id}',
                     func=hltype(self.unmap_backend),
                     frontend_session_id=hlid(frontend._session_id),


### PR DESCRIPTION
This reduces the log verbosity for `info` level. A remedy for https://github.com/crossbario/crossbar/issues/1964

The change in `cryptosign.py` only affects authenticators of type `function`. The `dynamic` authenticator already sets a similar log to `debug`, so that change only makes the log-level behavior uniform.

The changes to `proxy.py` basically moves logging of actual backend config to debug level and a bit more.

