### PR TITLE
Updated eth-abi to use 4.0.0 instead of beta version

### DIFF
--- a/requirements-latest.txt
+++ b/requirements-latest.txt
@@ -12,7 +12,7 @@ cookiecutter>=2.1.1
 cryptography>=39.0.0
 docker>=6.0.1
 # required for python 3.11+ https://github.com/ethereum/eth-abi/pull/194
-eth-abi @ git+https://github.com/ethereum/eth-abi.git@v4.0.0-beta.2#egg=eth-abi
+eth-abi>=4.0.0
 # required for python 3.11+ (https://github.com/ethereum/eth-account/pull/212)
 eth-account @ git+https://github.com/crossbario/eth-account.git@fix-215#egg=eth-account
 eth-typing @ git+https://github.com/ethereum/eth-typing.git@v3.2.0#egg=eth-typing


### PR DESCRIPTION
Fix for #2069 