### PR TITLE
Fix inappropriate length comparison in code

### DIFF
--- a/crossbar/worker/rlink.py
+++ b/crossbar/worker/rlink.py
@@ -119,7 +119,7 @@ class BridgeSession(ApplicationSession):
 
                 if details.forward_for:
                     # the event comes already forwarded from a router node
-                    if len(details.forward_for) >= 0:
+                    if not details.forward_for:
                         self.log.debug('SKIP! already forwarded')
                         return
 
@@ -307,8 +307,8 @@ class BridgeSession(ApplicationSession):
                 }
 
                 if details.forward_for:
-                    # the call comes already forwarded from a router node ..
-                    if len(details.forward_for) >= 0:
+                    # the call comes already forwarded from a router node ..                    
+                    if not details.forward_for:
                         self.log.debug('SKIP! already forwarded')
                         return
 

--- a/crossbar/worker/rlink.py
+++ b/crossbar/worker/rlink.py
@@ -307,7 +307,7 @@ class BridgeSession(ApplicationSession):
                 }
 
                 if details.forward_for:
-                    # the call comes already forwarded from a router node ..                    
+                    # the call comes already forwarded from a router node ..
                     if not details.forward_for:
                         self.log.debug('SKIP! already forwarded')
                         return


### PR DESCRIPTION
In file: rlink.py, the comparison of collection length creates a logical short circuit. I suggested that the collection length comparison should be done without creating a logical short circuit. 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the Open Source Security Foundation (OpenSSF)(https://openssf.org/): Project Alpha-Omega(https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.