### PR TITLE
FIX: incompatibility with autobahn 24.4.2

### DIFF
--- a/requirements-latest.txt
+++ b/requirements-latest.txt
@@ -12,7 +12,7 @@ cookiecutter>=2.1.1
 cryptography>=39.0.0
 docker>=6.0.1
 # required for python 3.11+ https://github.com/ethereum/eth-abi/pull/194
-eth-abi @ git+https://github.com/ethereum/eth-abi.git@v4.0.0-beta.2#egg=eth-abi
+eth-abi @ git+https://github.com/ethereum/eth-abi.git@v4.0.0#egg=eth-abi
 # required for python 3.11+ (https://github.com/ethereum/eth-account/pull/212)
 eth-account @ git+https://github.com/crossbario/eth-account.git@fix-215#egg=eth-account
 eth-typing @ git+https://github.com/ethereum/eth-typing.git@v3.2.0#egg=eth-typing


### PR DESCRIPTION
ERROR: Cannot install autobahn[compress,encryption,scram,serialization,twisted,xbr]==24.4.2, crossbar and crossbar==23.1.2 because these package versions have
 conflicting dependencies.                                                                                                                                    
                                                                                                                                                              
The conflict is caused by:                                                                                                                                    
    crossbar 23.1.2 depends on eth-abi 4.0.0b2 (from git+https://github.com/ethereum/eth-abi.git@v4.0.0-beta.2#egg=eth-abi)                                   
    py-eth-sig-utils 0.4.0 depends on eth-abi>=1.1.1                                                                                                          
    autobahn[compress,encryption,scram,serialization,twisted,xbr] 24.4.2 depends on eth-abi>=4.0.0; extra == "xbr"                                            
