### PR TITLE
RLink fixes and enhancements

### DIFF
--- a/crossbar/router/realmstore.py
+++ b/crossbar/router/realmstore.py
@@ -166,9 +166,10 @@ class RealmStoreMemory(object):
         for sub in self._config.get('event-history', []):
             uri = sub['uri']
             match = sub.get('match', 'exact')
-            observation, was_already_observed, was_first_observer = subscription_map.add_observer(self,
-                                                                                                  uri=uri,
-                                                                                                  match=match)
+            observation, was_already_observed, was_first_observer, was_first_local_observer = \
+                subscription_map.add_observer(self,
+                                              uri=uri,
+                                              match=match)
             subscription_id = observation.id
 
             # for in-memory history, we just use a double-ended queue

--- a/crossbar/router/test/test_observation.py
+++ b/crossbar/router/test/test_observation.py
@@ -68,7 +68,7 @@ class TestUriObservationMap(unittest.TestCase):
 
         uri1 = "com.example.uri1"
         obs1 = FakeObserver()
-        observation, was_already_observed, is_first_observer = obs_map.add_observer(obs1, uri1)
+        observation, was_already_observed, is_first_observer, is_first_local_observer = obs_map.add_observer(obs1, uri1)
 
         self.assertIsInstance(observation, ExactUriObservation)
         self.assertFalse(was_already_observed)
@@ -84,10 +84,10 @@ class TestUriObservationMap(unittest.TestCase):
         uri1 = "com.example.uri1"
         obs1 = FakeObserver()
 
-        observation1, was_already_observed, _ = obs_map.add_observer(obs1, uri1)
+        observation1, was_already_observed, _, _ = obs_map.add_observer(obs1, uri1)
         self.assertFalse(was_already_observed)
 
-        observation2, was_already_observed, _ = obs_map.add_observer(obs1, uri1)
+        observation2, was_already_observed, _, _ = obs_map.add_observer(obs1, uri1)
         self.assertTrue(was_already_observed)
 
         self.assertEqual(observation1, observation2)
@@ -103,10 +103,10 @@ class TestUriObservationMap(unittest.TestCase):
         obs1 = FakeObserver()
         obs2 = FakeObserver()
 
-        _, _, is_first_observer = obs_map.add_observer(obs1, uri1)
+        _, _, is_first_observer, _ = obs_map.add_observer(obs1, uri1)
         self.assertTrue(is_first_observer)
 
-        _, _, is_first_observer = obs_map.add_observer(obs2, uri1)
+        _, _, is_first_observer, _ = obs_map.add_observer(obs2, uri1)
         self.assertFalse(is_first_observer)
 
     def test_delete_observer(self):
@@ -116,8 +116,8 @@ class TestUriObservationMap(unittest.TestCase):
         obs1 = FakeObserver()
         obs2 = FakeObserver()
 
-        ob1, uri1, _ = obs_map.add_observer(obs1, uri)
-        ob2, uri2, _ = obs_map.add_observer(obs2, uri)
+        ob1, uri1, _, _ = obs_map.add_observer(obs1, uri)
+        ob2, uri2, _, _ = obs_map.add_observer(obs2, uri)
 
         self.assertTrue(ob1 is ob2)
         obs_map.drop_observer(obs1, ob1)
@@ -140,7 +140,7 @@ class TestUriObservationMap(unittest.TestCase):
         uri1 = "com.example.uri1"
         obs1 = FakeObserver()
 
-        observation1, _, _ = obs_map.add_observer(obs1, uri1)
+        observation1, _, _, _ = obs_map.add_observer(obs1, uri1)
 
         observations = obs_map.match_observations(uri1)
 
@@ -158,9 +158,9 @@ class TestUriObservationMap(unittest.TestCase):
         obs2 = FakeObserver()
         obs3 = FakeObserver()
 
-        observation1, _, _ = obs_map.add_observer(obs1, uri1)
-        observation2, _, _ = obs_map.add_observer(obs2, uri1)
-        observation3, _, _ = obs_map.add_observer(obs3, uri1)
+        observation1, _, _, _ = obs_map.add_observer(obs1, uri1)
+        observation2, _, _, _ = obs_map.add_observer(obs2, uri1)
+        observation3, _, _, _ = obs_map.add_observer(obs3, uri1)
 
         observations = obs_map.match_observations(uri1)
 
@@ -177,9 +177,9 @@ class TestUriObservationMap(unittest.TestCase):
         uri1 = "com.example.uri1"
         obs1 = FakeObserver()
 
-        observation1, _, _ = obs_map.add_observer(obs1, uri1)
-        observation2, _, _ = obs_map.add_observer(obs1, uri1)
-        observation3, _, _ = obs_map.add_observer(obs1, uri1)
+        observation1, _, _, _ = obs_map.add_observer(obs1, uri1)
+        observation2, _, _, _ = obs_map.add_observer(obs1, uri1)
+        observation3, _, _, _ = obs_map.add_observer(obs1, uri1)
 
         self.assertEqual(observation1, observation2)
         self.assertEqual(observation1, observation3)
