### PR TITLE
make sort_keys optional in HTTP Bridge

### DIFF
--- a/crossbar/bridge/rest/subscriber.py
+++ b/crossbar/bridge/rest/subscriber.py
@@ -40,6 +40,7 @@ class MessageForwarder(ApplicationSession):
         debug = self.config.extra.get("debug", False)
         method = self.config.extra.get("method", "POST")
         expectedCode = self.config.extra.get("expectedcode")
+        sort_keys = self.config.extra.get("sort_keys", True)
 
         @inlineCallbacks
         def on_event(url, *args, **kwargs):
@@ -50,7 +51,7 @@ class MessageForwarder(ApplicationSession):
                 "args": args,
                 "kwargs": kwargs
             },
-                              sort_keys=True,
+                              sort_keys=sort_keys,
                               separators=(',', ':'),
                               ensure_ascii=False)
 

--- a/docs/HTTP-Bridge-Subscriber.rst
+++ b/docs/HTTP-Bridge-Subscriber.rst
@@ -92,6 +92,8 @@ The subscriber is configured through the ``extra`` dictionary:
 +---------------+------------------------------------------------------------------------------------------------------------------------+
 | method        | The HTTP method which the forwarding requests will be made with. (optional, "POST" by default)                         |
 +---------------+------------------------------------------------------------------------------------------------------------------------+
+| sort_keys     | Sort the dictionary output by key during JSON serialization (optional, true by default)                                |
++---------------+------------------------------------------------------------------------------------------------------------------------+
 | expectedcode  | The HTTP status code which is expected from the requests. If none is given, the status code is not checked. (optional) |
 +---------------+------------------------------------------------------------------------------------------------------------------------+
 | debug         | If true, then the response body will be printed to Crossbar's debug log. (optional, false by default)                  |


### PR DESCRIPTION
Sorting keys of different types (e.g. str and int) raises a TypeError.