### PR TITLE
Fix stop_proxy_realm_route()

### DIFF
--- a/crossbar/worker/proxy.py
+++ b/crossbar/worker/proxy.py
@@ -1638,7 +1638,7 @@ class ProxyController(TransportController):
         :return: Run-time information about the stopped route.
         """
         self.log.info('{func}(realm_name={realm_name}, caller_authid="{caller_authid}")',
-                      func=hltype(self.stop_proxy_route),
+                      func=hltype(self.stop_proxy_realm_route),
                       realm_name=realm_name,
                       caller_authid=hlval(details.caller_authid))
         if realm_name not in self._routes:


### PR DESCRIPTION
The function was broken because it referred to itself with the wrong (old ?) name.