@@ -198,7 +198,7 @@ class TestUriObservationMap(unittest.TestCase):
 
         obs1 = FakeObserver()
 
-        observation1, _, _ = obs_map.add_observer(obs1, "com.example", match=Subscribe.MATCH_PREFIX)
+        observation1, _, _, _ = obs_map.add_observer(obs1, "com.example", match=Subscribe.MATCH_PREFIX)
 
         # test matches
         for uri in [
@@ -224,7 +224,7 @@ class TestUriObservationMap(unittest.TestCase):
 
         obs1 = FakeObserver()
 
-        observation1, _, _ = obs_map.add_observer(obs1, "com.example..create", match=Subscribe.MATCH_WILDCARD)
+        observation1, _, _, _ = obs_map.add_observer(obs1, "com.example..create", match=Subscribe.MATCH_WILDCARD)
 
         # test matches
         for uri in ["com.example.foobar.create", "com.example.1.create"]:
@@ -248,7 +248,7 @@ class TestUriObservationMap(unittest.TestCase):
 
         obs1 = FakeObserver()
 
-        observation1, _, _ = obs_map.add_observer(obs1, "com...create", match=Subscribe.MATCH_WILDCARD)
+        observation1, _, _, _ = obs_map.add_observer(obs1, "com...create", match=Subscribe.MATCH_WILDCARD)
 
         # test matches
         for uri in [
@@ -284,9 +284,9 @@ class TestUriObservationMap(unittest.TestCase):
 
         obs1 = FakeObserver()
 
-        observation1, _, _ = obs_map.add_observer(obs1, "com.example.product.create", match=Subscribe.MATCH_EXACT)
-        observation2, _, _ = obs_map.add_observer(obs1, "com.example.product", match=Subscribe.MATCH_PREFIX)
-        observation3, _, _ = obs_map.add_observer(obs1, "com.example..create", match=Subscribe.MATCH_WILDCARD)
+        observation1, _, _, _ = obs_map.add_observer(obs1, "com.example.product.create", match=Subscribe.MATCH_EXACT)
+        observation2, _, _, _ = obs_map.add_observer(obs1, "com.example.product", match=Subscribe.MATCH_PREFIX)
+        observation3, _, _, _ = obs_map.add_observer(obs1, "com.example..create", match=Subscribe.MATCH_WILDCARD)
 
         observations = obs_map.match_observations("com.example.product.create")
         self.assertEqual(observations, [observation1, observation2, observation3])

--- a/crossbar/worker/main.py
+++ b/crossbar/worker/main.py
@@ -333,7 +333,10 @@ def _run_command_exec_worker(options, reactor=None, personality=None):
         from autobahn.twisted.websocket import WampWebSocketServerFactory
         transport_factory = WampWebSocketServerFactory(make_session, 'ws://localhost')
         transport_factory.protocol = WorkerServerProtocol
-        transport_factory.setProtocolOptions(failByDrop=False)
+
+        # we need to increase the opening handshake timeout,
+        # because when running multiple router workers controller may not be able to connect get to this worker in 5 seconds
+        transport_factory.setProtocolOptions(failByDrop=False, openHandshakeTimeout=45)
 
         # create a protocol instance and wire up to stdio
         #

--- a/requirements-latest.txt
+++ b/requirements-latest.txt
@@ -12,7 +12,7 @@ cookiecutter>=2.1.1
 cryptography>=39.0.0
 docker>=6.0.1
 # required for python 3.11+ https://github.com/ethereum/eth-abi/pull/194
-eth-abi @ git+https://github.com/ethereum/eth-abi.git@v4.0.0-beta.2#egg=eth-abi
+eth-abi>=4.0.0
 # required for python 3.11+ (https://github.com/ethereum/eth-account/pull/212)
 eth-account @ git+https://github.com/crossbario/eth-account.git@fix-215#egg=eth-account
 eth-typing @ git+https://github.com/ethereum/eth-typing.git@v3.2.0#egg=eth-typing

--- a/test/functests/cfctests/rlinks_tests.md
+++ b/test/functests/cfctests/rlinks_tests.md
@@ -1,0 +1,74 @@
+RLinks
+==========
+
+Nomenclature
+    - 1..9, A..F - nodes with RLinks
+    - U,V,W,X,Y,Z - nodes without RLinks
+    - l - local
+    - r - remote
+    - lr - local and remote (both)
+
+Node specification **N(\<target\>[l | r | lr])**, where N is the node number, target is the target node number, and **l | r | lr** -  Local/Remote/Both
+
+.. note::
+
+    Local (RLinkLocalSession) have authrole `trusted` and can see all registrations and events from
+    other all other sessions including remote (RLinkRemoteSession) sessions.
+
+    Remote (RLinkRemoteSession) have authrole `rlink` and can only see registrations local to the router,
+    but not from other rlinks. This is not the case for subscriptions:, remote session can see all events from
+    all sessions which results in full mesh subscriptions
+
+Topologies
+~~~~~~~~~~
+
+Two routers
+
+- 1[Xl],X - simple node with RLink to X, forwarding local invocations/events to X
+- 1[Xr],X - simple node with RLink to X, forwarding forwarding remote invocations/events from X
+- 1[Xlr],X - bi-directional RLink to X
+
+Chain
+
+- 1[2l],2[3l],3[Xl],X - chain of nodes with RLinks to the next node, forwarding local invocations/events to the next node
+- 1[2r],2[3r],3[Xr],X - chain of nodes with RLinks to the next node, forwarding remote invocations/events from the next node
+- 1[2lr],2[3lr],3[Xlr],X - chain of nodes with bi-directional RLinks to the next node
+
+Chain with reciprocal links
+
+- 1[2l],2(1l,3l),3(2l,4l),4(3l) - chain of nodes with RLinks to the next node, forwarding local invocations/events to the next node, and reciprocal links to the previous node
+- 1[2r],2(1r,3r),3(2r,4r),4(3r) - chain of nodes with RLinks to the next node, forwarding remote invocations/events from the next node, and reciprocal links to the previous node
+- 1[2lr],2(1lr,3lr),3(2lr,4lr),4(3lr) - [INVALID] Oversubscribed chain of nodes with bi-directional RLinks to the next node, and reciprocal links to the previous node
+
+Ring
+
+- 1[2l],2[3l],3[4l],4[1l] - ring of nodes with RLinks to the next node, forwarding local invocations/events to the next node
+- 1[2r],2[3r],3[4r],4[1r] - ring of nodes with RLinks to the next node, forwarding remote invocations/events from the next node
+- 1[2lr],2[3lr],3[4lr],4[1lr] - ring of nodes with bi-directional RLinks to the next node
+
+Ring with reciprocal links
+
+- 1[2l],2(1l,3l),3(2l,4l),4(3l,1l) - ring of nodes with RLinks to the next node, forwarding local invocations/events to the next node, and reciprocal links to the previous node
+- 1[2r],2(1r,3r),3(2r,4r),4(3r,1r) - ring of nodes with RLinks to the next node, forwarding remote invocations/events from the next node, and reciprocal links to the previous node
+- 1[2lr],2(1lr,3lr),3(2lr,4lr),4(3lr,1lr) - [INVALID] Oversubscribed ring of nodes with bi-directional RLinks to the next node, and reciprocal links to the previous node
+
+Star
+
+- 1[Xl],2[Xl],3[Xl],4[Xl],X - star (inward) of nodes with RLinks to the central node, forwarding local invocations/events to the central node
+- 1[Xr],2[Xr],3[Xr],4[Xr],X - star (inward) of nodes with RLinks to the central node, forwarding remote invocations/events from the central node
+- 1[Xlr],2[Xlr],3[Xlr],4[Xlr],X - star (inward) of nodes with bi-directional RLinks to the central node
+- 1(Xl, Yl, Zl),X,Y,Z - star (outward) of central node with RLinks to the outward nodes, forwarding local invocations/events to the outward nodes
+- 1(Xr, Yr, Zr),X,Y,Z - star (outward) of central node with RLinks to the outward nodes, forwarding remote invocations/events from the outward nodes
+- 1(Xlr, Ylr, Zlr),X,Y,Z - star (outward) of central node with bi-directional RLinks to the outward nodes
+
+Star with reciprocal links
+
+- 1[Cl],2[Cl],3[Cl],4[Cl],C(1l,2l,3l,4l) - star of nodes with RLinks to the central node, forwarding local invocations/events to the central node, and reciprocal links from the central node
+- 1[Cr],2[Cr],3[Cr],4[Cr],C(1r,2r,3r,4r) - star of nodes with RLinks to the central node, forwarding remote invocations/events from the central node, and reciprocal links from the central node
+
+Mesh
+
+- 1[2l,3l,4l],2[1l,3l,4l],3[1l,2l,4l],4[1l,2l,3l] - mesh of nodes with RLinks to all other nodes and reciprocal links (all forwarding local invocations/events)
+- 1[2r,3r,4r],2[1r,3r,4r],3[1r,2r,4r],4[1r,2r,3r] - mesh of nodes with RLinks to all other nodes and reciprocal links (all forwarding remote invocations/events)
+- 1[2lr,3lr,4lr],2[1lr,3lr,4lr],3[1lr,2lr,4lr],4[1lr,2lr,3lr] - [OVERKILL/INVALID] mesh of nodes with bi-directional RLinks to all other nodes and reciprocal links
+


### PR DESCRIPTION
Although this has been tested extensively this PR is for evaluation/discussion only.  

This PR is superseding #2090 and #2091

Issues that it addresses for some setups (tested with single route all-to-all mesh (not forwarding from other RLinks)

#2079 Forwarding subscriptions after reconnects
#2076 Internal error when attempting forwarding
#1894 Loop in invocation


Adds:
- #1959 Support for prefix and wildcard registrations and subscriptions
- Forced re-registration 
- Role override for RLink on local router:
   - When RLinkLocalSession is `trusted` it can "see" registrations and subs from other RLinks - making it an RLink forwarding other RLinks 
   - When RLinkLocalSession is 'rlink` it doesn't see registrations/subscriptions from other RLinks

