### PR TITLE
enhance log color detection and default to colored logs in docker

### DIFF
--- a/src/crossbar/node/main.py
+++ b/src/crossbar/node/main.py
@@ -701,18 +701,13 @@ def _start_logging(options, reactor):
         # We want to log to stdout/stderr.
 
         if color == "auto":
-            # Check environment variables to force colors (e.g., in Docker)
             if os.environ.get('NO_COLOR'):
-                # NO_COLOR disables colors
                 color = False
             elif os.environ.get('FORCE_COLOR') or os.environ.get('CLICOLOR_FORCE'):
-                # Explicitly force colors
                 color = True
-            elif sys.__stdout__.isatty():
-                # Auto-detect TTY
+            elif sys.__stdout__ is not None and sys.__stdout__.isatty():
                 color = True
             else:
-                # Default to enabling colors to match chalk behavior in Docker logs
                 color = True
         elif color == "true":
             color = True

--- a/src/crossbar/node/main.py
+++ b/src/crossbar/node/main.py
@@ -701,10 +701,19 @@ def _start_logging(options, reactor):
         # We want to log to stdout/stderr.
 
         if color == "auto":
-            if sys.__stdout__.isatty():
+            # Check environment variables to force colors (e.g., in Docker)
+            if os.environ.get('NO_COLOR'):
+                # NO_COLOR disables colors
+                color = False
+            elif os.environ.get('FORCE_COLOR') or os.environ.get('CLICOLOR_FORCE'):
+                # Explicitly force colors
+                color = True
+            elif sys.__stdout__.isatty():
+                # Auto-detect TTY
                 color = True
             else:
-                color = False
+                # Default to enabling colors to match chalk behavior in Docker logs
+                color = True
         elif color == "true":
             color = True
         else:


### PR DESCRIPTION
## Support NO_COLOR/FORCE_COLOR environment variables for log output

### Description

This PR improves log color detection to support standard environment variables and provide better defaults for containerized environments.

### Changes

- Add support for `NO_COLOR` environment variable to disable colors ([no-color.org](https://no-color.org/))
- Add support for `FORCE_COLOR` and `CLICOLOR_FORCE` environment variables to enable colors
- Default to enabling colors in non-TTY environments (e.g., Docker containers)

### Motivation

When running crossbar in Docker or other non-TTY environments, log colors were always disabled because `sys.__stdout__.isatty()` returns `False`. This made logs harder to read when viewing via `docker logs` or in CI/CD systems that support ANSI colors.

### Usage

```bash
# Force colors on (useful in Docker/CI)
FORCE_COLOR=1 crossbar start

# Force colors off
NO_COLOR=1 crossbar start

# Auto-detect (default) - now enables colors even without TTY
crossbar start
```

### Breaking Changes

Minor: Logs in non-TTY environments will now show colors by default. Set `NO_COLOR=1` to restore previous behavior.

### Checklist

- [x] Code follows project style guidelines
- [x] Changes are minimal and focused
- [x] No new dependencies added
