### PR TITLE
Bug #2096 memory leak in dealer.py

### DIFF
--- a/crossbar/router/dealer.py
+++ b/crossbar/router/dealer.py
@@ -40,6 +40,7 @@ class InvocationRequest(object):
         'id',
         'registration',
         'caller',
+        'caller_session_id',
         'call',
         'callee',
         'forward_for',
@@ -53,6 +54,7 @@ class InvocationRequest(object):
         self.id = id
         self.registration = registration
         self.caller = caller
+        self.caller_session_id = caller._session_id
         self.call = call
         self.callee = callee
         self.forward_for = forward_for
@@ -1132,11 +1134,7 @@ class Dealer(object):
 
         del self._invocations[invocation_request.id]
 
-        # the session_id will be None if the caller session has
-        # already vanished
-        caller_id = invocation_request.caller._session_id
-        if caller_id is not None:
-            del self._invocations_by_call[caller_id, invocation_request.call.request]
+        del self._invocations_by_call[invocation_request.caller_session_id, invocation_request.call.request]
 
     # noinspection PyUnusedLocal
     def processCancel(self, session, cancel):


### PR DESCRIPTION
Fixes memory leak in dealer where `InvocationRequest` are not removed from `_invocations_by_call` dict when caller is already gone.  Invocation requests retain references to session objects and others, exacerbating the leak.

```
Partition of a set of 6356 objects. Total size = 779728 bytes.
 Index  Count   %     Size   % Cumulative  % Kind (class / dict of class)
     0   1158  18   227160  29    227160  29 dict (no owner)
     1    163   3    72072   9    299232  38 set
     2    735  12    64030   8    363262  47 str
     3     50   1    58800   8    422062  54 dict of
                                             crossbar.router.protocol.WampRawSocketServerProtocol
     4    887  14    54280   7    476342  61 tuple
     5    339   5    21696   3    498038  64 types.MethodType
     6     54   1    21600   3    519638  67 dict of crossbar.router.session.RouterSession
     7    270   4    21600   3    541238  69 functools.partial
     8    339   5    21520   3    562758  72 list
     9     32   1    15736   2    578494  74 types.FrameType
```