### PR TITLE
Fix proxy controller has_realm() logic

### DIFF
--- a/crossbar/worker/proxy.py
+++ b/crossbar/worker/proxy.py
@@ -1190,7 +1190,7 @@ class ProxyController(TransportController):
         :returns: True if a route to the realm (for any role) exists.
         :rtype: bool
         """
-        result = realm in self._routes and len(self._routes[realm]) > 0
+        result = realm in self._routes
         self.log.debug('{func}(realm="{realm}") -> {result}',
                        func=hltype(ProxyController.has_realm),
                        realm=hlid(realm),
@@ -1651,6 +1651,11 @@ class ProxyController(TransportController):
         route = self._routes[realm_name][route_id]
         yield route.stop()
         del self._routes[realm_name][route_id]
+
+        # If all routes are stopped, clear the realm from routes map
+        # Relevant discussion: https://github.com/crossbario/crossbar/pull/1968
+        if len(self._routes[realm_name]) == 0:
+            del self._routes[realm_name]
 
         returnValue(route.marshal())
 

--- a/crossbar/worker/proxy.py
+++ b/crossbar/worker/proxy.py
@@ -1004,7 +1004,7 @@ class ProxyRoute(object):
         yield self._controller.publish(topic, self.marshal(), options=types.PublishOptions(acknowledge=True))
 
         self.log.info('{func} proxy route {route_id} stopped for realm "{realm}"',
-                      func=hltype(self.start),
+                      func=hltype(self.stop),
                       route_id=hlid(self._route_id),
                       realm=hlval(self._realm_name))
 
@@ -1190,7 +1190,7 @@ class ProxyController(TransportController):
         :returns: True if a route to the realm (for any role) exists.
         :rtype: bool
         """
-        result = realm in self._routes
+        result = realm in self._routes and len(self._routes[realm]) > 0
         self.log.debug('{func}(realm="{realm}") -> {result}',
                        func=hltype(ProxyController.has_realm),
                        realm=hlid(realm),


### PR DESCRIPTION
`ProxyController.has_realm()`, checks if the route for a realm exists or not. Initially that function works correctly when no route exists, however when a route is started and later stopped, that function still returns `True` because the code only checks for the existence of a key. It also needs to check if the key returns an empty dictionary or not.

Here is the relevant part which actually removes a route https://github.com/crossbario/crossbar/blob/e88876f47f12a830d76d225723e0b8d13fdc589c/crossbar/worker/proxy.py#L1653.