### PR TITLE
Multiple resource leaks fixed in proxy and dealer

### DIFF
--- a/crossbar/__init__.py
+++ b/crossbar/__init__.py
@@ -22,6 +22,10 @@ if not hasattr(eth_abi, 'encode_abi') and hasattr(eth_abi, 'encode'):
 if not hasattr(eth_abi, 'encode_single') and hasattr(eth_abi, 'encode'):
     eth_abi.encode_single = eth_abi.encode
 
+import eth_typing
+if not hasattr(eth_typing, 'ChainID') and hasattr(eth_typing, 'ChainId'):
+    eth_typing.ChainID = eth_typing.ChainId
+
 # monkey patch web3 for master branch / upcoming v6 (which we need for python 3.11)
 # AttributeError: type object 'Web3' has no attribute 'toChecksumAddress'. Did you mean: 'to_checksum_address'?
 import web3

--- a/crossbar/router/session.py
+++ b/crossbar/router/session.py
@@ -736,12 +736,13 @@ class RouterSession(BaseSession):
                 self.onLeave(CloseDetails())
             except Exception:
                 self.log.failure("Exception raised in onLeave callback")
+                self.log.warn("{tb}".format(tb=Failure().getTraceback()))
 
             try:
                 self._router.detach(self)
             except Exception as e:
                 self.log.error("Failed to detach session '{}': {}".format(self._session_id, e))
-                self.log.debug("{tb}".format(tb=Failure().getTraceback()))
+                self.log.warn("{tb}".format(tb=Failure().getTraceback()))
 
             self._session_id = None
 

--- a/crossbar/worker/main.py
+++ b/crossbar/worker/main.py
@@ -123,7 +123,7 @@ def _run_command_exec_worker(options, reactor=None, personality=None):
 
     # we use an Autobahn utility to import the "best" available Twisted reactor
     from autobahn.twisted.choosereactor import install_reactor
-    reactor = install_reactor(options.reactor)
+    reactor = install_reactor(explicit_reactor=options.reactor or os.environ.get('CROSSBAR_REACTOR', None))
 
     # make sure logging to something else than stdio is setup _first_
     from crossbar._logging import make_JSON_observer, cb_logging_aware

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -58,7 +58,7 @@ wheel
 twine
 hashin
 
-pyinstaller==4.2
+pyinstaller>=4.2
 
 # FIXME: the docker shit insists on old deps (yaml, jsonschema)
 # https://github.com/docker/compose/blob/30fcb72cf3b136598883752edfa6ea4f3b8643d4/setup.py#L27

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -35,7 +35,7 @@ eth-keyfile==0.6.0
 eth-keys==0.4.0
 eth-rlp==0.3.0
 eth-typing @ git+https://github.com/ethereum/eth-typing.git@c93c57f7331c8e515cf72e5893bf2c9cec7e5c69
-eth-utils==2.1.0
+eth-utils==2.2.1
 Flask==2.2.2
 flatbuffers==23.1.21
 frozenlist==1.3.3

--- a/tox.ini
+++ b/tox.ini
@@ -162,7 +162,7 @@ exclude = crossbar/worker/test/examples/syntaxerror.py
 deps =
     bandit
 commands =
-    bandit -r -s B101,B110,B311 \
+    bandit -r -s B101,B110,B311,B113 \
         -x crossbar/common/key.py,crossbar/bridge/mqtt/test/test_wamp.py,crossbar/bridge/rest/test/__init__.py,crossbar/bridge/mqtt/test/test_wamp.py,crossbar/webservice/misc.py \
         crossbar
 
@@ -176,7 +176,7 @@ deps =
 commands =
     flake8 \
         --exclude crossbar/shell/reflection \
-        --ignore=E501,E402,E722,E741,W503,W504,E126,E251 \
+        --ignore=E501,E402,E722,E741,W503,W504,E126,E251,E721 \
         crossbar
 
 


### PR DESCRIPTION
The following resource leaks were identified and fixed:

1. Proxy doesn't handle client (frontend) disconnects while establishing a backend session (UDS transport)  -> UDS handle is leaked, Router retains session indefinitely
2. Proxy doesn't handle client disconnects in the middle of authentication (HELLO/CHALLENGE, AUTHENTICATE/WELCOME) -> does not close backend session -> UDS handle is leaked, Router retains session from proxy (since there is no ping on UDS, it will never discover client is gone)
3. Invocations in router were leaked if caller or callee disconnected while invocation(s) were in flight -> referenced caller/callee session objects leaked. Call timeout timers are not cancelled. #2096
4. Small (startup/static) leak of authenticator sessions in proxy.  If there is a flood of connections on startup, each one see absence of authenticator session in `_service_sessions[realm][authrole]` and try to create one.  Last one to be created will be stored overwriting any previous ones.  RouterSessions on the router side will never be closed.  

Leaks were discovered during stress/load testing with continuous stream of simulated faulty clients (abruptly closing connections at different stages, with invocations in flight, load-balancer failures resulting in mass disconnects).  
No leaks were detected in router or proxy processes with fixes.

![image](https://github.com/crossbario/crossbar/assets/408858/bb077e9d-cc1b-4385-aa88-ecf7e9af7b89)
