### PR TITLE
Reduce and fix logging

### DIFF
--- a/crossbar/router/router.py
+++ b/crossbar/router/router.py
@@ -342,10 +342,10 @@ class Router(object):
 
         :returns: bool - `True` if a role under the given URI exists on this router.
         """
-        self.log.info('{func}: uri="{uri}", exists={exists}',
-                      func=hltype(self.has_role),
-                      uri=hlval(uri),
-                      exists=(uri in self._roles))
+        self.log.debug('{func}: uri="{uri}", exists={exists}',
+                       func=hltype(self.has_role),
+                       uri=hlval(uri),
+                       exists=(uri in self._roles))
         return uri in self._roles
 
     def add_role(self, role):

--- a/crossbar/router/router.py
+++ b/crossbar/router/router.py
@@ -342,10 +342,10 @@ class Router(object):
 
         :returns: bool - `True` if a role under the given URI exists on this router.
         """
-        self.log.debug('{func}: uri="{uri}", exists={exists}',
-                       func=hltype(self.has_role),
-                       uri=hlval(uri),
-                       exists=(uri in self._roles))
+        self.log.info('{func}: uri="{uri}", exists={exists}',
+                      func=hltype(self.has_role),
+                      uri=hlval(uri),
+                      exists=(uri in self._roles))
         return uri in self._roles
 
     def add_role(self, role):

--- a/crossbar/worker/proxy.py
+++ b/crossbar/worker/proxy.py
@@ -1334,12 +1334,11 @@ class ProxyController(TransportController):
             self._backends_by_frontend[frontend] = backend_proto
 
         self.log.info(
-            '{func}: ok, proxy backend session {session_id} opened mapping frontend session to realm "{realm}", authrole "{authrole}"',
+            '{func}: ok, proxy backend connection opened mapping frontend session to realm "{realm}", authrole "{authrole}"',
             func=hltype(self.map_backend),
             backend_config=pformat(backend_config),
             realm=hlid(realm),
-            authrole=hlid(authrole),
-            session_id=hlid(backend_proto._session_id))
+            authrole=hlid(authrole))
 
         returnValue(backend_proto)
 

--- a/crossbar/worker/router.py
+++ b/crossbar/worker/router.py
@@ -419,11 +419,11 @@ class RouterController(TransportController):
             # note: this is to enable eg built-in "trusted" authrole
             result = result or authrole in self._service_sessions[realm]
 
-        self.log.info('{func}(realm="{realm}", authrole="{authrole}") -> {result}',
-                      func=hltype(RouterController.has_role),
-                      realm=hlid(realm),
-                      authrole=hlid(authrole),
-                      result=hlval(result))
+        self.log.debug('{func}(realm="{realm}", authrole="{authrole}") -> {result}',
+                       func=hltype(RouterController.has_role),
+                       realm=hlid(realm),
+                       authrole=hlid(authrole),
+                       result=hlval(result))
         return result
 
     def set_service_session(self, session, realm, authrole):


### PR DESCRIPTION
The change in `proxy.py` fixes a "bug" in logging, because the session object we have at that point is only **connected** to the router, the actual join does not happen in that function. Hence the `backend_proto._session_id` is None during the execution of this code. That prints something like.
```
ok, proxy backend session None opened mapping frontend session to realm "test1", authrole "owner"
```

The other change make logging behavior consistent with other locations